### PR TITLE
Initial PSR-2 changes

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -176,3 +176,13 @@ Be sure to `git rebase` your changes once done, and 'squish' changes
 into a single commit, then force push to your "fork". If you have
 write access to the main alloc repo, **NEVER** rebase and force push
 to the main alloc repo! This will mess up other peoples clones.
+
+## Alloc coding standards
+
+We follow the [PSR-2](https://www.php-fig.org/psr/psr-2/) coding
+standard with the exception of `else if`. Please use `else if` instead
+of `elseif`.
+
+Because the alloc code base did not use PSR-2 until late 2018, many
+class/method names do not match the PSR-2 recommendations, this is an
+ongoing effort.

--- a/alloc.php
+++ b/alloc.php
@@ -3,39 +3,40 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-// The order of file processing usually goes: 
+// The order of file processing usually goes:
 // requested_script.php -> alloc.php -> alloc_config.php -> more includes -> back to requested_script.php
 
-function &singleton($name, $thing=null) {
-  static $instances;
-  isset($name) && isset($thing) and $instances[$name] = &$thing;
-  return $instances[$name];
+function &singleton($name, $thing = null)
+{
+    static $instances;
+    isset($name) && isset($thing) and $instances[$name] = &$thing;
+    return $instances[$name];
 }
 
 ini_set("error_reporting", E_ALL & ~E_NOTICE & ~E_STRICT);
-ini_set('include_path',ini_get('include_path').PATH_SEPARATOR.dirname(__FILE__).DIRECTORY_SEPARATOR."zend");
-singleton("errors_fatal",false);
-singleton("errors_format","html");
-singleton("errors_logged",false);
-singleton("errors_thrown",false);
-singleton("errors_haltdb",false);
+ini_set('include_path', ini_get('include_path').PATH_SEPARATOR.dirname(__FILE__).DIRECTORY_SEPARATOR."zend");
+singleton("errors_fatal", false);
+singleton("errors_format", "html");
+singleton("errors_logged", false);
+singleton("errors_thrown", false);
+singleton("errors_haltdb", false);
 
 // Set the charset for Zend Lucene search indexer http://framework.zend.com/manual/en/zend.search.lucene.charset.html
 require_once("Zend".DIRECTORY_SEPARATOR."Search".DIRECTORY_SEPARATOR."Lucene.php");
@@ -44,60 +45,61 @@ Zend_Search_Lucene_Search_Query_Wildcard::setMinPrefixLength(0);
 
 // Undo magic quotes if it's enabled
 if (get_magic_quotes_gpc()) {
-  function stripslashes_array($array) {
-    return is_array($array) ? array_map('stripslashes_array', $array) : stripslashes($array);
-  }
+    function stripslashes_array($array)
+    {
+        return is_array($array) ? array_map('stripslashes_array', $array) : stripslashes($array);
+    }
 
-  $_COOKIE = stripslashes_array($_COOKIE);
-  $_FILES = stripslashes_array($_FILES);
-  $_GET = stripslashes_array($_GET);
-  $_POST = stripslashes_array($_POST);
-  $_REQUEST = stripslashes_array($_REQUEST);
+    $_COOKIE = stripslashes_array($_COOKIE);
+    $_FILES = stripslashes_array($_FILES);
+    $_GET = stripslashes_array($_GET);
+    $_POST = stripslashes_array($_POST);
+    $_REQUEST = stripslashes_array($_REQUEST);
 }
 
 // Get the alloc directory
 $f = trim(dirname(__FILE__));
-substr($f,-1,1) != DIRECTORY_SEPARATOR and $f.= DIRECTORY_SEPARATOR;
-define("ALLOC_MOD_DIR",$f);
+substr($f, -1, 1) != DIRECTORY_SEPARATOR and $f.= DIRECTORY_SEPARATOR;
+define("ALLOC_MOD_DIR", $f);
 unset($f);
 
 define("APPLICATION_NAME", "allocPSA");
-define("ALLOC_GD_IMAGE_TYPE","PNG");
+define("ALLOC_GD_IMAGE_TYPE", "PNG");
 
-define("DATE_FORMAT","d/m/Y");
+define("DATE_FORMAT", "d/m/Y");
 
 // Source and destination modifiers for various values
-define("SRC_DATABASE"       , 1);  // Reading the value from the database
-define("SRC_VARIABLE"       , 2);  // Reading the value from a PHP variable (except a form variable)
-define("SRC_REQUEST"        , 3);  // Reading the value from a get or post variable
-define("DST_DATABASE"       , 1);  // For writing to a database
-define("DST_VARIABLE"       , 2);  // For use within the PHP script itself
-define("DST_HTML_DISPLAY"   , 4);  // For display to the user as non-editable HTML text
+define("SRC_DATABASE", 1);  // Reading the value from the database
+define("SRC_VARIABLE", 2);  // Reading the value from a PHP variable (except a form variable)
+define("SRC_REQUEST", 3);  // Reading the value from a get or post variable
+define("DST_DATABASE", 1);  // For writing to a database
+define("DST_VARIABLE", 2);  // For use within the PHP script itself
+define("DST_HTML_DISPLAY", 4);  // For display to the user as non-editable HTML text
   
 // The list of all the modules that are enabled for this install of alloc
-$m = array("shared"       
-          ,"home"         
-          ,"project"      
-          ,"task"         
-          ,"time"         
-          ,"finance"      
-          ,"invoice"      
-          ,"client"       
-          ,"comment"       
-          ,"item"         
-          ,"person"       
-          ,"announcement" 
-          ,"reminder" 
-          ,"security"     
-          ,"config"       
-          ,"search"       
-          ,"tools"        
-          ,"report"       
-          ,"login"        
-          ,"services"         
-          ,"installation" 
-          ,"help" 
-          ,"email" 
+$m = array("shared"
+          ,"home"
+          ,"project"
+          ,"task"
+          ,"time"
+          ,"finance"
+          ,"invoice"
+          ,"client"
+          ,"comment"
+          ,"item"
+          ,"person"
+          ,"announcement"
+          ,"reminder"
+          ,"security"
+          ,"config"
+          ,"search"
+          ,"tools"
+          ,"report"
+          ,"login"
+          ,"services"
+          ,"installation"
+          ,"help"
+          ,"email"
           ,"sale"
           ,"wiki"
           ,"audit"
@@ -111,23 +113,23 @@ $external_storage_directories = array("task","client","project","invoice","comme
 require_once(ALLOC_MOD_DIR."shared".DIRECTORY_SEPARATOR."util.inc.php");
 
 foreach ($m as $module_name) {
-  if (file_exists(ALLOC_MOD_DIR.$module_name.DIRECTORY_SEPARATOR."lib".DIRECTORY_SEPARATOR."init.php")) {
-    require_once(ALLOC_MOD_DIR.$module_name.DIRECTORY_SEPARATOR."lib".DIRECTORY_SEPARATOR."init.php");
-    $module_class = $module_name."_module";
-    $module = new $module_class();
-    $modules[$module_name] = $module;
-  }
+    if (file_exists(ALLOC_MOD_DIR.$module_name.DIRECTORY_SEPARATOR."lib".DIRECTORY_SEPARATOR."init.php")) {
+        require_once(ALLOC_MOD_DIR.$module_name.DIRECTORY_SEPARATOR."lib".DIRECTORY_SEPARATOR."init.php");
+        $module_class = $module_name."_module";
+        $module = new $module_class();
+        $modules[$module_name] = $module;
+    }
 }
-singleton("modules",$modules);
+singleton("modules", $modules);
 
 // Get the web base url SCRIPT_PATH for the alloc site
 $path = dirname($_SERVER["SCRIPT_NAME"]);
-$bits = explode("/",$path);
-is_array($m) && in_array(end($bits),$m) && array_pop($bits);
-is_array($bits) and $path = implode("/",$bits);
+$bits = explode("/", $path);
+is_array($m) && in_array(end($bits), $m) && array_pop($bits);
+is_array($bits) and $path = implode("/", $bits);
 $path[0] != "/" and $path = "/".$path;
 $path[strlen($path)-1] != "/" and $path.="/";
-define("SCRIPT_PATH",$path); 
+define("SCRIPT_PATH", $path);
 
 unset($m);
 
@@ -147,11 +149,11 @@ $TPL = array("url_alloc_index"                          => SCRIPT_PATH."index.ph
 
   
 if (file_exists(ALLOC_MOD_DIR."alloc_config.php")) {
-  require_once(ALLOC_MOD_DIR."alloc_config.php");
+    require_once(ALLOC_MOD_DIR."alloc_config.php");
 }
 
 $db = new db_alloc();
-singleton("db",$db);
+singleton("db", $db);
 
 // ATTACHMENTS_DIR is defined above in alloc_config.php
 define("ALLOC_LOGO", ATTACHMENTS_DIR."logos/logo.jpg");
@@ -159,75 +161,71 @@ define("ALLOC_LOGO_SMALL", ATTACHMENTS_DIR."logos/logo_small.jpg");
 
 // If we're inside the installation process
 if (defined("IN_INSTALL_RIGHT_NOW")) {
-
   // Re-direct home if an alloc_config.php already exists
-  if (!defined("ALLOCPSA_PLATFORM") && file_exists(ALLOC_MOD_DIR."alloc_config.php") && is_readable(ALLOC_MOD_DIR."alloc_config.php") && filesize(ALLOC_MOD_DIR."alloc_config.php") >= 2 && defined("ALLOC_DB_NAME")) {
-    alloc_redirect($TPL["url_alloc_login"]);
-    exit();
-  }
+    if (!defined("ALLOCPSA_PLATFORM") && file_exists(ALLOC_MOD_DIR."alloc_config.php") && is_readable(ALLOC_MOD_DIR."alloc_config.php") && filesize(ALLOC_MOD_DIR."alloc_config.php") >= 2 && defined("ALLOC_DB_NAME")) {
+        alloc_redirect($TPL["url_alloc_login"]);
+        exit();
+    }
 
 // Else if were not in the installation process and there's no alloc_config.php file then redirect to the installation directory
 } else if (!file_exists(ALLOC_MOD_DIR."alloc_config.php") || !is_readable(ALLOC_MOD_DIR."alloc_config.php") || filesize(ALLOC_MOD_DIR."alloc_config.php") < 5 || !defined("ALLOC_DB_NAME")) {
-  alloc_redirect($TPL["url_alloc_installation"]);
-  exit();
+    alloc_redirect($TPL["url_alloc_installation"]);
+    exit();
 
 // Else include the alloc_config.php file and begin with proceedings..
 } else {
-
   // The timezone must be dealt with before anything else uses it or php will emit a warning
-  $timezone = config::get_config_item("allocTimezone");
-  date_default_timezone_set($timezone); 
+    $timezone = config::get_config_item("allocTimezone");
+    date_default_timezone_set($timezone);
 
   // Now the timezone is set, replace the missing stuff from the template
-  $TPL["current_date"] = date("Y-m-d H:i:s");
-  $TPL["today"] = date("Y-m-d");
+    $TPL["current_date"] = date("Y-m-d H:i:s");
+    $TPL["today"] = date("Y-m-d");
 
 
-  // The default From: email address 
-  if (config::get_config_item("AllocFromEmailAddress")) {
-    define("ALLOC_DEFAULT_FROM_ADDRESS", add_brackets(config::get_config_item("AllocFromEmailAddress")));
-  }
+  // The default From: email address
+    if (config::get_config_item("AllocFromEmailAddress")) {
+        define("ALLOC_DEFAULT_FROM_ADDRESS", add_brackets(config::get_config_item("AllocFromEmailAddress")));
+    }
 
   // The default email bounce address
-  define("ALLOC_DEFAULT_RETURN_PATH_ADDRESS",config::get_config_item("allocEmailAdmin"));
+    define("ALLOC_DEFAULT_RETURN_PATH_ADDRESS", config::get_config_item("allocEmailAdmin"));
 
 
   // If a script has NO_AUTH enabled, then it will perform its own
   // authentication. And will be responsible for setting up any of:
   // $current_user and $sess.
-  if (!defined("NO_AUTH")) {
+    if (!defined("NO_AUTH")) {
+        $current_user = &singleton("current_user", new person());
+        $sess = new session();
 
-    $current_user = &singleton("current_user",new person());
-    $sess = new session();
+      // If session hasn't been started re-direct to login page
+        if (!$sess->Started()) {
+            defined("NO_REDIRECT") && exit("Session expired. Please <a href='".$TPL["url_alloc_login"]."'>log in</a> again.");
+            alloc_redirect($TPL["url_alloc_login"] . ($_SERVER['REQUEST_URI'] != '/' ? '?forward='.urlencode($_SERVER['REQUEST_URI']) : ''));
 
-    // If session hasn't been started re-direct to login page
-    if (!$sess->Started()) {
-      defined("NO_REDIRECT") && exit("Session expired. Please <a href='".$TPL["url_alloc_login"]."'>log in</a> again.");
-      alloc_redirect($TPL["url_alloc_login"] . ($_SERVER['REQUEST_URI'] != '/' ? '?forward='.urlencode($_SERVER['REQUEST_URI']) : ''));
-
-    // Else load up the current_user and continue
-    } else if ($sess->Get("personID")) {
-      $current_user->load_current_user($sess->Get("personID"));
+        // Else load up the current_user and continue
+        } else if ($sess->Get("personID")) {
+            $current_user->load_current_user($sess->Get("personID"));
+        }
     }
-  }
 
   // Setup all the urls
-  require_once(ALLOC_MOD_DIR."shared".DIRECTORY_SEPARATOR."global_tpl_values.inc.php");
-  $TPL = get_alloc_urls($TPL,$sess);
+    require_once(ALLOC_MOD_DIR."shared".DIRECTORY_SEPARATOR."global_tpl_values.inc.php");
+    $TPL = get_alloc_urls($TPL, $sess);
 
   // Add user's navigation to quick list dropdown
-  if (is_object($current_user) && $current_user->get_id()) {
-    $history = new history();
-    $history->save_history();
-    $TPL["current_user"] = &$current_user;
-  }
+    if (is_object($current_user) && $current_user->get_id()) {
+        $history = new history();
+        $history->save_history();
+        $TPL["current_user"] = &$current_user;
+    }
 }
 
 // This is a hook for the SaaS side of alloc, to allow per-site code customizations
 if (!function_exists("ace_augment")) {
-  function ace_augment($name,$default=null) {
-    return $default;
-  }
+    function ace_augment($name, $default = null)
+    {
+        return $default;
+    }
 }
-
-?>

--- a/announcement/announcement.php
+++ b/announcement/announcement.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -29,8 +29,8 @@ $announcement = new announcement();
 // load the announcement from the database
 $announcementID = $_POST["announcementID"] or $announcementID = $_GET["announcementID"];
 if ($announcementID) {
-  $announcement->set_id($announcementID);
-  $announcement->select();
+    $announcement->set_id($announcementID);
+    $announcement->select();
 }
 
 // read announcement variables set by the request
@@ -38,15 +38,15 @@ $announcement->read_globals();
 
 // process submission of the form using the save button
 if ($_POST["save"]) {
-  $announcement->set_value("personID", $current_user->get_id());
-  $announcement->save();
-  alloc_redirect($TPL["url_alloc_announcementList"]);
+    $announcement->set_value("personID", $current_user->get_id());
+    $announcement->save();
+    alloc_redirect($TPL["url_alloc_announcementList"]);
 
 // process submission of the form using the delete button
 } else if ($_POST["delete"]) {
-  $announcement->delete();
-  alloc_redirect($TPL["url_alloc_announcementList"]);
-  exit();
+    $announcement->delete();
+    alloc_redirect($TPL["url_alloc_announcementList"]);
+    exit();
 }
 
 // load data for display in the template
@@ -56,7 +56,3 @@ $TPL["main_alloc_title"] = "Edit Announcement - ".APPLICATION_NAME;
 
 // invoke the page's main template
 include_template("templates/announcementM.tpl");
-
-
-
-?>

--- a/announcement/announcementList.php
+++ b/announcement/announcementList.php
@@ -3,49 +3,45 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function show_announcements($template_name) {
-  global $TPL;
+function show_announcements($template_name)
+{
+    global $TPL;
 
-  $people =& get_cached_table("person");
-  $query = "SELECT announcement.* 
+    $people =& get_cached_table("person");
+    $query = "SELECT announcement.* 
               FROM announcement 
               ORDER BY displayFromDate DESC";
-  $db = new db_alloc();
-  $db->query($query);
-  while ($db->next_record()) {
-    $announcement = new announcement();
-    $announcement->read_db_record($db);
-    $announcement->set_values();
-    $TPL["personName"] = $people[$announcement->get_value("personID")]["name"];
-    $TPL["odd_even"] = $TPL["odd_even"] == "odd" ? "even" : "odd";
-    include_template($template_name);
-  }
+    $db = new db_alloc();
+    $db->query($query);
+    while ($db->next_record()) {
+        $announcement = new announcement();
+        $announcement->read_db_record($db);
+        $announcement->set_values();
+        $TPL["personName"] = $people[$announcement->get_value("personID")]["name"];
+        $TPL["odd_even"] = $TPL["odd_even"] == "odd" ? "even" : "odd";
+        include_template($template_name);
+    }
 }
 
 $TPL["main_alloc_title"] = "Announcement List - ".APPLICATION_NAME;
 
 include_template("templates/announcementListM.tpl");
-
-
-
-
-?>

--- a/announcement/lib/announcement.inc.php
+++ b/announcement/lib/announcement.inc.php
@@ -3,47 +3,44 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class announcement extends db_entity {
-  public $data_table = "announcement";
-  public $display_field_name = "heading";
-  public $key_field = "announcementID";
-  public $data_fields = array("heading"
+class announcement extends db_entity
+{
+    public $data_table = "announcement";
+    public $display_field_name = "heading";
+    public $key_field = "announcementID";
+    public $data_fields = array("heading"
                              ,"body"
                              ,"personID"
                              ,"displayFromDate"
                              ,"displayToDate"
                              );
 
-  function has_announcements() {
-    $db = new db_alloc();
-    $today = date("Y-m-d");
-    $query = prepare("select * from announcement where displayFromDate <= '%s' and displayToDate >= '%s'", $today, $today);
-    $db->query($query);
-    if ($db->next_record()) {
-      return true;
+    function has_announcements()
+    {
+        $db = new db_alloc();
+        $today = date("Y-m-d");
+        $query = prepare("select * from announcement where displayFromDate <= '%s' and displayToDate >= '%s'", $today, $today);
+        $db->query($query);
+        if ($db->next_record()) {
+            return true;
+        }
+        return false;
     }
-    return false;
-  }
-
 }
-
-
-
-?>

--- a/announcement/lib/announcements_home_item.inc.php
+++ b/announcement/lib/announcements_home_item.inc.php
@@ -3,58 +3,59 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class announcements_home_item extends home_item {
-  function __construct() {
-    parent::__construct("announcements", "Announcements", "announcement", "announcementsH.tpl", "standard", 10);
-  }
+class announcements_home_item extends home_item
+{
+    function __construct()
+    {
+        parent::__construct("announcements", "Announcements", "announcement", "announcementsH.tpl", "standard", 10);
+    }
 
-  function visible() {
-    $announcement = new announcement();
-    return $announcement->has_announcements();
-  }
+    function visible()
+    {
+        $announcement = new announcement();
+        return $announcement->has_announcements();
+    }
 
-  function render() {
-    return true;
-  }
+    function render()
+    {
+        return true;
+    }
 
-  function show_announcements($template_name) {
-    $current_user = &singleton("current_user");
-    global $TPL;
+    function show_announcements($template_name)
+    {
+        $current_user = &singleton("current_user");
+        global $TPL;
 
-    $query = "SELECT *
+        $query = "SELECT *
                 FROM announcement 
                WHERE displayFromDate <= CURDATE() AND displayToDate >= CURDATE()
             ORDER BY displayFromDate desc";
-    $db = new db_alloc();
-    $db->query($query);
-    while ($db->next_record()) {
-      $announcement = new announcement();
-      $announcement->read_db_record($db);
-      $announcement->set_tpl_values();
-      $person = $announcement->get_foreign_object("person");
-      $TPL["personName"] = $person->get_name();
-      include_template($this->get_template_dir().$template_name);
+        $db = new db_alloc();
+        $db->query($query);
+        while ($db->next_record()) {
+            $announcement = new announcement();
+            $announcement->read_db_record($db);
+            $announcement->set_tpl_values();
+            $person = $announcement->get_foreign_object("person");
+            $TPL["personName"] = $person->get_name();
+            include_template($this->get_template_dir().$template_name);
+        }
     }
-  }
 }
-
-
-
-?>

--- a/announcement/lib/init.php
+++ b/announcement/lib/init.php
@@ -3,27 +3,27 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class announcement_module extends module {
-  var $module = "announcement";
-  var $db_entities = array("announcement");
-  var $home_items = array("announcements_home_item");
+class announcement_module extends module
+{
+    var $module = "announcement";
+    var $db_entities = array("announcement");
+    var $home_items = array("announcements_home_item");
 }
-?>

--- a/audit/lib/audit.inc.php
+++ b/audit/lib/audit.inc.php
@@ -3,27 +3,28 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class audit extends db_entity {
-  public $data_table = "audit";
-  public $key_field = "auditID";
-  public $data_fields = array("auditID"
+class audit extends db_entity
+{
+    public $data_table = "audit";
+    public $key_field = "auditID";
+    public $data_fields = array("auditID"
                              ,"taskID"
                              ,"projectID"
                              ,"personID"
@@ -32,62 +33,63 @@ class audit extends db_entity {
                              ,"value"
                              );
 
-  public static function get_list($_FORM) {
-    /*
-     *
-     * Get a list of task history items with sophisticated filtering and somewhat sophisticated output
-     *
-     * (n.b., the output from this generally needs to be post-processed to handle the semantic meaning of changes in various fields)
-     *
-     */
+    public static function get_list($_FORM)
+    {
+      /*
+       *
+       * Get a list of task history items with sophisticated filtering and somewhat sophisticated output
+       *
+       * (n.b., the output from this generally needs to be post-processed to handle the semantic meaning of changes in various fields)
+       *
+       */
 
-    $filter = audit::get_list_filter($_FORM);
+        $filter = audit::get_list_filter($_FORM);
 
-    if(is_array($filter) && count($filter)) {
-      $where_clause = " WHERE " . implode(" AND ", $filter);
-    }
+        if (is_array($filter) && count($filter)) {
+            $where_clause = " WHERE " . implode(" AND ", $filter);
+        }
 
-    if ($_FORM["projectID"]) {
-      $entity = new project();
-      $entity->set_id($_FORM["projectID"]);
-      $entity->select();
-    } else if ($_FORM["taskID"]) {
-      $entity = new task();
-      $entity->set_id($_FORM["taskID"]);
-      $entity->select();
-    }
+        if ($_FORM["projectID"]) {
+            $entity = new project();
+            $entity->set_id($_FORM["projectID"]);
+            $entity->select();
+        } else if ($_FORM["taskID"]) {
+            $entity = new task();
+            $entity->set_id($_FORM["taskID"]);
+            $entity->select();
+        }
 
 
-    $q = "SELECT *
+        $q = "SELECT *
             FROM audit
           $where_clause
         ORDER BY dateChanged";
 
-    $db = new db_alloc();
-    $db->query($q);
+        $db = new db_alloc();
+        $db->query($q);
 
-    $items = array();
-    while($row = $db->next_record()) {
-      $audit = new audit();
-      $audit->read_db_record($db);
-      $rows[] = $row;
+        $items = array();
+        while ($row = $db->next_record()) {
+            $audit = new audit();
+            $audit->read_db_record($db);
+            $rows[] = $row;
+        }
+
+        return $rows;
     }
 
-    return $rows;
-  }
 
+    public static function get_list_filter($filter)
+    {
+        $filter["taskID"]    and $sql[] = prepare("(taskID = %d)", $filter["taskID"]);
+        $filter["projectID"] and $sql[] = prepare("(projectID = %d)", $filter["projectID"]);
+        return $sql;
+    }
 
-  public static function get_list_filter($filter) {
-    $filter["taskID"]    and $sql[] = prepare("(taskID = %d)", $filter["taskID"]);
-    $filter["projectID"] and $sql[] = prepare("(projectID = %d)", $filter["projectID"]);
-    return $sql;
-  }
-
-  function get_list_vars() {
-    return array("taskID"           => "The task id to find audit records for"
+    function get_list_vars()
+    {
+        return array("taskID"           => "The task id to find audit records for"
                 ,"projectID"        => "The project id to find audit records for"
                 );
-  }
-
+    }
 }
-?>

--- a/audit/lib/init.php
+++ b/audit/lib/init.php
@@ -3,26 +3,26 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class audit_module extends module {
-  var $module = "audit";
-  var $db_entities = array("audit");
+class audit_module extends module
+{
+    var $module = "audit";
+    var $db_entities = array("audit");
 }
-?>

--- a/calendar/calendar.php
+++ b/calendar/calendar.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,20 +23,14 @@
 
 require_once("../alloc.php");
 
-function show_task_calendar_recursive() {
-  $calendar = new calendar(2,20);
-  $calendar->set_cal_person($_GET["personID"]);
-  $calendar->set_return_mode("calendar");
-  $calendar->draw();
+function show_task_calendar_recursive()
+{
+    $calendar = new calendar(2, 20);
+    $calendar->set_cal_person($_GET["personID"]);
+    $calendar->set_return_mode("calendar");
+    $calendar->draw();
 }
 
 $TPL["username"] = person::get_fullname($_GET["personID"]);
 
 include_template("templates/taskCalendarM.tpl");
-
-
-
-
-
-
-?>

--- a/calendar/lib/calendar.inc.php
+++ b/calendar/lib/calendar.inc.php
@@ -3,368 +3,394 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class calendar {
-  var $person;
-  var $week_start;
-  var $weeks_to_display;
-  var $days_of_week = array();
-  var $rtp;
-  var $first_date;
-  var $last_date;
-  var $db;
-  var $first_day_of_week;
+class calendar
+{
+    var $person;
+    var $week_start;
+    var $weeks_to_display;
+    var $days_of_week = array();
+    var $rtp;
+    var $first_date;
+    var $last_date;
+    var $db;
+    var $first_day_of_week;
 
 
-  function __construct($week_start=1, $weeks_to_display=4) {
-    $this->db = new db_alloc();
-    $this->first_day_of_week = config::get_config_item("calendarFirstDay");
-    $this->set_cal_date_range($week_start, $weeks_to_display);
-    $this->days_of_week = $this->get_days_of_week_array($this->first_day_of_week);
-  }
-
-  function set_cal_person($personID) {
-    $this->person = new person();
-    $this->person->set_id($personID);
-    $this->person->select();
-  }
-
-  function set_cal_date_range($week_start, $weeks_to_display) {
-    $this->week_start = $week_start;
-    $this->weeks_to_display = $weeks_to_display;
-
-    // Wind the date forward till we find the starting day of week
-    while (date("D", mktime(0, 0, 0, date("m"), date("d") + $i, date("Y"))) != $this->first_day_of_week) {
-      $i++;
+    function __construct($week_start = 1, $weeks_to_display = 4)
+    {
+        $this->db = new db_alloc();
+        $this->first_day_of_week = config::get_config_item("calendarFirstDay");
+        $this->set_cal_date_range($week_start, $weeks_to_display);
+        $this->days_of_week = $this->get_days_of_week_array($this->first_day_of_week);
     }
-    $fd = mktime(date("H"),date("i"),date("s"),date("m"),date("d")-($this->week_start*7)+($i-7),date("Y"));
+
+    function set_cal_person($personID)
+    {
+        $this->person = new person();
+        $this->person->set_id($personID);
+        $this->person->select();
+    }
+
+    function set_cal_date_range($week_start, $weeks_to_display)
+    {
+        $this->week_start = $week_start;
+        $this->weeks_to_display = $weeks_to_display;
+
+      // Wind the date forward till we find the starting day of week
+        while (date("D", mktime(0, 0, 0, date("m"), date("d") + $i, date("Y"))) != $this->first_day_of_week) {
+            $i++;
+        }
+        $fd = mktime(date("H"), date("i"), date("s"), date("m"), date("d")-($this->week_start*7)+($i-7), date("Y"));
     
-    /// Set the first and last date on the page 
-    $this->first_date = date("Y-m-d",$fd); 
-    $this->last_date = date("Y-m-d", mktime(date("H",$fd)
-                                           ,date("i",$fd)
-                                           ,date("s",$fd)
-                                           ,date("m",$fd)
-                                           ,date("d",$fd)+(($this->weeks_to_display*7)-1)
-                                           ,date("Y",$fd)));
-  }
+      /// Set the first and last date on the page
+        $this->first_date = date("Y-m-d", $fd);
+        $this->last_date = date("Y-m-d", mktime(
+            date("H", $fd),
+            date("i", $fd),
+            date("s", $fd),
+            date("m", $fd),
+            date("d", $fd)+(($this->weeks_to_display*7)-1),
+            date("Y", $fd)
+        ));
+    }
 
-  function get_cal_reminders() {
+    function get_cal_reminders()
+    {
 
-    // Get persons reminders
-    $query = prepare("SELECT * 
+      // Get persons reminders
+        $query = prepare("SELECT * 
                         FROM reminder
                         JOIN reminderRecipient ON reminderRecipient.reminderID = reminder.reminderID
                        WHERE personID = %d
                          AND (reminderRecuringInterval = 'No' OR (reminderRecuringInterval != 'No' AND reminderActive))
                        GROUP BY reminder.reminderID", $this->person->get_id());
-    $this->db->query($query);
-    $reminders = array();
-    while ($row = $this->db->row()) {
-      $reminder = new reminder();
-      $reminder->read_db_record($this->db);
+        $this->db->query($query);
+        $reminders = array();
+        while ($row = $this->db->row()) {
+            $reminder = new reminder();
+            $reminder->read_db_record($this->db);
 
-      if ($reminder->is_alive()) {
-        $reminderTime = format_date("U",$reminder->get_value("reminderTime"));
+            if ($reminder->is_alive()) {
+                $reminderTime = format_date("U", $reminder->get_value("reminderTime"));
 
-        // If repeating reminder
-        if ($reminder->get_value('reminderRecuringInterval') != "No" && $reminder->get_value('reminderRecuringValue') != 0) {
-          $interval = $reminder->get_value('reminderRecuringValue');
-          $intervalUnit = $reminder->get_value('reminderRecuringInterval');
+              // If repeating reminder
+                if ($reminder->get_value('reminderRecuringInterval') != "No" && $reminder->get_value('reminderRecuringValue') != 0) {
+                    $interval = $reminder->get_value('reminderRecuringValue');
+                    $intervalUnit = $reminder->get_value('reminderRecuringInterval');
 
-          while ($reminderTime < format_date("U",$this->last_date)+86400) {
-            $row["reminderTime"] = $reminderTime;
-            $reminders[date("Y-m-d",$reminderTime)][] = $row;
-            $reminderTime = $reminder->get_next_reminder_time($reminderTime,$interval,$intervalUnit);
-          }
+                    while ($reminderTime < format_date("U", $this->last_date)+86400) {
+                        $row["reminderTime"] = $reminderTime;
+                        $reminders[date("Y-m-d", $reminderTime)][] = $row;
+                        $reminderTime = $reminder->get_next_reminder_time($reminderTime, $interval, $intervalUnit);
+                    }
 
-        // Else if once off reminder
-        } else {
-          $row["reminderTime"] = $reminderTime;
-          $reminders[date("Y-m-d",$reminderTime)][] = $row;
+                  // Else if once off reminder
+                } else {
+                    $row["reminderTime"] = $reminderTime;
+                    $reminders[date("Y-m-d", $reminderTime)][] = $row;
+                }
+            }
         }
-      }
+
+        return $reminders;
     }
 
-    return $reminders;
-  }
-
-  function get_cal_tasks_to_start() {
+    function get_cal_tasks_to_start()
+    {
     
-    list($ts_open,$ts_pending,$ts_closed) = task::get_task_status_in_set_sql();
-    // Select all tasks which are targetted to start
-    $query = prepare("SELECT * 
+        list($ts_open,$ts_pending,$ts_closed) = task::get_task_status_in_set_sql();
+      // Select all tasks which are targetted to start
+        $query = prepare(
+            "SELECT * 
                         FROM task 
                        WHERE personID = %d 
                          AND dateTargetStart >= '%s' 
                          AND dateTargetStart < '%s'
-                         AND taskStatus NOT IN (".$ts_closed.")"
-                    ,$this->person->get_id()
-                    ,$this->first_date
-                    ,$this->last_date);
+                         AND taskStatus NOT IN (".$ts_closed.")",
+            $this->person->get_id(),
+            $this->first_date,
+            $this->last_date
+        );
 
-    $this->db->query($query);
-    $tasks_to_start = array();
-    while ($row = $this->db->next_record()) {
-      $tasks_to_start[$row["dateTargetStart"]][] = $row;
+        $this->db->query($query);
+        $tasks_to_start = array();
+        while ($row = $this->db->next_record()) {
+            $tasks_to_start[$row["dateTargetStart"]][] = $row;
+        }
+        return $tasks_to_start;
     }
-    return $tasks_to_start;
-  }
 
-  function get_cal_tasks_to_complete() {
+    function get_cal_tasks_to_complete()
+    {
 
-    list($ts_open,$ts_pending,$ts_closed) = task::get_task_status_in_set_sql();
-    // Select all tasks which are targetted for completion
-    $query = prepare("SELECT * 
+        list($ts_open,$ts_pending,$ts_closed) = task::get_task_status_in_set_sql();
+      // Select all tasks which are targetted for completion
+        $query = prepare(
+            "SELECT * 
                         FROM task 
                        WHERE personID = %d 
                          AND dateTargetCompletion >= '%s' 
                          AND dateTargetCompletion < '%s'
-                         AND taskStatus NOT IN (".$ts_closed.")"
-                    ,$this->person->get_id()
-                    ,$this->first_date
-                    ,$this->last_date);
+                         AND taskStatus NOT IN (".$ts_closed.")",
+            $this->person->get_id(),
+            $this->first_date,
+            $this->last_date
+        );
 
-    $this->db->query($query);
-    $tasks_to_complete = array();
-    while ($row = $this->db->next_record()) {
-      $tasks_to_complete[$row["dateTargetCompletion"]][] = $row;
+        $this->db->query($query);
+        $tasks_to_complete = array();
+        while ($row = $this->db->next_record()) {
+            $tasks_to_complete[$row["dateTargetCompletion"]][] = $row;
+        }
+        return $tasks_to_complete;
     }
-    return $tasks_to_complete;
-  }
 
-  function get_cal_absences() {
-    $query = prepare("SELECT * 
+    function get_cal_absences()
+    {
+        $query = prepare(
+            "SELECT * 
                         FROM absence
-                       WHERE (dateFrom >= '%s' OR dateTo <= '%s')"
-                    ,$this->first_date,$this->last_date);
+                       WHERE (dateFrom >= '%s' OR dateTo <= '%s')",
+            $this->first_date,
+            $this->last_date
+        );
 
-    $current_user = &singleton("current_user");
-    $current_user->have_role("admin") || $current_user->have_role("manage") or $query.= prepare(" AND personID = %d",$current_user->get_id());
+        $current_user = &singleton("current_user");
+        $current_user->have_role("admin") || $current_user->have_role("manage") or $query.= prepare(" AND personID = %d", $current_user->get_id());
 
-    $this->db->query($query);
-    $absences = array();
-    while ($row = $this->db->row()) {
-      $start_time = format_date("U",$row["dateFrom"]);
-      $end_time = format_date("U",$row["dateTo"]);
-      while ($start_time < $end_time) {
-    
-        if (date("Y-m-d",$start_time) == $prev_date) {
-          // Can't use timezone friendly date magic before 5.3.
-          // If the date didn't increment by a day, as is want to happen on DST days, then
-          // we manually roll it forward by one hour. Thus hopefully knocking it into the next day.
-          $start_time+=3600;
+        $this->db->query($query);
+        $absences = array();
+        while ($row = $this->db->row()) {
+            $start_time = format_date("U", $row["dateFrom"]);
+            $end_time = format_date("U", $row["dateTo"]);
+            while ($start_time < $end_time) {
+                if (date("Y-m-d", $start_time) == $prev_date) {
+                    // Can't use timezone friendly date magic before 5.3.
+                    // If the date didn't increment by a day, as is want to happen on DST days, then
+                    // we manually roll it forward by one hour. Thus hopefully knocking it into the next day.
+                    $start_time+=3600;
+                }
+
+                $row["dates"] = date("Y-m-d H:i:s", $start_time)." ---- ".date("Y-m-d H:i:s", $end_time);
+                $absences[date("Y-m-d", $start_time)][] = $row;
+                $prev_date = date("Y-m-d", $start_time);
+                $start_time += 86400;
+            }
         }
-
-        $row["dates"] = date("Y-m-d H:i:s",$start_time)." ---- ".date("Y-m-d H:i:s",$end_time);
-        $absences[date("Y-m-d",$start_time)][] = $row;
-        $prev_date = date("Y-m-d",$start_time);
-        $start_time += 86400;
-      }
+        return $absences;
     }
-    return $absences;
-  }
 
-  function get_days_of_week_array($first_day) {
-    // Generate a list of days, being mindful that a user may not want Sunday to be the first day of the week
-    $days = array("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"); 
-    foreach ($days as $day) {
-      if (($day == $first_day || $go) && count($days_of_week) < 7) {
-        $days_of_week[] = $day;
-        $go = true;
-      } 
+    function get_days_of_week_array($first_day)
+    {
+      // Generate a list of days, being mindful that a user may not want Sunday to be the first day of the week
+        $days = array("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat");
+        foreach ($days as $day) {
+            if (($day == $first_day || $go) && count($days_of_week) < 7) {
+                $days_of_week[] = $day;
+                $go = true;
+            }
+        }
+        return $days_of_week;
     }
-    return $days_of_week;
-  }
 
-  function set_return_mode($mode) {
-    $this->rtp = $mode;
-  }
+    function set_return_mode($mode)
+    {
+        $this->rtp = $mode;
+    }
 
-  function draw() {
-    global $TPL;
+    function draw()
+    {
+        global $TPL;
 
-    $this->draw_canvas();
-    $this->draw_row_header();
+        $this->draw_canvas();
+        $this->draw_row_header();
 
-    $this->draw_body();
+        $this->draw_body();
 
-    $i = -7;
+        $i = -7;
  
 
-    while (date("D", mktime(0, 0, 0, date("m"), date("d") + $i, date("Y"))) != $this->first_day_of_week) {
-      $i++;
-    }
-    $i = $i - ($this->week_start * 7);
-    $sunday_day = date("d", mktime(0, 0, 0, date("m"), date("d") + $i, date("Y")));
-    $sunday_month = date("m", mktime(0, 0, 0, date("m"), date("d") + $i, date("Y")));
-    $sunday_year = date("Y", mktime(0, 0, 0, date("m"), date("d") + $i, date("Y")));
-
-    $i = 0;
-
-    $absences = $this->get_cal_absences();
-    $reminders = $this->get_cal_reminders();
-    $tasks_to_start = $this->get_cal_tasks_to_start();
-    $tasks_to_complete = $this->get_cal_tasks_to_complete();
-
-    // For each single week...
-    while ($i < $this->weeks_to_display) {
-      $this->draw_row();
-
-      $a = 0;
-      while ($a < 7) {
-        $dates_of_week[$this->days_of_week[$a]] = date("Y-m-d", mktime(0, 0, 0, $sunday_month, $sunday_day + (7 * $i) + $a, $sunday_year));
-        $a++;
-      }
-
-
-      foreach($dates_of_week as $day=>$date) {
- 
-        $d = new calendar_day();
-        #$d->set_date(date("Y-m-d", mktime(0, 0, 0, $sunday_month, $sunday_day + (7 * $i + $k), $sunday_year));
-        $d->set_date($date);
-        $d->set_links($this->get_link_new_task($date).$this->get_link_new_reminder($date).$this->get_link_new_absence($date));
-
-
-        // Tasks to be Started
-        $tasks_to_start[$date] or $tasks_to_start[$date] = array();
-        foreach($tasks_to_start[$date] as $t) {
-          unset($extra);
-          $t["timeLimit"] and $extra = " (".sprintf("Limit %0.1fhrs",$t["timeLimit"]).")";
-          $d->start_tasks[] = '<a href="'.$TPL["url_alloc_task"].'taskID='.$t["taskID"].'">'.page::htmlentities($t["taskName"].$extra)."</a>";
+        while (date("D", mktime(0, 0, 0, date("m"), date("d") + $i, date("Y"))) != $this->first_day_of_week) {
+            $i++;
         }
+        $i = $i - ($this->week_start * 7);
+        $sunday_day = date("d", mktime(0, 0, 0, date("m"), date("d") + $i, date("Y")));
+        $sunday_month = date("m", mktime(0, 0, 0, date("m"), date("d") + $i, date("Y")));
+        $sunday_year = date("Y", mktime(0, 0, 0, date("m"), date("d") + $i, date("Y")));
 
-        // Tasks to be Completed
-        $tasks_to_complete[$date] or $tasks_to_complete[$date] = array();
-        foreach($tasks_to_complete[$date] as $t) {
-          unset($extra);
-          $t["timeLimit"] and $extra = " (".sprintf("Limit %0.1fhrs",$t["timeLimit"]).")";
-          $d->complete_tasks[] = '<a href="'.$TPL["url_alloc_task"].'taskID='.$t["taskID"].'">'.page::htmlentities($t["taskName"].$extra)."</a>";
-        }
+        $i = 0;
 
-        // Reminders
-        $reminders[$date] or $reminders[$date] = array();
-        foreach ($reminders[$date] as $r) {
-          #if (date("Y-m-d",$r["reminderTime"]) == $date) {
-            unset($wrap_start,$wrap_end);
-            if (!$r["reminderActive"]) {
-              $wrap_start = "<strike>";
-              $wrap_end = "</strike>";
+        $absences = $this->get_cal_absences();
+        $reminders = $this->get_cal_reminders();
+        $tasks_to_start = $this->get_cal_tasks_to_start();
+        $tasks_to_complete = $this->get_cal_tasks_to_complete();
+
+      // For each single week...
+        while ($i < $this->weeks_to_display) {
+            $this->draw_row();
+
+            $a = 0;
+            while ($a < 7) {
+                $dates_of_week[$this->days_of_week[$a]] = date("Y-m-d", mktime(0, 0, 0, $sunday_month, $sunday_day + (7 * $i) + $a, $sunday_year));
+                $a++;
             }
 
-            $text = page::htmlentities($r["reminderSubject"]);
-            $r["reminderTime"] and $text = date("g:ia",$r["reminderTime"])." ".$text;
-            $d->reminders[] = '<a href="'.$TPL["url_alloc_reminder"].'&step=3&reminderID='.$r["reminderID"].'&returnToParent='.$this->rtp.'&personID='.$r["personID"].'">'.$wrap_start.$text.$wrap_end.'</a>';
-          #}
+
+            foreach ($dates_of_week as $day => $date) {
+                $d = new calendar_day();
+                #$d->set_date(date("Y-m-d", mktime(0, 0, 0, $sunday_month, $sunday_day + (7 * $i + $k), $sunday_year));
+                $d->set_date($date);
+                $d->set_links($this->get_link_new_task($date).$this->get_link_new_reminder($date).$this->get_link_new_absence($date));
+
+
+                // Tasks to be Started
+                $tasks_to_start[$date] or $tasks_to_start[$date] = array();
+                foreach ($tasks_to_start[$date] as $t) {
+                    unset($extra);
+                    $t["timeLimit"] and $extra = " (".sprintf("Limit %0.1fhrs", $t["timeLimit"]).")";
+                    $d->start_tasks[] = '<a href="'.$TPL["url_alloc_task"].'taskID='.$t["taskID"].'">'.page::htmlentities($t["taskName"].$extra)."</a>";
+                }
+
+                // Tasks to be Completed
+                $tasks_to_complete[$date] or $tasks_to_complete[$date] = array();
+                foreach ($tasks_to_complete[$date] as $t) {
+                    unset($extra);
+                    $t["timeLimit"] and $extra = " (".sprintf("Limit %0.1fhrs", $t["timeLimit"]).")";
+                    $d->complete_tasks[] = '<a href="'.$TPL["url_alloc_task"].'taskID='.$t["taskID"].'">'.page::htmlentities($t["taskName"].$extra)."</a>";
+                }
+
+                // Reminders
+                $reminders[$date] or $reminders[$date] = array();
+                foreach ($reminders[$date] as $r) {
+                  #if (date("Y-m-d",$r["reminderTime"]) == $date) {
+                    unset($wrap_start, $wrap_end);
+                    if (!$r["reminderActive"]) {
+                        $wrap_start = "<strike>";
+                        $wrap_end = "</strike>";
+                    }
+
+                    $text = page::htmlentities($r["reminderSubject"]);
+                    $r["reminderTime"] and $text = date("g:ia", $r["reminderTime"])." ".$text;
+                    $d->reminders[] = '<a href="'.$TPL["url_alloc_reminder"].'&step=3&reminderID='.$r["reminderID"].'&returnToParent='.$this->rtp.'&personID='.$r["personID"].'">'.$wrap_start.$text.$wrap_end.'</a>';
+                  #}
+                }
+
+                // Absences
+                $absences[$date] or $absences[$date] = array();
+                foreach ($absences[$date] as $a) {
+                    $d->absences[] = '<a href="'.$TPL["url_alloc_absence"].'absenceID='.$a["absenceID"].'&returnToParent='.$this->rtp.'">'.person::get_fullname($a["personID"]).': '.page::htmlentities($a["absenceType"]).'</a>';
+                }
+
+                $d->draw_day_html();
+
+                $k++;
+            }
+            $i++;
+            $this->draw_row_end();
         }
+        $this->draw_body_end();
+        $this->draw_canvas_end();
+    }
 
-        // Absences
-        $absences[$date] or $absences[$date] = array();
-        foreach ($absences[$date] as $a) {
-          $d->absences[] = '<a href="'.$TPL["url_alloc_absence"].'absenceID='.$a["absenceID"].'&returnToParent='.$this->rtp.'">'.person::get_fullname($a["personID"]).': '.page::htmlentities($a["absenceType"]).'</a>';
+    function draw_canvas()
+    {
+        echo "<table border='0' cellspacing='0' class='alloc_calendar' cellpadding='3'>";
+    }
+    function draw_canvas_end()
+    {
+        echo "</table>";
+    }
+    function draw_body()
+    {
+      # Unfortunately browser support for this seems to be quite bad. Eventually
+      # this should cause the table to have headers draw at the start of
+      # each page where the table is broken, but for now it doesn't seem to
+      # work.
+        echo "<tbody>";
+    }
+    function draw_body_end()
+    {
+        echo "</tbody>";
+    }
+    function draw_row()
+    {
+        echo "\n<tr>";
+    }
+    function draw_row_end()
+    {
+        echo "</tr>";
+    }
+    function draw_row_header()
+    {
+        echo "\n<thead><tr>";
+        foreach ($this->days_of_week as $day) {
+            echo "<th>".$day."</th>";
         }
-
-        $d->draw_day_html();
-
-        $k++;
-      }
-      $i++;
-      $this->draw_row_end();
+        echo "</tr></thead>";
     }
-    $this->draw_body_end();
-    $this->draw_canvas_end();
-  }
 
-  function draw_canvas() {
-    echo "<table border='0' cellspacing='0' class='alloc_calendar' cellpadding='3'>";
-  }
-  function draw_canvas_end() {
-    echo "</table>";
-  }
-  function draw_body() {
-    # Unfortunately browser support for this seems to be quite bad. Eventually 
-    # this should cause the table to have headers draw at the start of 
-    # each page where the table is broken, but for now it doesn't seem to 
-    # work.
-    echo "<tbody>";
-  }
-  function draw_body_end() {
-    echo "</tbody>";
-  }
-  function draw_row() {
-    echo "\n<tr>";
-  }
-  function draw_row_end() {
-    echo "</tr>";
-  }
-  function draw_row_header() {
-    echo "\n<thead><tr>";
-    foreach ($this->days_of_week as $day) {
-      echo "<th>".$day."</th>";
+    function get_link_new_task($date)
+    {
+        global $TPL;
+        $link = '<a href="'.$TPL["url_alloc_task"].'dateTargetStart='.$date.'&personID='.$this->person->get_id().'">';
+        $link.= $this->get_img_new_task();
+        $link.= "</a>";
+        return $link;
     }
-    echo "</tr></thead>";
-  }
 
-  function get_link_new_task($date) {
-    global $TPL;
-    $link = '<a href="'.$TPL["url_alloc_task"].'dateTargetStart='.$date.'&personID='.$this->person->get_id().'">';
-    $link.= $this->get_img_new_task();
-    $link.= "</a>";
-    return $link;
-  }
+    function get_link_new_reminder($date)
+    {
+        global $TPL;
+        $time = urlencode($date." 9:00am");
+        $link = '<a href="'.$TPL["url_alloc_reminder"].'parentType=general&step=2&returnToParent='.$this->rtp.'&reminderTime='.$time;
+        $link.= '&personID='.$this->person->get_id().'">';
+        $link.= $this->get_img_new_reminder();
+        $link.= "</a>";
+        return $link;
+    }
 
-  function get_link_new_reminder($date) {
-    global $TPL;
-    $time = urlencode($date." 9:00am");
-    $link = '<a href="'.$TPL["url_alloc_reminder"].'parentType=general&step=2&returnToParent='.$this->rtp.'&reminderTime='.$time;
-    $link.= '&personID='.$this->person->get_id().'">';
-    $link.= $this->get_img_new_reminder();
-    $link.= "</a>";
-    return $link;
-  }
+    function get_link_new_absence($date)
+    {
+        global $TPL;
+        $link = '<a href="'.$TPL["url_alloc_absence"].'date='.$date.'&personID='.$this->person->get_id().'&returnToParent='.$this->rtp.'">';
+        $link.= $this->get_img_new_absence();
+        $link.= "</a>";
+        return $link;
+    }
 
-  function get_link_new_absence($date) {
-    global $TPL;
-    $link = '<a href="'.$TPL["url_alloc_absence"].'date='.$date.'&personID='.$this->person->get_id().'&returnToParent='.$this->rtp.'">';
-    $link.= $this->get_img_new_absence();
-    $link.= "</a>";
-    return $link;
-  }
+    function get_img_new_task()
+    {
+        global $TPL;
+        return "<img border=\"0\" src=\"".$TPL["url_alloc_images"]."task.gif\" alt=\"New Task\" title=\"New Task\">";
+    }
 
-  function get_img_new_task() {
-    global $TPL;
-    return "<img border=\"0\" src=\"".$TPL["url_alloc_images"]."task.gif\" alt=\"New Task\" title=\"New Task\">";
-  }
+    function get_img_new_reminder()
+    {
+        global $TPL;
+        return "<img border=\"0\" src=\"".$TPL["url_alloc_images"]."reminder.gif\" alt=\"New Reminder\" title=\"New Reminder\">";
+    }
 
-  function get_img_new_reminder() {
-    global $TPL;
-    return "<img border=\"0\" src=\"".$TPL["url_alloc_images"]."reminder.gif\" alt=\"New Reminder\" title=\"New Reminder\">";
-  }
-
-  function get_img_new_absence() {
-    global $TPL;
-    return "<img border=\"0\" src=\"".$TPL["url_alloc_images"]."absence.gif\" alt=\"New Absence\" title=\"New Absence\">";
-  }
-
+    function get_img_new_absence()
+    {
+        global $TPL;
+        return "<img border=\"0\" src=\"".$TPL["url_alloc_images"]."absence.gif\" alt=\"New Absence\" title=\"New Absence\">";
+    }
 }
-
-
-
-?>

--- a/calendar/lib/calendar_day.inc.php
+++ b/calendar/lib/calendar_day.inc.php
@@ -3,88 +3,90 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class calendar_day {
-  var $date;          // Y-m-d
-  var $day;           // Mon
-  var $display_date;  // m-Y
-  var $links;
-  var $class;
-  var $absences = array();
-  var $start_tasks = array();
-  var $complete_tasks = array();
-  var $reminders = array();
+class calendar_day
+{
+    var $date;          // Y-m-d
+    var $day;           // Mon
+    var $display_date;  // m-Y
+    var $links;
+    var $class;
+    var $absences = array();
+    var $start_tasks = array();
+    var $complete_tasks = array();
+    var $reminders = array();
       
-  function __construct() {
-  }
-
-  function set_date($date) {
-    $this->date = $date;
-    $this->day = format_date("D",$date);
-    $this->display_date = format_date("j M",$date);
-
-    if ($this->date == date("Y-m-d")) {
-      $this->class = "today";
-
-    // Toggle every second month to have slightly different coloured shading 
-    } else if (date("n", format_date("U",$this->date)) % 2 == 0) {
-      $this->class = "even";
+    function __construct()
+    {
     }
-  }
 
-  function set_links($links) {
-    $this->links = $links;
-  }
+    function set_date($date)
+    {
+        $this->date = $date;
+        $this->day = format_date("D", $date);
+        $this->display_date = format_date("j M", $date);
 
-  function draw_day_html() {
-    global $TPL;
+        if ($this->date == date("Y-m-d")) {
+            $this->class = "today";
+
+        // Toggle every second month to have slightly different coloured shading
+        } else if (date("n", format_date("U", $this->date)) % 2 == 0) {
+            $this->class = "even";
+        }
+    }
+
+    function set_links($links)
+    {
+        $this->links = $links;
+    }
+
+    function draw_day_html()
+    {
+        global $TPL;
     
-    if ($this->absences) {
-      $rows[] = "<br>Absent:";
-      $rows[] = implode("<br>",$this->absences);
-    }
+        if ($this->absences) {
+            $rows[] = "<br>Absent:";
+            $rows[] = implode("<br>", $this->absences);
+        }
   
-    if ($this->start_tasks) {
-      $rows[] = "<br>To be started:";
-      $rows[] = implode("<br>",$this->start_tasks);
+        if ($this->start_tasks) {
+            $rows[] = "<br>To be started:";
+            $rows[] = implode("<br>", $this->start_tasks);
+        }
+
+        if ($this->complete_tasks) {
+            $rows[] = "<br>To be complete:";
+            $rows[] = implode("<br>", $this->complete_tasks);
+        }
+        if ($this->reminders) {
+            $rows[] = "<br>Reminders:";
+            $rows[] = implode("<br>", $this->reminders);
+        }
+
+        echo "\n<td class=\"calendar_day ".$this->class."\">";
+        echo "<h1>".$this->links.$this->display_date."</h1>";
+
+        if (count($rows)) {
+            echo implode("<br>", $rows);
+        }
+
+        echo "</td>";
     }
-
-    if ($this->complete_tasks) {
-      $rows[] = "<br>To be complete:";
-      $rows[] = implode("<br>",$this->complete_tasks);
-    }
-    if ($this->reminders) {
-      $rows[] = "<br>Reminders:";
-      $rows[] = implode("<br>",$this->reminders);
-    }
-
-    echo "\n<td class=\"calendar_day ".$this->class."\">";
-    echo "<h1>".$this->links.$this->display_date."</h1>";
-
-    if (count($rows)) {
-      echo implode("<br>",$rows);
-    }
-
-    echo "</td>";
-  }
-
 }
-
-?>

--- a/calendar/lib/init.php
+++ b/calendar/lib/init.php
@@ -3,27 +3,27 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class calendar_module extends module {
-  var $module = "calendar";
-  var $db_entities = array();
-  var $home_items = array("task_calendar_home_item");
+class calendar_module extends module
+{
+    var $module = "calendar";
+    var $db_entities = array();
+    var $home_items = array("task_calendar_home_item");
 }
-?>

--- a/calendar/lib/task_calendar_home_item.inc.php
+++ b/calendar/lib/task_calendar_home_item.inc.php
@@ -3,60 +3,61 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class task_calendar_home_item extends home_item {
-  var $date;
+class task_calendar_home_item extends home_item
+{
+    var $date;
 
-  function __construct() {
-    $this->has_config = true;
-    parent::__construct("task_calendar_home_item", "Calendar", "calendar", "taskCalendarS.tpl","standard",30);
-  }
+    function __construct()
+    {
+        $this->has_config = true;
+        parent::__construct("task_calendar_home_item", "Calendar", "calendar", "taskCalendarS.tpl", "standard", 30);
+    }
 
-  function visible() {
-    $current_user = &singleton("current_user");
+    function visible()
+    {
+        $current_user = &singleton("current_user");
   
-    if (!isset($current_user->prefs["showCalendarHome"])) {
-      $current_user->prefs["showCalendarHome"] = 1;
-      $current_user->prefs["tasksGraphPlotHome"] = 4;
-      $current_user->prefs["tasksGraphPlotHomeStart"] = 1;
+        if (!isset($current_user->prefs["showCalendarHome"])) {
+            $current_user->prefs["showCalendarHome"] = 1;
+            $current_user->prefs["tasksGraphPlotHome"] = 4;
+            $current_user->prefs["tasksGraphPlotHomeStart"] = 1;
+        }
+
+        if ($current_user->prefs["showCalendarHome"]) {
+            return true;
+        }
     }
 
-    if ($current_user->prefs["showCalendarHome"]) {
-      return true;
+    function render()
+    {
+        return true;
     }
-  }
 
-  function render() {
-    return true;
-  }
-
-  function show_task_calendar_recursive() {
-    $current_user = &singleton("current_user");
-    $tasksGraphPlotHomeStart = $current_user->prefs["tasksGraphPlotHomeStart"];
-    $tasksGraphPlotHome = $current_user->prefs["tasksGraphPlotHome"];
-    $calendar = new calendar($tasksGraphPlotHomeStart,$tasksGraphPlotHome);
-    $calendar->set_cal_person($current_user->get_id());
-    $calendar->set_return_mode("home");
-    $calendar->draw($template);
-  }
+    function show_task_calendar_recursive()
+    {
+        $current_user = &singleton("current_user");
+        $tasksGraphPlotHomeStart = $current_user->prefs["tasksGraphPlotHomeStart"];
+        $tasksGraphPlotHome = $current_user->prefs["tasksGraphPlotHome"];
+        $calendar = new calendar($tasksGraphPlotHomeStart, $tasksGraphPlotHome);
+        $calendar->set_cal_person($current_user->get_id());
+        $calendar->set_return_mode("home");
+        $calendar->draw($template);
+    }
 }
-
-
-
-?>

--- a/client/client.php
+++ b/client/client.php
@@ -3,40 +3,42 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-  function check_optional_client_exists() {
+function check_optional_client_exists()
+{
     global $clientID;
     return $clientID;
-  }
+}
 
-  function show_client_contacts() {
+function show_client_contacts()
+{
     global $TPL;
     global $clientID;
 
     $TPL["clientContact_clientID"] = $clientID;
 
     if ($_POST["clientContact_delete"] && $_POST["clientContactID"]) {
-      $clientContact = new clientContact();
-      $clientContact->set_id($_POST["clientContactID"]);
-      $clientContact->delete();
+        $clientContact = new clientContact();
+        $clientContact->set_id($_POST["clientContactID"]);
+        $clientContact->delete();
     }
 
     $client = new client();
@@ -52,150 +54,155 @@ require_once("../alloc.php");
     $db = new db_alloc();
     $db->query($query);
     while ($db->next_record()) {
-      $clientContact = new clientContact();
-      $clientContact->read_db_record($db);
+        $clientContact = new clientContact();
+        $clientContact->read_db_record($db);
 
-      if ($_POST["clientContact_edit"] && $_POST["clientContactID"] == $clientContact->get_id()) {
-        continue;
-      }
-
-
-      $pc = "";
-      if ($clientContact->get_value("primaryContact")) {
-        $pc = " [Primary]";
-      }
-
-      $vcard_img = "icon_vcard.png";
-      $clientContact->get_value("clientContactActive") or $vcard_img = "icon_vcard_faded.png";
-
-      $vcard = '<a href="'.$TPL["url_alloc_client"].'clientContactID='.$clientContact->get_id().'&get_vcard=1"><img style="vertical-align:middle; padding:3px 6px 3px 3px;border: none" src="'.$TPL["url_alloc_images"].$vcard_img.'" alt="Download VCard" ></a>';
-
-      $col1 = array();
-      $clientContact->get_value('clientContactName') and $col1[] = "<h2 style='margin:0px; display:inline;'>".$vcard.$clientContact->get_value('clientContactName',DST_HTML_DISPLAY)."</h2>".$pc;
-      $clientContact->get_value('clientContactStreetAddress') and $col1[] = $clientContact->get_value('clientContactStreetAddress',DST_HTML_DISPLAY);
-
-      $clientContact->get_value('clientContactSuburb') || $clientContact->get_value('clientContactState') || $clientContact->get_value('clientContactPostcode') and
-      $col1[] = $clientContact->get_value('clientContactSuburb',DST_HTML_DISPLAY).' '.$clientContact->get_value('clientContactState',DST_HTML_DISPLAY)." ".$clientContact->get_value('clientContactPostcode',DST_HTML_DISPLAY);
-
-      $clientContact->get_value('clientContactCountry') and $col1[] = $clientContact->get_value('clientContactCountry',DST_HTML_DISPLAY);
+        if ($_POST["clientContact_edit"] && $_POST["clientContactID"] == $clientContact->get_id()) {
+            continue;
+        }
 
 
-      // find some gpl icons!
-      #$ico_e = "<img src=\"".$TPL["url_alloc_images"]."/icon_email.gif\">";
-      #$ico_p = "<img src=\"".$TPL["url_alloc_images"]."/icon_phone.gif\">";
-      #$ico_m = "<img src=\"".$TPL["url_alloc_images"]."/icon_mobile.gif\">";
-      #$ico_f = "<img src=\"".$TPL["url_alloc_images"]."/icon_fax.gif\">";
+        $pc = "";
+        if ($clientContact->get_value("primaryContact")) {
+            $pc = " [Primary]";
+        }
 
-      $ico_e = "E: ";
-      $ico_p = "P: ";
-      $ico_m = "M: ";
-      $ico_f = "F: ";
+        $vcard_img = "icon_vcard.png";
+        $clientContact->get_value("clientContactActive") or $vcard_img = "icon_vcard_faded.png";
 
-      $col2 = array();
-      $email = $clientContact->get_value("clientContactEmail",DST_HTML_DISPLAY);
-      $email = str_replace("<","",$email);
-      $email = str_replace(">","",$email);
-      $email = str_replace("&lt;","",$email);
-      $email = str_replace("&gt;","",$email);
+        $vcard = '<a href="'.$TPL["url_alloc_client"].'clientContactID='.$clientContact->get_id().'&get_vcard=1"><img style="vertical-align:middle; padding:3px 6px 3px 3px;border: none" src="'.$TPL["url_alloc_images"].$vcard_img.'" alt="Download VCard" ></a>';
 
-      $userName = $clientContact->get_value('clientContactName', DST_HTML_DISPLAY);
-      if ($userName) {
-          $mailto = '"' . $userName . '" <' . $email . ">";
-      } else {
-          $mailto = $email;
-      }
-      $email and $col2[] = $ico_e."<a href='mailto:".rawurlencode($mailto)."'>".$email."</a>";
+        $col1 = array();
+        $clientContact->get_value('clientContactName') and $col1[] = "<h2 style='margin:0px; display:inline;'>".$vcard.$clientContact->get_value('clientContactName', DST_HTML_DISPLAY)."</h2>".$pc;
+        $clientContact->get_value('clientContactStreetAddress') and $col1[] = $clientContact->get_value('clientContactStreetAddress', DST_HTML_DISPLAY);
 
-      $phone = $clientContact->get_value('clientContactPhone',DST_HTML_DISPLAY);
-      $phone and $col2[] = $ico_p.$phone;
+        $clientContact->get_value('clientContactSuburb') || $clientContact->get_value('clientContactState') || $clientContact->get_value('clientContactPostcode') and
+        $col1[] = $clientContact->get_value('clientContactSuburb', DST_HTML_DISPLAY).' '.$clientContact->get_value('clientContactState', DST_HTML_DISPLAY)." ".$clientContact->get_value('clientContactPostcode', DST_HTML_DISPLAY);
 
-      $mobile = $clientContact->get_value('clientContactMobile',DST_HTML_DISPLAY);
-      $mobile and $col2[] = $ico_m.$mobile;
+        $clientContact->get_value('clientContactCountry') and $col1[] = $clientContact->get_value('clientContactCountry', DST_HTML_DISPLAY);
 
-      $fax = $clientContact->get_value('clientContactFax',DST_HTML_DISPLAY);
-      $fax and $col2[] = $ico_f.$fax;
 
-      if ($clientContact->get_value("clientContactActive")) {
-        $class_extra = " loud";
-      } else {
-        $class_extra = " quiet";
-      }
+        // find some gpl icons!
+        #$ico_e = "<img src=\"".$TPL["url_alloc_images"]."/icon_email.gif\">";
+        #$ico_p = "<img src=\"".$TPL["url_alloc_images"]."/icon_phone.gif\">";
+        #$ico_m = "<img src=\"".$TPL["url_alloc_images"]."/icon_mobile.gif\">";
+        #$ico_f = "<img src=\"".$TPL["url_alloc_images"]."/icon_fax.gif\">";
 
-      $buttons = '<nobr>
+        $ico_e = "E: ";
+        $ico_p = "P: ";
+        $ico_m = "M: ";
+        $ico_f = "F: ";
+
+        $col2 = array();
+        $email = $clientContact->get_value("clientContactEmail", DST_HTML_DISPLAY);
+        $email = str_replace("<", "", $email);
+        $email = str_replace(">", "", $email);
+        $email = str_replace("&lt;", "", $email);
+        $email = str_replace("&gt;", "", $email);
+
+        $userName = $clientContact->get_value('clientContactName', DST_HTML_DISPLAY);
+        if ($userName) {
+            $mailto = '"' . $userName . '" <' . $email . ">";
+        } else {
+            $mailto = $email;
+        }
+        $email and $col2[] = $ico_e."<a href='mailto:".rawurlencode($mailto)."'>".$email."</a>";
+
+        $phone = $clientContact->get_value('clientContactPhone', DST_HTML_DISPLAY);
+        $phone and $col2[] = $ico_p.$phone;
+
+        $mobile = $clientContact->get_value('clientContactMobile', DST_HTML_DISPLAY);
+        $mobile and $col2[] = $ico_m.$mobile;
+
+        $fax = $clientContact->get_value('clientContactFax', DST_HTML_DISPLAY);
+        $fax and $col2[] = $ico_f.$fax;
+
+        if ($clientContact->get_value("clientContactActive")) {
+            $class_extra = " loud";
+        } else {
+            $class_extra = " quiet";
+        }
+
+        $buttons = '<nobr>
       <button type="submit" name="clientContact_delete" value="1" class="delete_button">Delete<i class="icon-trash"></i></button>
       <button type="submit" name="clientContact_edit" value="1"">Edit<i class="icon-edit"></i></button>
       </nobr>';
 
-      $rtn[] =  '<form action="'.$TPL["url_alloc_client"].'" method="post">';
-      $rtn[] =  '<input type="hidden" name="clientContactID" value="'.$clientContact->get_id().'">';
-      $rtn[] =  '<input type="hidden" name="clientID" value="'.$clientID.'">';
-      $rtn[] =  '<div class="panel'.$class_extra.' corner">';
-      $rtn[] =  '<table width="100%" cellspacing="0" border="0">';
-      $rtn[] =  '<tr>';
-      $rtn[] =  '  <td width="25%" valign="top"><span class="nobr">'.implode('</span><br><span class="nobr">',$col1).'</span>&nbsp;</td>';
-      $rtn[] =  '  <td width="20%" valign="top"><span class="nobr">'.implode('</span><br><span class="nobr">',$col2).'</span>&nbsp;</td>';
-      $rtn[] =  '  <td width="50%" align="left" valign="top">'.nl2br($clientContact->get_value('clientContactOther',DST_HTML_DISPLAY)).'&nbsp;</td>';
-      $rtn[] =  '  <td align="right" class="right nobr">'.$buttons.'</td>';
-      $rtn[] =  '  <td align="right" class="right nobr" width="1%">'.page::star("clientContact",$clientContact->get_id()).'</td>';
-      $rtn[] =  '</tr>';
-      $rtn[] =  '</table>';
-      $rtn[] =  '</div>';
-      $rtn[] =  '<input type="hidden" name="sessID" value="'.$TPL["sessID"].'">';
-      $rtn[] =  '</form>';
-
+        $rtn[] =  '<form action="'.$TPL["url_alloc_client"].'" method="post">';
+        $rtn[] =  '<input type="hidden" name="clientContactID" value="'.$clientContact->get_id().'">';
+        $rtn[] =  '<input type="hidden" name="clientID" value="'.$clientID.'">';
+        $rtn[] =  '<div class="panel'.$class_extra.' corner">';
+        $rtn[] =  '<table width="100%" cellspacing="0" border="0">';
+        $rtn[] =  '<tr>';
+        $rtn[] =  '  <td width="25%" valign="top"><span class="nobr">'.implode('</span><br><span class="nobr">', $col1).'</span>&nbsp;</td>';
+        $rtn[] =  '  <td width="20%" valign="top"><span class="nobr">'.implode('</span><br><span class="nobr">', $col2).'</span>&nbsp;</td>';
+        $rtn[] =  '  <td width="50%" align="left" valign="top">'.nl2br($clientContact->get_value('clientContactOther', DST_HTML_DISPLAY)).'&nbsp;</td>';
+        $rtn[] =  '  <td align="right" class="right nobr">'.$buttons.'</td>';
+        $rtn[] =  '  <td align="right" class="right nobr" width="1%">'.page::star("clientContact", $clientContact->get_id()).'</td>';
+        $rtn[] =  '</tr>';
+        $rtn[] =  '</table>';
+        $rtn[] =  '</div>';
+        $rtn[] =  '<input type="hidden" name="sessID" value="'.$TPL["sessID"].'">';
+        $rtn[] =  '</form>';
     }
 
-    if (is_array($rtn)) { 
-      $TPL["clientContacts"] = implode("\n",$rtn);
-    } 
+    if (is_array($rtn)) {
+        $TPL["clientContacts"] = implode("\n", $rtn);
+    }
     if ($_POST["clientContact_edit"] && $_POST["clientContactID"]) {
-      $clientContact = new clientContact();
-      $clientContact->set_id($_POST["clientContactID"]);
-      $clientContact->select();
-      $clientContact->set_values("clientContact_");
-      if ($clientContact->get_value("primaryContact")) {
-        $TPL["primaryContact_checked"] = " checked";
-      }
-      if ($clientContact->get_value("clientContactActive")) {
-        $TPL["clientContactActive_checked"] = " checked";
-      }
+        $clientContact = new clientContact();
+        $clientContact->set_id($_POST["clientContactID"]);
+        $clientContact->select();
+        $clientContact->set_values("clientContact_");
+        if ($clientContact->get_value("primaryContact")) {
+            $TPL["primaryContact_checked"] = " checked";
+        }
+        if ($clientContact->get_value("clientContactActive")) {
+            $TPL["clientContactActive_checked"] = " checked";
+        }
     } else if ($rtn) {
-      $TPL["class_new_client_contact"] = "hidden";
+        $TPL["class_new_client_contact"] = "hidden";
     }
 
     if (!$_POST["clientContactID"] || $_POST["clientContact_save"]) {
-      $TPL["clientContactActive_checked"] = " checked";
+        $TPL["clientContactActive_checked"] = " checked";
     }
 
     include_template("templates/clientContactM.tpl");
-  }
+}
 
-  function show_attachments() {
+function show_attachments()
+{
     global $clientID;
-    util_show_attachments("client",$clientID);
-  }
+    util_show_attachments("client", $clientID);
+}
  
-  function show_comments() {
+function show_comments()
+{
     global $clientID;
     global $TPL;
     global $client;
-    $TPL["commentsR"] = comment::util_get_comments("client",$clientID);
+    $TPL["commentsR"] = comment::util_get_comments("client", $clientID);
     $TPL["commentsR"] and $TPL["class_new_comment"] = "hidden";
     $interestedPartyOptions = $client->get_all_parties();
-    $interestedPartyOptions = interestedParty::get_interested_parties("client",$client->get_id()
-                                                                     ,$interestedPartyOptions);
+    $interestedPartyOptions = interestedParty::get_interested_parties(
+        "client",
+        $client->get_id(),
+        $interestedPartyOptions
+    );
     $TPL["allParties"] = $interestedPartyOptions or $TPL["allParties"] = array();
     $TPL["entity"] = "client";
     $TPL["entityID"] = $client->get_id();
     $TPL["clientID"] = $client->get_id();
 
     $commentTemplate = new commentTemplate();
-    $ops = $commentTemplate->get_assoc_array("commentTemplateID","commentTemplateName","",array("commentTemplateType"=>"client"));
+    $ops = $commentTemplate->get_assoc_array("commentTemplateID", "commentTemplateName", "", array("commentTemplateType"=>"client"));
     $TPL["commentTemplateOptions"] = "<option value=\"\">Comment Templates</option>".page::select_options($ops);
     include_template("../comment/templates/commentM.tpl");
-  }
+}
 
-  function show_invoices() {
+function show_invoices()
+{
     $current_user = &singleton("current_user");
     global $clientID;
 
@@ -209,14 +216,14 @@ require_once("../alloc.php");
     $_FORM["showInvoiceStatus"] = true;
     $_FORM["clientID"] = $clientID;
 
-    // Restrict non-admin users records  
+    // Restrict non-admin users records
     if (!$current_user->have_role("admin")) {
-      $_FORM["personID"] = $current_user->get_id();  
+        $_FORM["personID"] = $current_user->get_id();
     }
 
     $rows = invoice::get_list($_FORM);
-    echo invoice::get_list_html($rows,$_FORM);
-  }
+    echo invoice::get_list_html($rows, $_FORM);
+}
 
 
 
@@ -225,90 +232,86 @@ $clientID = $_POST["clientID"] or $clientID = $_GET["clientID"];
 
 
 if ($_POST["save"]) {
-  if (!$_POST["clientName"]) {
-    alloc_error("Please enter a Client Name.");
-  }
-  $client->read_globals();
-  $client->set_value("clientModifiedTime", date("Y-m-d"));
-  $clientID = $client->get_id();
-  $client->set_values("client_");
-
-  if (!$client->get_id()) {
-    // New client.
-    $client->set_value("clientCreatedTime", date("Y-m-d"));
-    $new_client = true;
-  }
-
-  if (!$TPL["message"]) {
-    $client->save();
+    if (!$_POST["clientName"]) {
+        alloc_error("Please enter a Client Name.");
+    }
+    $client->read_globals();
+    $client->set_value("clientModifiedTime", date("Y-m-d"));
     $clientID = $client->get_id();
     $client->set_values("client_");
-  }
-  
+
+    if (!$client->get_id()) {
+      // New client.
+        $client->set_value("clientCreatedTime", date("Y-m-d"));
+        $new_client = true;
+    }
+
+    if (!$TPL["message"]) {
+        $client->save();
+        $clientID = $client->get_id();
+        $client->set_values("client_");
+    }
 } else if ($_POST["save_attachment"]) {
-  move_attachment("client",$clientID);
-  alloc_redirect($TPL["url_alloc_client"]."clientID=".$clientID."&sbs_link=attachments");
-
+    move_attachment("client", $clientID);
+    alloc_redirect($TPL["url_alloc_client"]."clientID=".$clientID."&sbs_link=attachments");
 } else if ($_GET["get_vcard"]) {
-  $clientContact = new clientContact();
-  $clientContact->set_id($_GET["clientContactID"]);
-  $clientContact->select();
-  $clientContact->output_vcard();
-  return;
+    $clientContact = new clientContact();
+    $clientContact->set_id($_GET["clientContactID"]);
+    $clientContact->select();
+    $clientContact->output_vcard();
+    return;
 } else {
+    if ($_POST["delete"]) {
+        $client->read_globals();
+        $client->delete();
+        alloc_redirect($TPL["url_alloc_clientList"]);
+    } else {
+        $client->set_id($clientID);
+        $client->select();
+    }
 
-  if ($_POST["delete"]) {
-    $client->read_globals();
-    $client->delete();
-    alloc_redirect($TPL["url_alloc_clientList"]);
-  } else {
-    $client->set_id($clientID);
-    $client->select();
-  }
-
-  $client->set_values("client_");
+    $client->set_values("client_");
 }
 
 $m = new meta("clientStatus");
-$clientStatus_array = $m->get_assoc_array("clientStatusID","clientStatusID");
+$clientStatus_array = $m->get_assoc_array("clientStatusID", "clientStatusID");
 $TPL["clientStatusOptions"] = page::select_options($clientStatus_array, $client->get_value("clientStatus"));
 
 $clientCategories = config::get_config_item("clientCategories") or $clientCategories = array();
 foreach ($clientCategories as $k => $v) {
-  $cc[$v["value"]] = $v["label"];
+    $cc[$v["value"]] = $v["label"];
 }
-$TPL["clientCategoryOptions"] = page::select_options($cc,$client->get_value("clientCategory"));
+$TPL["clientCategoryOptions"] = page::select_options($cc, $client->get_value("clientCategory"));
 $client->get_value("clientCategory") and $TPL["client_clientCategoryLabel"] = $cc[$client->get_value("clientCategory")];
 
 
 // client contacts
 if ($_POST["clientContact_save"] || $_POST["clientContact_delete"]) {
+    $clientContact = new clientContact();
+    $clientContact->read_globals();
 
-  $clientContact = new clientContact();
-  $clientContact->read_globals();
+    if ($_POST["clientContact_save"]) {
+      #$clientContact->set_value('clientID', $_POST["clientID"]);
+        $clientContact->save();
+    }
 
-  if ($_POST["clientContact_save"]) {
-    #$clientContact->set_value('clientID', $_POST["clientID"]);
-    $clientContact->save();
-  }
-
-  if ($_POST["clientContact_delete"]) {
-    $clientContact->delete();
-  }
+    if ($_POST["clientContact_delete"]) {
+        $clientContact->delete();
+    }
 }
 
 if (!$clientID) {
-  $TPL["message_help"][] = "Create a new Client by inputting the Client Name and other details and clicking the Create New Client button.";
-  $TPL["main_alloc_title"] = "New Client - ".APPLICATION_NAME;
-  $TPL["clientSelfLink"] = "New Client";
+    $TPL["message_help"][] = "Create a new Client by inputting the Client Name and other details and clicking the Create New Client button.";
+    $TPL["main_alloc_title"] = "New Client - ".APPLICATION_NAME;
+    $TPL["clientSelfLink"] = "New Client";
 } else {
-  $TPL["main_alloc_title"] = "Client " . $client->get_id() . ": " . $client->get_name()." - ".APPLICATION_NAME;
-  $TPL["clientSelfLink"] = sprintf("<a href=\"%s\">%d %s</a>", $client->get_url(), $client->get_id(), $client->get_name(array("return"=>"html")));
+    $TPL["main_alloc_title"] = "Client " . $client->get_id() . ": " . $client->get_name()." - ".APPLICATION_NAME;
+    $TPL["clientSelfLink"] = sprintf("<a href=\"%s\">%d %s</a>", $client->get_url(), $client->get_id(), $client->get_name(array("return"=>"html")));
 }
 
 
 if ($current_user->have_role("admin")) {
-  $TPL["invoice_links"].= "<a href=\"".$TPL["url_alloc_invoice"]."clientID=".$clientID."\">New Invoice</a>";
+    $TPL["invoice_links"].= "<a href=\"".$TPL["url_alloc_invoice"]."clientID=".$clientID."\">New Invoice</a>";
 }
 
 $projectListOps = array("showProjectType"=>true
@@ -321,8 +324,3 @@ $TPL["client_clientPostalAddress"] = $client->format_address("postal");
 $TPL["client_clientStreetAddress"] = $client->format_address("street");
 
 include_template("templates/clientM.tpl");
-
-
-
-
-?>

--- a/client/clientList.php
+++ b/client/clientList.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -28,13 +28,14 @@ $defaults = array("url_form_action"=>$TPL["url_alloc_clientList"]
                  );
 
 
-function show_filter() {
-  global $TPL;
-  global $defaults;
-  $_FORM = client::load_form_data($defaults);
-  $arr = client::load_client_filter($_FORM);
-  is_array($arr) and $TPL = array_merge($TPL,$arr);
-  include_template("templates/clientListFilterS.tpl");
+function show_filter()
+{
+    global $TPL;
+    global $defaults;
+    $_FORM = client::load_form_data($defaults);
+    $arr = client::load_client_filter($_FORM);
+    is_array($arr) and $TPL = array_merge($TPL, $arr);
+    include_template("templates/clientListFilterS.tpl");
 }
 
 
@@ -42,7 +43,7 @@ $_FORM = client::load_form_data($defaults);
 $TPL["clientListRows"] = client::get_list($_FORM);
 
 if (!$current_user->prefs["clientList_filter"]) {
-  $TPL["message_help"][] = "
+    $TPL["message_help"][] = "
 
 allocPSA allows you to store pertinent information about your Clients and
 the organisations that you interact with. This page allows you to see a list of Clients.
@@ -53,13 +54,8 @@ Simply adjust the filter settings and click the <b>Filter</b> button to
 display a list of previously created Clients. 
 If you would prefer to create a new Client, click the <b>New Client</b> link
 in the top-right hand corner of the box below.";
-
 }
 
 
 $TPL["main_alloc_title"] = "Client List - ".APPLICATION_NAME;
 include_template("templates/clientListM.tpl");
-
-
-
-?>

--- a/client/lib/client.inc.php
+++ b/client/lib/client.inc.php
@@ -3,29 +3,30 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class client extends db_entity {
-  public $classname = "client";
-  public $data_table = "client";
-  public $display_field_name = "clientName";
-  public $key_field = "clientID";
-  public $data_fields = array("clientName"
+class client extends db_entity
+{
+    public $classname = "client";
+    public $data_table = "client";
+    public $display_field_name = "clientName";
+    public $key_field = "clientID";
+    public $data_fields = array("clientName"
                              ,"clientStreetAddressOne"
                              ,"clientStreetAddressTwo"
                              ,"clientSuburbOne"
@@ -47,165 +48,179 @@ class client extends db_entity {
                              );
 
 
-  function delete() {
-    // delete all contacts and comments linked with this client as well
-    $db = new db_alloc();
-    $query = prepare("SELECT * FROM clientContact WHERE clientID=%d", $this->get_id());
-    $db->query($query);
-    while ($db->next_record()) {
-      $clientContact = new clientContact();
-      $clientContact->read_db_record($db);
-      $clientContact->delete();
+    function delete()
+    {
+      // delete all contacts and comments linked with this client as well
+        $db = new db_alloc();
+        $query = prepare("SELECT * FROM clientContact WHERE clientID=%d", $this->get_id());
+        $db->query($query);
+        while ($db->next_record()) {
+            $clientContact = new clientContact();
+            $clientContact->read_db_record($db);
+            $clientContact->delete();
+        }
+        $query = prepare("SELECT * FROM comment WHERE commentType = 'client' and commentLinkID=%d", $this->get_id());
+        $db->query($query);
+        while ($db->next_record()) {
+            $comment = new comment();
+            $comment->read_db_record($db);
+            $comment->delete();
+        }
+        return parent::delete();
     }
-    $query = prepare("SELECT * FROM comment WHERE commentType = 'client' and commentLinkID=%d", $this->get_id());
-    $db->query($query);
-    while ($db->next_record()) {
-      $comment = new comment();
-      $comment->read_db_record($db);
-      $comment->delete();
+
+    function is_owner()
+    {
+        $current_user = &singleton("current_user");
+        return $current_user->is_employee();
     }
-    return parent::delete();
-  }
 
-  function is_owner() {
-    $current_user = &singleton("current_user");
-    return $current_user->is_employee();
-  }
+    function has_attachment_permission($person)
+    {
+      // Placeholder for security check in shared/get_attchment.php
+        return true;
+    }
 
-  function has_attachment_permission($person) {
-    // Placeholder for security check in shared/get_attchment.php
-    return true;
-  }
+    function has_attachment_permission_delete($person)
+    {
+      // Placeholder for security check in shared/get_attchment.php
+        return true;
+    }
 
-  function has_attachment_permission_delete($person) {
-    // Placeholder for security check in shared/get_attchment.php
-    return true;
-  }
-
-  function get_client_select($clientStatus="", $clientID="") {
-    global $TPL;
-    $db = new db_alloc();
-    if ($clientStatus) {
-      $q = prepare("SELECT clientID as value, clientName as label 
+    function get_client_select($clientStatus = "", $clientID = "")
+    {
+        global $TPL;
+        $db = new db_alloc();
+        if ($clientStatus) {
+            $q = prepare(
+                "SELECT clientID as value, clientName as label 
                       FROM client 
                      WHERE clientStatus = '%s' 
                         OR clientID = %d 
-                  ORDER BY clientName"
-                    ,$clientStatus,$clientID);
+                  ORDER BY clientName",
+                $clientStatus,
+                $clientID
+            );
+        }
+        $options.= page::select_options($q, $clientID, 100);
+        $str = "<select id=\"clientID\" name=\"clientID\" style=\"width:100%;\">";
+        $str.= "<option value=\"\">";
+        $str.= $options;
+        $str.= "</select>";
+        return $str;
     }
-    $options.= page::select_options($q,$clientID,100);
-    $str = "<select id=\"clientID\" name=\"clientID\" style=\"width:100%;\">";
-    $str.= "<option value=\"\">";
-    $str.= $options;
-    $str.= "</select>";
-    return $str;
-  }
  
-  function get_client_contact_select($clientID="",$clientContactID="") {
-    $clientID or $clientID = $_GET["clientID"];
-    $db = new db_alloc();
-    $q = prepare("SELECT clientContactName as label, clientContactID as value FROM clientContact WHERE clientID = %d",$clientID);
-    $options = page::select_options($q,$clientContactID,100);
-    return "<select id=\"clientContactID\" name=\"clientContactID\" style=\"width:100%\"><option value=\"\">".$options."</select>";
-  }
+    function get_client_contact_select($clientID = "", $clientContactID = "")
+    {
+        $clientID or $clientID = $_GET["clientID"];
+        $db = new db_alloc();
+        $q = prepare("SELECT clientContactName as label, clientContactID as value FROM clientContact WHERE clientID = %d", $clientID);
+        $options = page::select_options($q, $clientContactID, 100);
+        return "<select id=\"clientContactID\" name=\"clientContactID\" style=\"width:100%\"><option value=\"\">".$options."</select>";
+    }
  
-  function get_name($_FORM=array()) {
-    if ($_FORM["return"] == "html") { 
-      return $this->get_value("clientName",DST_HTML_DISPLAY);
-    } else {
-      return $this->get_value("clientName");
-    }
-  }
-
-  function get_client_link($_FORM=array()) {
-    global $TPL;
-    return "<a href=\"".$TPL["url_alloc_client"]."clientID=".$this->get_id()."\">".$this->get_name($_FORM)."</a>";
-  }
-
-  function get_list_filter($filter=array()) {
-    $current_user = &singleton("current_user");
-
-    // If they want starred, load up the clientID filter element
-    if ($filter["starred"]) {
-      foreach ((array)$current_user->prefs["stars"]["client"] as $k=>$v) {
-        $filter["clientID"][] = $k;
-      }
-      is_array($filter["clientID"]) or $filter["clientID"][] = -1;
+    function get_name($_FORM = array())
+    {
+        if ($_FORM["return"] == "html") {
+            return $this->get_value("clientName", DST_HTML_DISPLAY);
+        } else {
+            return $this->get_value("clientName");
+        }
     }
 
-    // Filter on clientID
-    $filter["clientID"] and $sql[] = sprintf_implode("client.clientID = %d", $filter["clientID"]);
-
-    // No point continuing if primary key specified, so return
-    if ($filter["clientID"] || $filter["starred"]) {
-      return $sql;
+    function get_client_link($_FORM = array())
+    {
+        global $TPL;
+        return "<a href=\"".$TPL["url_alloc_client"]."clientID=".$this->get_id()."\">".$this->get_name($_FORM)."</a>";
     }
 
-    $filter["clientStatus"]   and $sql[] = sprintf_implode("client.clientStatus = '%s'", $filter["clientStatus"]);
-    $filter["clientCategory"] and $sql[] = sprintf_implode("IFNULL(client.clientCategory,'') = '%s'", $filter["clientCategory"]);
-    $filter["clientName"]     and $sql[] = sprintf_implode("IFNULL(clientName,'') LIKE '%%%s%%'",$filter["clientName"]);
-    $filter["contactName"]    and $sql[] = sprintf_implode("IFNULL(clientContactName,'') LIKE '%%%s%%'",$filter["contactName"]);
+    function get_list_filter($filter = array())
+    {
+        $current_user = &singleton("current_user");
 
-    if ($filter["clientLetter"] && $filter["clientLetter"] == "A") {
-      $sql[] = "(clientName like 'A%' or clientName REGEXP '^[^[:alpha:]]')";
-    } else if ($filter["clientLetter"] && $filter["clientLetter"] != "ALL") {
-      $sql[] = sprintf_implode("clientName LIKE '%s%%'",$filter["clientLetter"]);
+      // If they want starred, load up the clientID filter element
+        if ($filter["starred"]) {
+            foreach ((array)$current_user->prefs["stars"]["client"] as $k => $v) {
+                $filter["clientID"][] = $k;
+            }
+            is_array($filter["clientID"]) or $filter["clientID"][] = -1;
+        }
+
+      // Filter on clientID
+        $filter["clientID"] and $sql[] = sprintf_implode("client.clientID = %d", $filter["clientID"]);
+
+      // No point continuing if primary key specified, so return
+        if ($filter["clientID"] || $filter["starred"]) {
+            return $sql;
+        }
+
+        $filter["clientStatus"]   and $sql[] = sprintf_implode("client.clientStatus = '%s'", $filter["clientStatus"]);
+        $filter["clientCategory"] and $sql[] = sprintf_implode("IFNULL(client.clientCategory,'') = '%s'", $filter["clientCategory"]);
+        $filter["clientName"]     and $sql[] = sprintf_implode("IFNULL(clientName,'') LIKE '%%%s%%'", $filter["clientName"]);
+        $filter["contactName"]    and $sql[] = sprintf_implode("IFNULL(clientContactName,'') LIKE '%%%s%%'", $filter["contactName"]);
+
+        if ($filter["clientLetter"] && $filter["clientLetter"] == "A") {
+            $sql[] = "(clientName like 'A%' or clientName REGEXP '^[^[:alpha:]]')";
+        } else if ($filter["clientLetter"] && $filter["clientLetter"] != "ALL") {
+            $sql[] = sprintf_implode("clientName LIKE '%s%%'", $filter["clientLetter"]);
+        }
+
+        return $sql;
     }
 
-    return $sql;
-  }
-
-  public static function get_list($_FORM) {
-    /*
-     * This is the definitive method of getting a list of clients that need a sophisticated level of filtering
-     *
-     */
+    public static function get_list($_FORM)
+    {
+      /*
+       * This is the definitive method of getting a list of clients that need a sophisticated level of filtering
+       *
+       */
 
 
-    global $TPL;
-    $filter = client::get_list_filter($_FORM);
+        global $TPL;
+        $filter = client::get_list_filter($_FORM);
 
-    $debug = $_FORM["debug"];
-    $debug and print "<pre>_FORM: ".print_r($_FORM,1)."</pre>";
-    $debug and print "<pre>filter: ".print_r($filter,1)."</pre>";
+        $debug = $_FORM["debug"];
+        $debug and print "<pre>_FORM: ".print_r($_FORM, 1)."</pre>";
+        $debug and print "<pre>filter: ".print_r($filter, 1)."</pre>";
   
-    $_FORM["return"] or $_FORM["return"] = "html";
+        $_FORM["return"] or $_FORM["return"] = "html";
 
-    if (is_array($filter) && count($filter)) {
-      $filter = " WHERE ".implode(" AND ",$filter);
-    }
+        if (is_array($filter) && count($filter)) {
+            $filter = " WHERE ".implode(" AND ", $filter);
+        }
 
-    $cc = config::get_config_item("clientCategories");
-    foreach ($cc as $k => $v) {
-      $clientCategories[$v["value"]] = $v["label"];
-    }
+        $cc = config::get_config_item("clientCategories");
+        foreach ($cc as $k => $v) {
+            $clientCategories[$v["value"]] = $v["label"];
+        }
 
-    $q = "SELECT client.*,clientContactName, clientContactEmail, clientContactPhone, clientContactMobile
+        $q = "SELECT client.*,clientContactName, clientContactEmail, clientContactPhone, clientContactMobile
             FROM client 
        LEFT JOIN clientContact ON client.clientID = clientContact.clientID AND clientContact.clientContactActive = 1
                  ".$filter." 
         GROUP BY client.clientID 
         ORDER BY clientName,clientContact.primaryContact asc";
-    $debug and print "Query: ".$q;
-    $db = new db_alloc();
-    $db2 = new db_alloc();
-    $db->query($q);
-    while ($row = $db->next_record()) {
-      $print = true;
-      $c = new client();
-      $c->read_db_record($db);
-      $row["clientCategoryLabel"] = $clientCategories[$c->get_value("clientCategory")];
-      $row["clientLink"] = $c->get_client_link($_FORM);
-      $row["clientContactEmail"] and $row["clientContactEmail"] = "<a href=\"mailto:".page::htmlentities($row["clientContactName"]." <".$row["clientContactEmail"].">")."\">".page::htmlentities($row["clientContactEmail"])."</a>";
+        $debug and print "Query: ".$q;
+        $db = new db_alloc();
+        $db2 = new db_alloc();
+        $db->query($q);
+        while ($row = $db->next_record()) {
+            $print = true;
+            $c = new client();
+            $c->read_db_record($db);
+            $row["clientCategoryLabel"] = $clientCategories[$c->get_value("clientCategory")];
+            $row["clientLink"] = $c->get_client_link($_FORM);
+            $row["clientContactEmail"] and $row["clientContactEmail"] = "<a href=\"mailto:".page::htmlentities($row["clientContactName"]." <".$row["clientContactEmail"].">")."\">".page::htmlentities($row["clientContactEmail"])."</a>";
 
-      $rows[$c->get_id()] = $row;
+            $rows[$c->get_id()] = $row;
+        }
+        return (array)$rows;
     }
-    return (array)$rows;
-  }
 
-  function get_list_vars() {
+    function get_list_vars()
+    {
 
-    return array("clientStatus"             => "Client status eg: Current | Potential | Archived"
+        return array("clientStatus"             => "Client status eg: Current | Potential | Archived"
                 ,"clientCategory"           => "Client category eg: 1-7"
                 ,"clientName"               => "Client name like *something*"
                 ,"contactName"              => "Client Contact name like *something*"
@@ -215,262 +230,265 @@ class client extends db_entity {
                 ,"dontSave"                 => "Specify that the filter preferences should not be saved this time"
                 ,"applyFilter"              => "Saves this filter as the persons preference"
                 );
-  }
-
-  function load_form_data($defaults=array()) {
-    $current_user = &singleton("current_user");
-
-    $page_vars = array_keys(client::get_list_vars());
-
-    $_FORM = get_all_form_data($page_vars,$defaults);
-
-    if (!$_FORM["applyFilter"]) {
-      $_FORM = $current_user->prefs[$_FORM["form_name"]];
-      if (!isset($current_user->prefs[$_FORM["form_name"]])) {
-        $_FORM["clientLetter"] = "A";
-        $_FORM["clientStatus"] = "Current";
-      }
-
-    } else if ($_FORM["applyFilter"] && is_object($current_user) && !$_FORM["dontSave"]) {
-      $url = $_FORM["url_form_action"];
-      unset($_FORM["url_form_action"]);
-      $current_user->prefs[$_FORM["form_name"]] = $_FORM;
-      $_FORM["url_form_action"] = $url;
     }
 
-    return $_FORM;
-  }
+    function load_form_data($defaults = array())
+    {
+        $current_user = &singleton("current_user");
 
-  function load_client_filter($_FORM) {
-    global $TPL;
+        $page_vars = array_keys(client::get_list_vars());
 
-    $db = new db_alloc();
+        $_FORM = get_all_form_data($page_vars, $defaults);
 
-    // Load up the forms action url
-    $rtn["url_form_action"] = $_FORM["url_form_action"];
+        if (!$_FORM["applyFilter"]) {
+            $_FORM = $current_user->prefs[$_FORM["form_name"]];
+            if (!isset($current_user->prefs[$_FORM["form_name"]])) {
+                $_FORM["clientLetter"] = "A";
+                $_FORM["clientStatus"] = "Current";
+            }
+        } else if ($_FORM["applyFilter"] && is_object($current_user) && !$_FORM["dontSave"]) {
+            $url = $_FORM["url_form_action"];
+            unset($_FORM["url_form_action"]);
+            $current_user->prefs[$_FORM["form_name"]] = $_FORM;
+            $_FORM["url_form_action"] = $url;
+        }
 
-    $m = new meta("clientStatus");
-    $clientStatus_array = $m->get_assoc_array("clientStatusID","clientStatusID");
-    $rtn["clientStatusOptions"] = page::select_options($clientStatus_array, $_FORM["clientStatus"]);
-    $rtn["clientName"] = $_FORM["clientName"];
-    $rtn["contactName"] = $_FORM["contactName"];
-    $letters = array("A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "ALL");
-    foreach($letters as $letter) {
-      if ($_FORM["clientLetter"] == $letter) {
-        $rtn["alphabet_filter"].= "&nbsp;&nbsp;".$letter;
-      } else {
-        $rtn["alphabet_filter"].= "&nbsp;&nbsp;<a href=\"".$TPL["url_alloc_clientList"]."clientLetter=".$letter."&clientStatus=Current&applyFilter=1\">".$letter."</a>";
-      }
+        return $_FORM;
     }
+
+    function load_client_filter($_FORM)
+    {
+        global $TPL;
+
+        $db = new db_alloc();
+
+      // Load up the forms action url
+        $rtn["url_form_action"] = $_FORM["url_form_action"];
+
+        $m = new meta("clientStatus");
+        $clientStatus_array = $m->get_assoc_array("clientStatusID", "clientStatusID");
+        $rtn["clientStatusOptions"] = page::select_options($clientStatus_array, $_FORM["clientStatus"]);
+        $rtn["clientName"] = $_FORM["clientName"];
+        $rtn["contactName"] = $_FORM["contactName"];
+        $letters = array("A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "ALL");
+        foreach ($letters as $letter) {
+            if ($_FORM["clientLetter"] == $letter) {
+                $rtn["alphabet_filter"].= "&nbsp;&nbsp;".$letter;
+            } else {
+                $rtn["alphabet_filter"].= "&nbsp;&nbsp;<a href=\"".$TPL["url_alloc_clientList"]."clientLetter=".$letter."&clientStatus=Current&applyFilter=1\">".$letter."</a>";
+            }
+        }
     
-    $clientCategory = $_FORM["clientCategory"];
-    $clientCategories = config::get_config_item("clientCategories") or $clientCategories = array();
-    foreach ($clientCategories as $k => $v) {
-      $cc[$v["value"]] = $v["label"];
-    }
-    $rtn["clientCategoryOptions"] = page::select_options($cc,$clientCategory);
+        $clientCategory = $_FORM["clientCategory"];
+        $clientCategories = config::get_config_item("clientCategories") or $clientCategories = array();
+        foreach ($clientCategories as $k => $v) {
+            $cc[$v["value"]] = $v["label"];
+        }
+        $rtn["clientCategoryOptions"] = page::select_options($cc, $clientCategory);
 
-    // Get
-    $rtn["FORM"] = "FORM=".urlencode(serialize($_FORM));
+      // Get
+        $rtn["FORM"] = "FORM=".urlencode(serialize($_FORM));
 
-    return $rtn;
-  }
-
-  function get_url() {
-    global $TPL;
-    global $sess;
-    $url = "client/client.php?&clientID=".$this->get_id();
-    return $TPL["url_alloc_client"].$url;
-  }
-
-  function get_clientID_from_name($name) {
-    static $clients;
-    if (!$clients) {
-      $db = new db_alloc();
-      $q = prepare("SELECT * FROM client");
-      $db->query($q);
-      while ($db->next_record()) {
-        $clients[$db->f("clientID")] = $db->f("clientName");
-      }
+        return $rtn;
     }
 
-    $stack = array();
-    foreach ($clients as $clientID => $clientName) {
-      similar_text(strtolower($name),strtolower($clientName),$percent);
-      $stack[$clientID] = $percent;
-    }
-    asort($stack);
-    end($stack);
-    $probable_clientID = key($stack);
-    $client_percent = current($stack);
-    return array($probable_clientID,$client_percent);
-  }
-
-  function get_client_and_project_dropdowns_and_links($clientID=false, $projectID=false, $onlymine=false) {
-    // This function returns dropdown lists and links for both client and
-    // project. The two dropdown lists are linked, in that if you change the
-    // client, then the project dropdown dynamically updates 
-    global $TPL;
-
-    $project = new project();
-    $project->set_id($projectID);
-    $project->select();
-    if (!$clientID) {
-      $clientID = $project->get_value("clientID");
+    function get_url()
+    {
+        global $TPL;
+        global $sess;
+        $url = "client/client.php?&clientID=".$this->get_id();
+        return $TPL["url_alloc_client"].$url;
     }
 
-    $client = new client();
-    $client->set_id($clientID);
-    $client->select();
+    function get_clientID_from_name($name)
+    {
+        static $clients;
+        if (!$clients) {
+            $db = new db_alloc();
+            $q = prepare("SELECT * FROM client");
+            $db->query($q);
+            while ($db->next_record()) {
+                $clients[$db->f("clientID")] = $db->f("clientName");
+            }
+        }
 
-    $options["clientStatus"] = "Current";
-    $ops = client::get_list($options);
-    $ops = array_kv($ops,"clientID","clientName");
-    $client->get_id() and $ops[$client->get_id()] = $client->get_value("clientName");
-    $client_select = "<select id=\"clientID\" name=\"clientID\" onChange=\"makeAjaxRequest('".$TPL["url_alloc_updateProjectListByClient"]."clientID='+$('#clientID').attr('value')+'&onlymine=".sprintf("%d",$onlymine)."','projectDropdown')\"><option></option>";
-    $client_select.= page::select_options($ops,$clientID,100)."</select>";
+        $stack = array();
+        foreach ($clients as $clientID => $clientName) {
+            similar_text(strtolower($name), strtolower($clientName), $percent);
+            $stack[$clientID] = $percent;
+        }
+        asort($stack);
+        end($stack);
+        $probable_clientID = key($stack);
+        $client_percent = current($stack);
+        return array($probable_clientID,$client_percent);
+    }
 
-    $client_link = $client->get_link();
+    function get_client_and_project_dropdowns_and_links($clientID = false, $projectID = false, $onlymine = false)
+    {
+      // This function returns dropdown lists and links for both client and
+      // project. The two dropdown lists are linked, in that if you change the
+      // client, then the project dropdown dynamically updates
+        global $TPL;
+
+        $project = new project();
+        $project->set_id($projectID);
+        $project->select();
+        if (!$clientID) {
+            $clientID = $project->get_value("clientID");
+        }
+
+        $client = new client();
+        $client->set_id($clientID);
+        $client->select();
+
+        $options["clientStatus"] = "Current";
+        $ops = client::get_list($options);
+        $ops = array_kv($ops, "clientID", "clientName");
+        $client->get_id() and $ops[$client->get_id()] = $client->get_value("clientName");
+        $client_select = "<select id=\"clientID\" name=\"clientID\" onChange=\"makeAjaxRequest('".$TPL["url_alloc_updateProjectListByClient"]."clientID='+$('#clientID').attr('value')+'&onlymine=".sprintf("%d", $onlymine)."','projectDropdown')\"><option></option>";
+        $client_select.= page::select_options($ops, $clientID, 100)."</select>";
+
+        $client_link = $client->get_link();
 
 
-    $project_select = '<div id="projectDropdown" style="display:inline">'.$project->get_dropdown_by_client($clientID,$onlymine).'</div>';
-    $project_link = $project->get_link();
+        $project_select = '<div id="projectDropdown" style="display:inline">'.$project->get_dropdown_by_client($clientID, $onlymine).'</div>';
+        $project_link = $project->get_link();
   
-    return array($client_select, $client_link, $project_select, $project_link);
-  }
-
-  function update_search_index_doc(&$index) {
-    $person =& get_cached_table("person");
-    $clientModifiedUser = $this->get_value("clientModifiedUser");
-    $clientModifiedUser_field = $clientModifiedUser." ".$person[$clientModifiedUser]["username"]." ".$person[$clientModifiedUser]["name"];
-
-    $this->get_value("clientStreetAddressOne") and $postal[] = $this->get_value("clientStreetAddressOne");
-    $this->get_value("clientSuburbOne")        and $postal[] = $this->get_value("clientSuburbOne");
-    $this->get_value("clientStateOne")         and $postal[] = $this->get_value("clientStateOne");
-    $this->get_value("clientPostcodeOne")      and $postal[] = $this->get_value("clientPostcodeOne");
-    $this->get_value("clientCountryOne")       and $postal[] = $this->get_value("clientCountryOne");
-    $p = implode("\n",(array)$postal);
-    $p and $p = "Postal Address:\n".$p;
-
-    $this->get_value("clientStreetAddressTwo") and $street[] = $this->get_value("clientStreetAddressTwo");
-    $this->get_value("clientSuburbTwo")        and $street[] = $this->get_value("clientSuburbTwo");
-    $this->get_value("clientStateTwo")         and $street[] = $this->get_value("clientStateTwo");
-    $this->get_value("clientPostcodeTwo")      and $street[] = $this->get_value("clientPostcodeTwo");
-    $this->get_value("clientCountryTwo")       and $street[] = $this->get_value("clientCountryTwo");
-    $s = implode("\n",(array)$street);
-    $s and $s = "Street Address:\n".$s;
-
-    $p && $s and $p.= "\n\n";
-    $addresses = $p.$s;
-
-    $this->get_value("clientPhoneOne") and $ph = "Ph: ".$this->get_value("clientPhoneOne");
-    $this->get_value("clientFaxOne")   and $fx = "Fax: ".$this->get_value("clientFaxOne");
-
-    $ph and $ph = " ".$ph;
-    $fx and $fx = " ".$fx;
-    $name = $this->get_name().$ph.$fx;
-
-    $q = prepare("SELECT * FROM clientContact WHERE clientID = %d",$this->get_id());
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $c.= $nl.$row["clientContactName"];
-      $row["clientContactEmail"]         and $c.= " <".$row["clientContactEmail"].">";
-      $c.= " | ";
-      $row["clientContactStreetAddress"] and $c.= " ".$row["clientContactStreetAddress"];
-      $row["clientContactSuburb"]        and $c.= " ".$row["clientContactSuburb"];
-      $row["clientContactState"]         and $c.= " ".$row["clientContactState"];
-      $row["clientContactPostcode"]      and $c.= " ".$row["clientContactPostcode"];
-      $row["clientContactCountry"]       and $c.= " ".$row["clientContactCountry"];
-      $c.= " | ";
-      $row["clientContactPhone"]         and $c.= " Ph: ".$row["clientContactPhone"];
-      $row["clientContactMobile"]        and $c.= " Mob: ".$row["clientContactMobile"];
-      $row["clientContactFax"]           and $c.= " Fax: ".$row["clientContactFax"];
-      $row["primaryContact"]             and $c.= " Primary contact";
-      $c.= " | ";
-      $row["clientContactOther"]         and $c.= " ".$row["clientContactOther"];
-      $nl = "|+|=|";
-    }
-    $c and $contacts = $c;
-
-    $doc = new Zend_Search_Lucene_Document();
-    $doc->addField(Zend_Search_Lucene_Field::Keyword('id'   ,$this->get_id()));
-    $doc->addField(Zend_Search_Lucene_Field::Text('name'    ,$name,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('desc'    ,$addresses,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('contact' ,$contacts,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('status'  ,$this->get_value("clientStatus"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('modifier',$clientModifiedUser_field,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateModified',str_replace("-","",$this->get_value("clientModifiedTime")),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('category',$this->get_value("clientCategory"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateCreated',str_replace("-","",$this->get_value("clientCreatedTime")),"utf-8"));
-    $index->addDocument($doc);
-  }
-
-  function format_address($type="street", $map_link=true) {
-
-    if ($type == "postal") {
-      $f1 = $this->get_value("clientStreetAddressOne",DST_HTML_DISPLAY);
-      $f2 = $this->get_value("clientSuburbOne",DST_HTML_DISPLAY);
-      $f3 = $this->get_value("clientStateOne",DST_HTML_DISPLAY);
-      $f4 = $this->get_value("clientPostcodeOne",DST_HTML_DISPLAY);
-      $f5 = $this->get_value("clientCountryOne",DST_HTML_DISPLAY);
-
-    } else if ($type == "street") {
-      $f1 = $this->get_value("clientStreetAddressTwo",DST_HTML_DISPLAY);
-      $f2 = $this->get_value("clientSuburbTwo",DST_HTML_DISPLAY);
-      $f3 = $this->get_value("clientStateTwo",DST_HTML_DISPLAY);
-      $f4 = $this->get_value("clientPostcodeTwo",DST_HTML_DISPLAY);
-      $f5 = $this->get_value("clientCountryTwo",DST_HTML_DISPLAY);
+        return array($client_select, $client_link, $project_select, $project_link);
     }
 
-    // Create a map link, this will give you a link even if you only have the
-    // street address and the suburb OR post code. -- cjbayliss 2015-01
+    function update_search_index_doc(&$index)
+    {
+        $person =& get_cached_table("person");
+        $clientModifiedUser = $this->get_value("clientModifiedUser");
+        $clientModifiedUser_field = $clientModifiedUser." ".$person[$clientModifiedUser]["username"]." ".$person[$clientModifiedUser]["name"];
+
+        $this->get_value("clientStreetAddressOne") and $postal[] = $this->get_value("clientStreetAddressOne");
+        $this->get_value("clientSuburbOne")        and $postal[] = $this->get_value("clientSuburbOne");
+        $this->get_value("clientStateOne")         and $postal[] = $this->get_value("clientStateOne");
+        $this->get_value("clientPostcodeOne")      and $postal[] = $this->get_value("clientPostcodeOne");
+        $this->get_value("clientCountryOne")       and $postal[] = $this->get_value("clientCountryOne");
+        $p = implode("\n", (array)$postal);
+        $p and $p = "Postal Address:\n".$p;
+
+        $this->get_value("clientStreetAddressTwo") and $street[] = $this->get_value("clientStreetAddressTwo");
+        $this->get_value("clientSuburbTwo")        and $street[] = $this->get_value("clientSuburbTwo");
+        $this->get_value("clientStateTwo")         and $street[] = $this->get_value("clientStateTwo");
+        $this->get_value("clientPostcodeTwo")      and $street[] = $this->get_value("clientPostcodeTwo");
+        $this->get_value("clientCountryTwo")       and $street[] = $this->get_value("clientCountryTwo");
+        $s = implode("\n", (array)$street);
+        $s and $s = "Street Address:\n".$s;
+
+        $p && $s and $p.= "\n\n";
+        $addresses = $p.$s;
+
+        $this->get_value("clientPhoneOne") and $ph = "Ph: ".$this->get_value("clientPhoneOne");
+        $this->get_value("clientFaxOne")   and $fx = "Fax: ".$this->get_value("clientFaxOne");
+
+        $ph and $ph = " ".$ph;
+        $fx and $fx = " ".$fx;
+        $name = $this->get_name().$ph.$fx;
+
+        $q = prepare("SELECT * FROM clientContact WHERE clientID = %d", $this->get_id());
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $c.= $nl.$row["clientContactName"];
+            $row["clientContactEmail"]         and $c.= " <".$row["clientContactEmail"].">";
+            $c.= " | ";
+            $row["clientContactStreetAddress"] and $c.= " ".$row["clientContactStreetAddress"];
+            $row["clientContactSuburb"]        and $c.= " ".$row["clientContactSuburb"];
+            $row["clientContactState"]         and $c.= " ".$row["clientContactState"];
+            $row["clientContactPostcode"]      and $c.= " ".$row["clientContactPostcode"];
+            $row["clientContactCountry"]       and $c.= " ".$row["clientContactCountry"];
+            $c.= " | ";
+            $row["clientContactPhone"]         and $c.= " Ph: ".$row["clientContactPhone"];
+            $row["clientContactMobile"]        and $c.= " Mob: ".$row["clientContactMobile"];
+            $row["clientContactFax"]           and $c.= " Fax: ".$row["clientContactFax"];
+            $row["primaryContact"]             and $c.= " Primary contact";
+            $c.= " | ";
+            $row["clientContactOther"]         and $c.= " ".$row["clientContactOther"];
+            $nl = "|+|=|";
+        }
+        $c and $contacts = $c;
+
+        $doc = new Zend_Search_Lucene_Document();
+        $doc->addField(Zend_Search_Lucene_Field::Keyword('id', $this->get_id()));
+        $doc->addField(Zend_Search_Lucene_Field::Text('name', $name, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('desc', $addresses, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('contact', $contacts, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('status', $this->get_value("clientStatus"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('modifier', $clientModifiedUser_field, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateModified', str_replace("-", "", $this->get_value("clientModifiedTime")), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('category', $this->get_value("clientCategory"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateCreated', str_replace("-", "", $this->get_value("clientCreatedTime")), "utf-8"));
+        $index->addDocument($doc);
+    }
+
+    function format_address($type = "street", $map_link = true)
+    {
+
+        if ($type == "postal") {
+            $f1 = $this->get_value("clientStreetAddressOne", DST_HTML_DISPLAY);
+            $f2 = $this->get_value("clientSuburbOne", DST_HTML_DISPLAY);
+            $f3 = $this->get_value("clientStateOne", DST_HTML_DISPLAY);
+            $f4 = $this->get_value("clientPostcodeOne", DST_HTML_DISPLAY);
+            $f5 = $this->get_value("clientCountryOne", DST_HTML_DISPLAY);
+        } else if ($type == "street") {
+            $f1 = $this->get_value("clientStreetAddressTwo", DST_HTML_DISPLAY);
+            $f2 = $this->get_value("clientSuburbTwo", DST_HTML_DISPLAY);
+            $f3 = $this->get_value("clientStateTwo", DST_HTML_DISPLAY);
+            $f4 = $this->get_value("clientPostcodeTwo", DST_HTML_DISPLAY);
+            $f5 = $this->get_value("clientCountryTwo", DST_HTML_DISPLAY);
+        }
+
+      // Create a map link, this will give you a link even if you only have the
+      // street address and the suburb OR post code. -- cjbayliss 2015-01
     
-    if ($map_link && !empty($f1) and !empty($f2) || !empty($f4)) {
-      $map_base = config::get_config_item('mapURL');
-      $address = str_replace("%ad", urlencode(implode(", ",array($f1,$f2,$f3,$f4,$f5))), $map_base);
-      $str .= '<a href="' . $address .'">'.$f1.'<br/>'.$f2.' '.$f3.' '.$f4.'<br/>'.$f5.'</a>';
-    } else if ($f1 != ""){
-      $str = $f1;
-      $f2 and $str.= "<br>".$f2;
-      $f3 and $str.= " ".$f3;
-      $f4 and $str.= " ".$f4;
-      $f5 and $str.= "<br>".$f5;
+        if ($map_link && !empty($f1) and !empty($f2) || !empty($f4)) {
+            $map_base = config::get_config_item('mapURL');
+            $address = str_replace("%ad", urlencode(implode(", ", array($f1,$f2,$f3,$f4,$f5))), $map_base);
+            $str .= '<a href="' . $address .'">'.$f1.'<br/>'.$f2.' '.$f3.' '.$f4.'<br/>'.$f5.'</a>';
+        } else if ($f1 != "") {
+            $str = $f1;
+            $f2 and $str.= "<br>".$f2;
+            $f3 and $str.= " ".$f3;
+            $f4 and $str.= " ".$f4;
+            $f5 and $str.= "<br>".$f5;
+        }
+
+        return $str;
     }
 
-    return $str;
-  }
-
-  function get_all_parties($clientID=false) {
-    if (!$clientID && is_object($this)) {
-      $clientID = $this->get_id();
-    }
-    if ($clientID) {
-      // Get all client contacts 
-      $db = new db_alloc();
-      $q = prepare("SELECT clientContactName, clientContactEmail, clientContactID 
+    function get_all_parties($clientID = false)
+    {
+        if (!$clientID && is_object($this)) {
+            $clientID = $this->get_id();
+        }
+        if ($clientID) {
+          // Get all client contacts
+            $db = new db_alloc();
+            $q = prepare("SELECT clientContactName, clientContactEmail, clientContactID 
                       FROM clientContact 
                      WHERE clientID = %d
                        AND clientContactActive = 1
-                     ",$clientID);
-      $db->query($q);
-      while ($db->next_record()) {
-        $interestedPartyOptions[$db->f("clientContactEmail")] = array("name"=>$db->f("clientContactName"),"external"=>"1","clientContactID"=>$db->f("clientContactID"));
-      }
+                     ", $clientID);
+            $db->query($q);
+            while ($db->next_record()) {
+                  $interestedPartyOptions[$db->f("clientContactEmail")] = array("name"=>$db->f("clientContactName"),"external"=>"1","clientContactID"=>$db->f("clientContactID"));
+            }
+        }
+      // return an aggregation of the current task/proj/client parties + the existing interested parties
+        $interestedPartyOptions = interestedParty::get_interested_parties("client", $clientID, $interestedPartyOptions);
+        return (array)$interestedPartyOptions;
     }
-    // return an aggregation of the current task/proj/client parties + the existing interested parties
-    $interestedPartyOptions = interestedParty::get_interested_parties("client",$clientID,$interestedPartyOptions);
-    return (array)$interestedPartyOptions;
-  }
 
-  function get_list_html($rows=array(),$ops=array()) {
-    global $TPL;
-    $TPL["clientListRows"] = $rows;
-    $TPL["_FORM"] = $ops;
-    include_template(dirname(__FILE__)."/../templates/clientListS.tpl");
-  }
+    function get_list_html($rows = array(), $ops = array())
+    {
+        global $TPL;
+        $TPL["clientListRows"] = $rows;
+        $TPL["_FORM"] = $ops;
+        include_template(dirname(__FILE__)."/../templates/clientListS.tpl");
+    }
 }
-
-
-
-?>

--- a/client/lib/clientContact.inc.php
+++ b/client/lib/clientContact.inc.php
@@ -3,29 +3,30 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class clientContact extends db_entity {
-  public $classname = "clientContact";
-  public $data_table = "clientContact";
-  public $display_field_name = "clientContactName";
-  public $key_field = "clientContactID";
-  public $data_fields = array("clientID"
+class clientContact extends db_entity
+{
+    public $classname = "clientContact";
+    public $data_table = "clientContact";
+    public $display_field_name = "clientContactName";
+    public $key_field = "clientContactID";
+    public $data_fields = array("clientID"
                              ,"clientContactName"
                              ,"clientContactStreetAddress"
                              ,"clientContactSuburb"
@@ -41,246 +42,259 @@ class clientContact extends db_entity {
                              ,"clientContactActive"
                              );
 
-  function save() {
-    $rtn = parent::save();
-    $c = new client();
-    $c->set_id($this->get_value("clientID"));
-    $c->select();
-    $c->save();
-    return $rtn;
-  }
-
-  function find_by_name($name=false,$projectID=false,$percent=90) {
-    $stack1 = array();
-    $people = array();
-    $db = new db_alloc();
-
-    if ($projectID) {
-      $db->query("SELECT clientID FROM project WHERE projectID = %d",$projectID);
-      $row = $db->qr();
-      if ($row["clientID"]) {
-        $extra = prepare("AND clientID = %d",$row["clientID"]);
-      }
+    function save()
+    {
+        $rtn = parent::save();
+        $c = new client();
+        $c->set_id($this->get_value("clientID"));
+        $c->select();
+        $c->save();
+        return $rtn;
     }
-    $extra or $extra = prepare("AND clientContactName = '%s'",$name);
 
-    $q = "SELECT clientContactID, clientContactName FROM clientContact WHERE 1=1 ".$extra;
-    $db->query($q);
-    while ($row = $db->row()) {
-      $people[$db->f("clientContactID")] = $row;
-    }
+    function find_by_name($name = false, $projectID = false, $percent = 90)
+    {
+        $stack1 = array();
+        $people = array();
+        $db = new db_alloc();
+
+        if ($projectID) {
+            $db->query("SELECT clientID FROM project WHERE projectID = %d", $projectID);
+            $row = $db->qr();
+            if ($row["clientID"]) {
+                $extra = prepare("AND clientID = %d", $row["clientID"]);
+            }
+        }
+        $extra or $extra = prepare("AND clientContactName = '%s'", $name);
+
+        $q = "SELECT clientContactID, clientContactName FROM clientContact WHERE 1=1 ".$extra;
+        $db->query($q);
+        while ($row = $db->row()) {
+            $people[$db->f("clientContactID")] = $row;
+        }
   
-    foreach ($people as $personID => $row) {
-      similar_text(strtolower($row["clientContactName"]),strtolower($name),$percent1);
-      $stack1[$personID] = $percent1;
+        foreach ($people as $personID => $row) {
+            similar_text(strtolower($row["clientContactName"]), strtolower($name), $percent1);
+            $stack1[$personID] = $percent1;
+        }
+
+        asort($stack1);
+        end($stack1);
+        $probable1_clientContactID = key($stack1);
+        $person_percent1 = current($stack1);
+
+        if ($probable1_clientContactID && $person_percent1 >= $percent) {
+            return $probable1_clientContactID;
+        }
     }
 
-    asort($stack1);
-    end($stack1);
-    $probable1_clientContactID = key($stack1);
-    $person_percent1 = current($stack1);
+    function find_by_partial_name($name = false, $projectID = false)
+    {
+        $stack1 = array();
+        $people = array();
+        $db = new db_alloc();
 
-    if ($probable1_clientContactID && $person_percent1 >= $percent) {
-      return $probable1_clientContactID;
-    }
-  }
+        if ($projectID) {
+            $db->query("SELECT clientID FROM project WHERE projectID = %d", $projectID);
+            $row = $db->qr();
+            if ($row["clientID"]) {
+                $extra = prepare("AND clientID = %d", $row["clientID"]);
+            }
+        }
 
-  function find_by_partial_name($name=false,$projectID=false) {
-    $stack1 = array();
-    $people = array();
-    $db = new db_alloc();
-
-    if ($projectID) {
-      $db->query("SELECT clientID FROM project WHERE projectID = %d",$projectID);
-      $row = $db->qr();
-      if ($row["clientID"]) {
-        $extra = prepare("AND clientID = %d",$row["clientID"]);
-      }
-    }
-
-    $q = prepare("SELECT clientContactID, clientContactName
+        $q = prepare(
+            "SELECT clientContactID, clientContactName
                     FROM clientContact
                    WHERE 1=1
                      AND clientContactName like '%s%%'"
-                         .$extra
-                ,$name);
-    $db->query($q);
-    while ($row = $db->row()) {
-      $people[$db->f("clientContactID")] = $row;
-    }
+                         .$extra,
+            $name
+        );
+        $db->query($q);
+        while ($row = $db->row()) {
+            $people[$db->f("clientContactID")] = $row;
+        }
   
-    foreach ($people as $personID => $row) {
-      similar_text(strtolower($row["clientContactName"]),strtolower($name),$percent1);
-      $stack1[$personID] = $percent1;
+        foreach ($people as $personID => $row) {
+            similar_text(strtolower($row["clientContactName"]), strtolower($name), $percent1);
+            $stack1[$personID] = $percent1;
+        }
+
+        asort($stack1);
+        end($stack1);
+        $probable1_clientContactID = key($stack1);
+        $person_percent1 = current($stack1);
+
+        if ($probable1_clientContactID) {
+            return $probable1_clientContactID;
+        }
     }
 
-    asort($stack1);
-    end($stack1);
-    $probable1_clientContactID = key($stack1);
-    $person_percent1 = current($stack1);
-
-    if ($probable1_clientContactID) {
-      return $probable1_clientContactID;
-    }
-  }
-
-  function find_by_nick($name=false,$clientID=false) {
-    $q = prepare("SELECT clientContactID
+    function find_by_nick($name = false, $clientID = false)
+    {
+        $q = prepare("SELECT clientContactID
                     FROM clientContact
                    WHERE SUBSTRING(clientContactEmail,1,LOCATE('@',clientContactEmail)-1) = '%s'
                      AND clientID = %d LIMIT 1
-                  ",$name,$clientID);
-    $db = new db_alloc();
-    $db->query($q);
-    $row = $db->row();
-    return $row["clientContactID"];
-  }
+                  ", $name, $clientID);
+        $db = new db_alloc();
+        $db->query($q);
+        $row = $db->row();
+        return $row["clientContactID"];
+    }
 
-  function find_by_email($email=false) {
-    $email = str_replace(array("<",">"),"",$email);
-    if ($email) {
-      $q = prepare("SELECT clientContactID
+    function find_by_email($email = false)
+    {
+        $email = str_replace(array("<",">"), "", $email);
+        if ($email) {
+            $q = prepare("SELECT clientContactID
                       FROM clientContact
                      WHERE replace(replace(clientContactEmail,'<',''),'>','') = '%s'
-                   ",$email);
-      $db = new db_alloc();
-      $db->query($q);
-      $row = $db->row();
-      return $row["clientContactID"];
+                   ", $email);
+            $db = new db_alloc();
+            $db->query($q);
+            $row = $db->row();
+            return $row["clientContactID"];
+        }
     }
-  }
 
-  function delete() {
-    // have to null out any records that point to this clientContact first to satisfy the referential integrity constraints
-    if ($this->get_id()) {
-      $db = new db_alloc();
-      $q = prepare("UPDATE interestedParty SET clientContactID = NULL where clientContactID = %d",$this->get_id());
-      $db->query($q);
-      $q = prepare("UPDATE comment SET commentCreatedUserClientContactID = NULL where commentCreatedUserClientContactID = %d",$this->get_id());
-      $db->query($q);
-      $q = prepare("UPDATE project SET clientContactID = NULL where clientContactID = %d",$this->get_id());
-      $db->query($q);
+    function delete()
+    {
+      // have to null out any records that point to this clientContact first to satisfy the referential integrity constraints
+        if ($this->get_id()) {
+            $db = new db_alloc();
+            $q = prepare("UPDATE interestedParty SET clientContactID = NULL where clientContactID = %d", $this->get_id());
+            $db->query($q);
+            $q = prepare("UPDATE comment SET commentCreatedUserClientContactID = NULL where commentCreatedUserClientContactID = %d", $this->get_id());
+            $db->query($q);
+            $q = prepare("UPDATE project SET clientContactID = NULL where clientContactID = %d", $this->get_id());
+            $db->query($q);
+        }
+        return parent::delete();
     }
-    return parent::delete();
-  }
 
-  function format_contact() {
-    $this->get_value("clientContactName")          and $str.= $this->get_value("clientContactName",DST_HTML_DISPLAY)."<br>";
-    $this->get_value("clientContactStreetAddress") and $str.= $this->get_value("clientContactStreetAddress",DST_HTML_DISPLAY)."<br>";  
-    $this->get_value("clientContactSuburb")        and $str.= $this->get_value("clientContactSuburb",DST_HTML_DISPLAY)."<br>";  
-    $this->get_value("clientContactPostcode")      and $str.= $this->get_value("clientContactPostcode",DST_HTML_DISPLAY)."<br>";  
-    $this->get_value("clientContactPhone")         and $str.= $this->get_value("clientContactPhone",DST_HTML_DISPLAY)."<br>";
-    $this->get_value("clientContactMobile")        and $str.= $this->get_value("clientContactMobile",DST_HTML_DISPLAY)."<br>";
-    $this->get_value("clientContactFax")           and $str.= $this->get_value("clientContactFax",DST_HTML_DISPLAY)."<br>";
-    $this->get_value("clientContactEmail")         and $str.= "<a href='mailto:\"".$this->get_value("clientContactName",DST_HTML_DISPLAY)."\" <".$this->get_value("clientContactEmail",DST_HTML_DISPLAY).">'>".$this->get_value("clientContactEmail",DST_HTML_DISPLAY)."</a><br>";
-    return $str;
-  }
+    function format_contact()
+    {
+        $this->get_value("clientContactName")          and $str.= $this->get_value("clientContactName", DST_HTML_DISPLAY)."<br>";
+        $this->get_value("clientContactStreetAddress") and $str.= $this->get_value("clientContactStreetAddress", DST_HTML_DISPLAY)."<br>";
+        $this->get_value("clientContactSuburb")        and $str.= $this->get_value("clientContactSuburb", DST_HTML_DISPLAY)."<br>";
+        $this->get_value("clientContactPostcode")      and $str.= $this->get_value("clientContactPostcode", DST_HTML_DISPLAY)."<br>";
+        $this->get_value("clientContactPhone")         and $str.= $this->get_value("clientContactPhone", DST_HTML_DISPLAY)."<br>";
+        $this->get_value("clientContactMobile")        and $str.= $this->get_value("clientContactMobile", DST_HTML_DISPLAY)."<br>";
+        $this->get_value("clientContactFax")           and $str.= $this->get_value("clientContactFax", DST_HTML_DISPLAY)."<br>";
+        $this->get_value("clientContactEmail")         and $str.= "<a href='mailto:\"".$this->get_value("clientContactName", DST_HTML_DISPLAY)."\" <".$this->get_value("clientContactEmail", DST_HTML_DISPLAY).">'>".$this->get_value("clientContactEmail", DST_HTML_DISPLAY)."</a><br>";
+        return $str;
+    }
 
-  function output_vcard() {
+    function output_vcard()
+    {
 
-    //array of mappings from DB field to vcard field
-    $fields = array( //clientContactName is special
+      //array of mappings from DB field to vcard field
+        $fields = array( //clientContactName is special
         "clientContactPhone" => "TEL;WORK;VOICE",
         "clientContactMobile" => "TEL;CELL",
         "clientContactFax" => "TEL;TYPE=WORK;FAX",
         "clientContactEmail" => "EMAIL;WORK"
-    ); //address fields are handled specially because they're a composite of DB fields
+        ); //address fields are handled specially because they're a composite of DB fields
 
-    $vcard = array();
+        $vcard = array();
 
-    // This could be templated, but there's not much point
-    // Based off the vcard output by Android 2.1
-    header("Content-type: text/x-vcard");
-    $filename = strtr($this->get_value("clientContactName"), " ", "_") . ".vcf";
-    header('Content-Disposition: attachment; filename="'.$filename.'"');
+      // This could be templated, but there's not much point
+      // Based off the vcard output by Android 2.1
+        header("Content-type: text/x-vcard");
+        $filename = strtr($this->get_value("clientContactName"), " ", "_") . ".vcf";
+        header('Content-Disposition: attachment; filename="'.$filename.'"');
 
-    print("BEGIN:VCARD\nVERSION:2.1\n");
+        print("BEGIN:VCARD\nVERSION:2.1\n");
 
-    if ($this->get_value("clientContactName")) {
-      //vcard stuff requires N to be last name; first name
-      // Assume whatever comes after the last space is the last name
-      // cut the string up to get <last name>;<everything else>
-      $name = explode(" ",$this->get_value("clientContactName"));
-      $lastname = array_slice($name, -1);
-      $lastname = $lastname[0];
+        if ($this->get_value("clientContactName")) {
+            //vcard stuff requires N to be last name; first name
+            // Assume whatever comes after the last space is the last name
+            // cut the string up to get <last name>;<everything else>
+            $name = explode(" ", $this->get_value("clientContactName"));
+            $lastname = array_slice($name, -1);
+            $lastname = $lastname[0];
 
-      $rest = implode(array_slice($name, 0, -1));
-      print "N:" . $lastname . ";" . $rest . "\n";
-      print "FN:" . $this->get_value("clientContactName")."\n";
+            $rest = implode(array_slice($name, 0, -1));
+            print "N:" . $lastname . ";" . $rest . "\n";
+            print "FN:" . $this->get_value("clientContactName")."\n";
+        }
 
-    }
-
-    foreach ($fields as $db => $label) {
-      if ($this->get_value($db))
-        print $label . ":" . $this->get_value($db) . "\n";
-    }
-    if ($this->get_value("clientContactStreetAddress")) {
-        print "ADR;HOME:;;" . $this->get_value("clientContactStreetAddress") . ";" .
+        foreach ($fields as $db => $label) {
+            if ($this->get_value($db)) {
+                print $label . ":" . $this->get_value($db) . "\n";
+            }
+        }
+        if ($this->get_value("clientContactStreetAddress")) {
+            print "ADR;HOME:;;" . $this->get_value("clientContactStreetAddress") . ";" .
             $this->get_value("clientContactSuburb") . ";;" . //county or something
-	    $this->get_value("clientContactPostcode") . ";" . 
-	    $this->get_value("clientContactCountry") . "\n";
-    }
-    print("END:VCARD\n");
-  }
-
-  function have_role($role="") {
-    return in_array($role, array("","client"));
-  }
-
-  function get_list_filter($filter=array()) {
-    $current_user = &singleton("current_user");
-
-    // If they want starred, load up the clientContactID filter element
-    if ($filter["starred"]) {
-      foreach ((array)$current_user->prefs["stars"]["clientContact"] as $k=>$v) {
-        $filter["clientContactID"][] = $k;
-      }
-      is_array($filter["clientContactID"]) or $filter["clientContactID"][] = -1;
+            $this->get_value("clientContactPostcode") . ";" .
+            $this->get_value("clientContactCountry") . "\n";
+        }
+        print("END:VCARD\n");
     }
 
-    // Filter on clientContactID
-    if ($filter["clientContactID"] && is_array($filter["clientContactID"])) {
-      $sql[] = prepare("(clientContact.clientContactID in (%s))",$filter["clientContactID"]);
-    } else if ($filter["clientContactID"]) {     
-      $sql[] = prepare("(clientContact.clientContactID = %d)", $filter["clientContactID"]);
+    function have_role($role = "")
+    {
+        return in_array($role, array("","client"));
     }
 
-    // No point continuing if primary key specified, so return
-    if ($filter["clientContactID"] || $filter["starred"]) {
-      return $sql;
-    }
-  }
+    function get_list_filter($filter = array())
+    {
+        $current_user = &singleton("current_user");
 
-  public static function get_list($_FORM) {
-    global $TPL;
-    $filter = clientContact::get_list_filter($_FORM);
-    if (is_array($filter) && count($filter)) {
-      $filter = " WHERE ".implode(" AND ",$filter);
+      // If they want starred, load up the clientContactID filter element
+        if ($filter["starred"]) {
+            foreach ((array)$current_user->prefs["stars"]["clientContact"] as $k => $v) {
+                $filter["clientContactID"][] = $k;
+            }
+            is_array($filter["clientContactID"]) or $filter["clientContactID"][] = -1;
+        }
+
+      // Filter on clientContactID
+        if ($filter["clientContactID"] && is_array($filter["clientContactID"])) {
+            $sql[] = prepare("(clientContact.clientContactID in (%s))", $filter["clientContactID"]);
+        } else if ($filter["clientContactID"]) {
+            $sql[] = prepare("(clientContact.clientContactID = %d)", $filter["clientContactID"]);
+        }
+
+      // No point continuing if primary key specified, so return
+        if ($filter["clientContactID"] || $filter["starred"]) {
+            return $sql;
+        }
     }
 
-    $q = "SELECT clientContact.*, client.*
+    public static function get_list($_FORM)
+    {
+        global $TPL;
+        $filter = clientContact::get_list_filter($_FORM);
+        if (is_array($filter) && count($filter)) {
+            $filter = " WHERE ".implode(" AND ", $filter);
+        }
+
+        $q = "SELECT clientContact.*, client.*
             FROM clientContact
        LEFT JOIN client ON client.clientID = clientContact.clientID
                  ".$filter." 
         GROUP BY clientContact.clientContactID 
         ORDER BY clientContactName,clientContact.primaryContact asc";
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->next_record()) {
-      $c = new client();
-      $c->read_db_record($db);
-      $row["clientLink"] = $c->get_client_link($_FORM);
-      $row["clientContactEmail"] and $row["clientContactEmail"] = "<a href=\"mailto:".page::htmlentities($row["clientContactName"]." <".$row["clientContactEmail"].">")."\">".page::htmlentities($row["clientContactEmail"])."</a>";
-      $rows[] = $row;
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->next_record()) {
+            $c = new client();
+            $c->read_db_record($db);
+            $row["clientLink"] = $c->get_client_link($_FORM);
+            $row["clientContactEmail"] and $row["clientContactEmail"] = "<a href=\"mailto:".page::htmlentities($row["clientContactName"]." <".$row["clientContactEmail"].">")."\">".page::htmlentities($row["clientContactEmail"])."</a>";
+            $rows[] = $row;
+        }
+        return $rows;
     }
-    return $rows;
-  }
 
-  function get_list_html($rows=array(),$ops=array()) {
-    global $TPL;
-    $TPL["clientContactListRows"] = $rows;
-    $TPL["_FORM"] = $ops;
-    include_template(dirname(__FILE__)."/../templates/clientContactListS.tpl");
-  }
+    function get_list_html($rows = array(), $ops = array())
+    {
+        global $TPL;
+        $TPL["clientContactListRows"] = $rows;
+        $TPL["_FORM"] = $ops;
+        include_template(dirname(__FILE__)."/../templates/clientContactListS.tpl");
+    }
 }
-?>

--- a/client/lib/init.php
+++ b/client/lib/init.php
@@ -3,26 +3,26 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class client_module extends module {
-  var $module = "client";
-  var $db_entities = array("client", "clientContact");
+class client_module extends module
+{
+    var $module = "client";
+    var $db_entities = array("client", "clientContact");
 }
-?>

--- a/client/updateClientDupes.php
+++ b/client/updateClientDupes.php
@@ -3,25 +3,25 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/client');
@@ -31,15 +31,12 @@ $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);
 $hits = $index->find($needle);
 
 foreach ($hits as $hit) {
-  $d = $hit->getDocument();
-  $str.= "<div style='padding-bottom:3px'>";
-  $str.= "<a href=\"".$TPL["url_alloc_client"]."clientID=".$d->getFieldValue('id')."\">".$d->getFieldValue('id')." ".$d->getFieldValue('name')."</a>";
-  $str.= "</div>";
+    $d = $hit->getDocument();
+    $str.= "<div style='padding-bottom:3px'>";
+    $str.= "<a href=\"".$TPL["url_alloc_client"]."clientID=".$d->getFieldValue('id')."\">".$d->getFieldValue('id')." ".$d->getFieldValue('name')."</a>";
+    $str.= "</div>";
 }
 
 if ($str) {
-  echo $str;
+    echo $str;
 }
-
-
-?>

--- a/comment/comment.php
+++ b/comment/comment.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -27,16 +27,21 @@ $current_user = &singleton("current_user");
 
 
 // add a comment
-$commentID = comment::add_comment($_REQUEST["entity"], $_REQUEST["entityID"], $_REQUEST["comment"], 
-                                  $_REQUEST["commentMaster"], $_REQUEST["commentMasterID"]);
+$commentID = comment::add_comment(
+    $_REQUEST["entity"],
+    $_REQUEST["entityID"],
+    $_REQUEST["comment"],
+    $_REQUEST["commentMaster"],
+    $_REQUEST["commentMasterID"]
+);
 
 if (!$commentID) {
-  alloc_error("Could not create comment.",1);
+    alloc_error("Could not create comment.", 1);
 }
 
 // add additional interested parties
 if ($_REQUEST["eo_email"]) {
-  $other_parties[$_REQUEST["eo_email"]] = array("name"       => $_REQUEST["eo_name"]
+    $other_parties[$_REQUEST["eo_email"]] = array("name"       => $_REQUEST["eo_name"]
                                                ,"addIP"      => $_REQUEST["eo_add_interested_party"]
                                                ,"addContact" => $_REQUEST["eo_add_client_contact"]
                                                ,"clientID"   => $_REQUEST["eo_client_id"]);
@@ -50,56 +55,56 @@ $files = array();
 
 // If someone uploads attachments
 if ($_FILES) {
-  $files = rejig_files_array($_FILES);
+    $files = rejig_files_array($_FILES);
 }
 
 // Attach any alloc generated timesheet pdf
 if ($_REQUEST["attach_timeSheet"]) {
-  $files[] = comment::attach_timeSheet($commentID, $_REQUEST["commentMasterID"], $_REQUEST["attach_timeSheet"]);
+    $files[] = comment::attach_timeSheet($commentID, $_REQUEST["commentMasterID"], $_REQUEST["attach_timeSheet"]);
 }
 
 // Attach any alloc generated invoice pdf
 if ($_REQUEST["attach_invoice"]) {
-  $_REQUEST["attach_invoice"] == $_REQUEST["generate_pdf_verbose"] and $verbose = true; // select
-  $_REQUEST["generate_pdf_verbose"] and $verbose = true; // link
-  $files[] = comment::attach_invoice($commentID,$_REQUEST["commentMasterID"],$verbose);
+    $_REQUEST["attach_invoice"] == $_REQUEST["generate_pdf_verbose"] and $verbose = true; // select
+    $_REQUEST["generate_pdf_verbose"] and $verbose = true; // link
+    $files[] = comment::attach_invoice($commentID, $_REQUEST["commentMasterID"], $verbose);
 }
 
 // Attach any alloc generated tasks pdf
 if ($_REQUEST["attach_tasks"]) {
-  $files[] = comment::attach_tasks($commentID,$_REQUEST["commentMasterID"],$_REQUEST["attach_tasks"]);
+    $files[] = comment::attach_tasks($commentID, $_REQUEST["commentMasterID"], $_REQUEST["attach_tasks"]);
 }
 
 // Store the files on the file-system temporarily in this dir
 $dir = ATTACHMENTS_DIR."comment".DIRECTORY_SEPARATOR.$commentID;
 if (!is_dir($dir)) {
-  mkdir($dir, 0777);
+    mkdir($dir, 0777);
 }
 
 // Write out all of the attachments and generated files to the local filesystem
 foreach ((array)$files as $k => $f) {
-  $fullpath = $dir.DIRECTORY_SEPARATOR.$f["name"];
-  if ($f["blob"]) {
-    file_put_contents($fullpath,$f["blob"]);
-  } else if ($f["tmp_name"]) {
-    rename($f["tmp_name"],$fullpath);
-  }
-  $files[$k]["fullpath"] = $fullpath;
+    $fullpath = $dir.DIRECTORY_SEPARATOR.$f["name"];
+    if ($f["blob"]) {
+        file_put_contents($fullpath, $f["blob"]);
+    } else if ($f["tmp_name"]) {
+        rename($f["tmp_name"], $fullpath);
+    }
+    $files[$k]["fullpath"] = $fullpath;
 }
 
 if ($files) {
-  comment::update_mime_parts($commentID, $files);
+    comment::update_mime_parts($commentID, $files);
 }
 
 // Re-email the comment out, including any attachments
-if (!comment::send_comment($commentID,$emailRecipients,false,$files)) {
-  alloc_error("Email failed to send.");
+if (!comment::send_comment($commentID, $emailRecipients, false, $files)) {
+    alloc_error("Email failed to send.");
 }
 
 foreach ((array)$files as $k => $f) {
-  if (file_exists($f["fullpath"])) {
-    unlink($f["fullpath"]);
-  }
+    if (file_exists($f["fullpath"])) {
+        unlink($f["fullpath"]);
+    }
 }
 rmdir_if_empty($dir);
 
@@ -109,6 +114,3 @@ rmdir_if_empty($dir);
 $TPL["message_good"][] = $message_good;
 $extra.= "&sbs_link=comments";
 alloc_redirect($TPL["url_alloc_".$_REQUEST["commentMaster"]].$_REQUEST["commentMaster"]."ID=".$_REQUEST["commentMasterID"].$extra);
-
-
-?>

--- a/comment/commentTemplate.php
+++ b/comment/commentTemplate.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -29,33 +29,30 @@ $commentTemplate = new commentTemplate();
 
 $commentTemplateID = $_POST["commentTemplateID"] or $commentTemplateID = $_GET["commentTemplateID"];
 
-if ($commentTemplateID){
- $commentTemplate->set_id($commentTemplateID);
- $commentTemplate->select();
+if ($commentTemplateID) {
+    $commentTemplate->set_id($commentTemplateID);
+    $commentTemplate->select();
 }
 
 // Process submission of the form using the save button
 if ($_POST["save"]) {
-  $commentTemplate->read_globals();
-  $commentTemplate->save();
-  alloc_redirect($TPL["url_alloc_commentTemplateList"]);
+    $commentTemplate->read_globals();
+    $commentTemplate->save();
+    alloc_redirect($TPL["url_alloc_commentTemplateList"]);
 
 // Process submission of the form using the delete button
 } else if ($_POST["delete"]) {
-  $commentTemplate->delete();
-  alloc_redirect($TPL["url_alloc_commentTemplateList"]);
-  exit();
+    $commentTemplate->delete();
+    alloc_redirect($TPL["url_alloc_commentTemplateList"]);
+    exit();
 }
 // Load data for display in the template
 $commentTemplate->set_values();
 
 $ops = array(""=>"Comment Template Type","task"=>"Task","timeSheet"=>"Time Sheet","project"=>"Project"
             ,"client"=>"Client", "invoice"=>"Invoice","productSale"=>"Sale");
-$TPL["commentTemplateTypeOptions"] = page::select_options($ops,$commentTemplate->get_value("commentTemplateType"));
+$TPL["commentTemplateTypeOptions"] = page::select_options($ops, $commentTemplate->get_value("commentTemplateType"));
 
 $TPL["main_alloc_title"] = "Edit Comment Template - ".APPLICATION_NAME;
 // Invoke the page's main template
 include_template("templates/commentTemplateM.tpl");
-
-?>
-

--- a/comment/commentTemplateList.php
+++ b/comment/commentTemplateList.php
@@ -3,42 +3,41 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function show_commentTemplate($template_name) {
-  global $TPL;
+function show_commentTemplate($template_name)
+{
+    global $TPL;
   
 // Run query and loop through the records
-  $db = new db_alloc();
-  $query = "SELECT * FROM commentTemplate ORDER BY commentTemplateType, commentTemplateName";
-  $db->query($query);
-  while ($db->next_record()) {
-    $commentTemplate = new commentTemplate();
-    $commentTemplate->read_db_record($db);
-    $commentTemplate->set_values();
-    $TPL["odd_even"] = $TPL["odd_even"] == "even" ? "odd" : "even";
-    include_template($template_name);
-  }
+    $db = new db_alloc();
+    $query = "SELECT * FROM commentTemplate ORDER BY commentTemplateType, commentTemplateName";
+    $db->query($query);
+    while ($db->next_record()) {
+        $commentTemplate = new commentTemplate();
+        $commentTemplate->read_db_record($db);
+        $commentTemplate->set_values();
+        $TPL["odd_even"] = $TPL["odd_even"] == "even" ? "odd" : "even";
+        include_template($template_name);
+    }
 }
 
 $TPL["main_alloc_title"] = "Comment Template List - ".APPLICATION_NAME;
 include_template("templates/commentTemplateListM.tpl");
-
-?>

--- a/comment/lib/comment.inc.php
+++ b/comment/lib/comment.inc.php
@@ -3,28 +3,29 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class comment extends db_entity {
-  public $classname = "comment";
-  public $data_table = "comment";
-  public $key_field = "commentID";
-  public $data_fields = array("commentMaster"
+class comment extends db_entity
+{
+    public $classname = "comment";
+    public $data_table = "comment";
+    public $key_field = "commentID";
+    public $data_fields = array("commentMaster"
                              ,"commentMasterID"
                              ,"commentType"
                              ,"commentLinkID"
@@ -41,66 +42,73 @@ class comment extends db_entity {
                              ,"comment"
                              );
 
-  function save() {
-    if ($this->get_value("commentType") == "comment") {
-      $parent_comment = new comment();
-      $parent_comment->set_id($this->get_value("commentLinkID"));
-      $parent_comment->select();
-      $this->set_value("commentMaster",$parent_comment->get_value("commentType"));
-      $this->set_value("commentMasterID",$parent_comment->get_value("commentLinkID"));
-    } else {
-      $this->set_value("commentMaster",$this->get_value("commentType"));
-      $this->set_value("commentMasterID",$this->get_value("commentLinkID"));
-    }
-    $this->set_value("comment",str_replace("\r\n","\n",$this->get_value("comment")));
-    return parent::save();
-  }
-
-  function delete() {
-  
-    if ($this->get_id()) {
-      $dir = ATTACHMENTS_DIR."comment".DIRECTORY_SEPARATOR.$this->get_id();
-      if (is_dir($dir)) {
-        $handle = opendir($dir);
-        clearstatcache();
-        while (false !== ($file = readdir($handle))) {
-          if ($file != "." && $file != ".." && file_exists($dir.DIRECTORY_SEPARATOR.$file)) {
-            unlink($dir.DIRECTORY_SEPARATOR.$file);
-            clearstatcache();
-          }
+    function save()
+    {
+        if ($this->get_value("commentType") == "comment") {
+            $parent_comment = new comment();
+            $parent_comment->set_id($this->get_value("commentLinkID"));
+            $parent_comment->select();
+            $this->set_value("commentMaster", $parent_comment->get_value("commentType"));
+            $this->set_value("commentMasterID", $parent_comment->get_value("commentLinkID"));
+        } else {
+            $this->set_value("commentMaster", $this->get_value("commentType"));
+            $this->set_value("commentMasterID", $this->get_value("commentLinkID"));
         }
-        is_dir($dir) && rmdir($dir);
-      }
+        $this->set_value("comment", str_replace("\r\n", "\n", $this->get_value("comment")));
+        return parent::save();
     }
-    parent::delete();
-  }
 
-  function is_owner() {
-    $current_user = &singleton("current_user");
-    $entity = $this->get_value("commentMaster");
-    $e = new $entity;
-    $e->set_id($this->get_value("commentMasterID"));
-    $e->select();
-    return $e->is_owner($current_user);
-  }
+    function delete()
+    {
+  
+        if ($this->get_id()) {
+            $dir = ATTACHMENTS_DIR."comment".DIRECTORY_SEPARATOR.$this->get_id();
+            if (is_dir($dir)) {
+                $handle = opendir($dir);
+                clearstatcache();
+                while (false !== ($file = readdir($handle))) {
+                    if ($file != "." && $file != ".." && file_exists($dir.DIRECTORY_SEPARATOR.$file)) {
+                        unlink($dir.DIRECTORY_SEPARATOR.$file);
+                        clearstatcache();
+                    }
+                }
+                is_dir($dir) && rmdir($dir);
+            }
+        }
+        parent::delete();
+    }
 
-  function has_attachment_permission($person) {
-    $current_user = &singleton("current_user");
-    $entity = $this->get_value("commentMaster");
-    $e = new $entity;
-    $e->set_id($this->get_value("commentMasterID"));
-    $e->select();
-    return $e->has_attachment_permission($person);
-  }
+    function is_owner()
+    {
+        $current_user = &singleton("current_user");
+        $entity = $this->get_value("commentMaster");
+        $e = new $entity;
+        $e->set_id($this->get_value("commentMasterID"));
+        $e->select();
+        return $e->is_owner($current_user);
+    }
 
-  function has_attachment_permission_delete($person) {
-    return $this->is_owner();
-  }
+    function has_attachment_permission($person)
+    {
+        $current_user = &singleton("current_user");
+        $entity = $this->get_value("commentMaster");
+        $e = new $entity;
+        $e->set_id($this->get_value("commentMasterID"));
+        $e->select();
+        return $e->has_attachment_permission($person);
+    }
 
-  function get_comments($commentMaster="",$commentMasterID="") {
-    $rows = array();
-    if ($commentMaster && $commentMasterID) {
-      $q = prepare("SELECT commentID, 
+    function has_attachment_permission_delete($person)
+    {
+        return $this->is_owner();
+    }
+
+    function get_comments($commentMaster = "", $commentMasterID = "")
+    {
+        $rows = array();
+        if ($commentMaster && $commentMasterID) {
+            $q = prepare(
+                "SELECT commentID, 
                            commentMaster, commentMasterID,
                            commentLinkID, commentType,
                            commentCreatedUser as personID, 
@@ -115,764 +123,782 @@ class comment extends db_entity {
                            commentMimeParts
                       FROM comment 
                      WHERE commentMaster = '%s' AND commentMasterID = %d 
-                  ORDER BY commentCreatedTime"
-                  ,$commentMaster, $commentMasterID);
-      $db = new db_alloc();
-      $db->query($q);
-      while ($row = $db->row()) {
-        if ($row["commentType"] == "comment") {
-          $rows[$row["commentLinkID"]]["children"][] = $row;
-        } else {
-          foreach ($row as $k=>$v) { // need to do it this way so that "children" doesn't get overriden
-            $rows[$row["commentID"]][$k] = $v;
-          }
+                  ORDER BY commentCreatedTime",
+                $commentMaster,
+                $commentMasterID
+            );
+            $db = new db_alloc();
+            $db->query($q);
+            while ($row = $db->row()) {
+                if ($row["commentType"] == "comment") {
+                    $rows[$row["commentLinkID"]]["children"][] = $row;
+                } else {
+                    foreach ($row as $k => $v) { // need to do it this way so that "children" doesn't get overriden
+                        $rows[$row["commentID"]][$k] = $v;
+                    }
+                }
+            }
         }
-      }
+      # commentID    commmentMaster   commmentMasterID  commentType   commentLinkID
+      # 1            task             10                task          10
+      # 2            task             10                comment       1
+      # 3            task             10                comment       1
+        return $rows;
     }
-    # commentID    commmentMaster   commmentMasterID  commentType   commentLinkID
-    # 1            task             10                task          10
-    # 2            task             10                comment       1
-    # 3            task             10                comment       1
-    return $rows;
-  }
 
-  function get_one_comment_array($v=array(),$all_parties=array()) {
-    global $TPL;
-    $current_user = &singleton("current_user");
-    $new = $v;
-    $token = new token();
-    if ($token->select_token_by_entity_and_action("comment",$new["commentID"],"add_comment_from_email")) {
-      if ($token->get_value("tokenHash")) {
-        $new["hash"] = $token->get_value("tokenHash");
-        $new["hashKey"] = "{Key:".$new["hash"]."}";
-        $new["hashHTML"] = " <em class=\"faint\">".$new["hashKey"]."</em>";
-      }
+    function get_one_comment_array($v = array(), $all_parties = array())
+    {
+        global $TPL;
+        $current_user = &singleton("current_user");
+        $new = $v;
+        $token = new token();
+        if ($token->select_token_by_entity_and_action("comment", $new["commentID"], "add_comment_from_email")) {
+            if ($token->get_value("tokenHash")) {
+                $new["hash"] = $token->get_value("tokenHash");
+                $new["hashKey"] = "{Key:".$new["hash"]."}";
+                $new["hashHTML"] = " <em class=\"faint\">".$new["hashKey"]."</em>";
+            }
 
-      $ip = interestedParty::get_interested_parties("comment",$new["commentID"]);
-      foreach((array)$ip as $email => $info) {
-        $all_parties += $ip;
-        if ($info["selected"]) {
-          $sel[] = $email;
-        }
-      }
-      foreach ($all_parties as $email=>$i) {
-        in_array($email,(array)$sel) and $recipient_selected[] = $i["identifier"];
-      }
+            $ip = interestedParty::get_interested_parties("comment", $new["commentID"]);
+            foreach ((array)$ip as $email => $info) {
+                $all_parties += $ip;
+                if ($info["selected"]) {
+                    $sel[] = $email;
+                }
+            }
+            foreach ($all_parties as $email => $i) {
+                in_array($email, (array)$sel) and $recipient_selected[] = $i["identifier"];
+            }
 
-      if (interestedParty::is_external("comment",$new["commentID"])) {
-        $new["external"] = " loud";
-        $label = "<em class='faint warn'>[ External Conversation ]</em>";
-      } else {
-        $label = "<em class='faint'>[ Internal Conversation ]</em>";
-      }
+            if (interestedParty::is_external("comment", $new["commentID"])) {
+                $new["external"] = " loud";
+                $label = "<em class='faint warn'>[ External Conversation ]</em>";
+            } else {
+                $label = "<em class='faint'>[ Internal Conversation ]</em>";
+            }
 
-      foreach((array)$all_parties as $email => $info) {
-        $recipient_ops[$info["identifier"]] = $info["name"]. " <".$email.">";
-      }
+            foreach ((array)$all_parties as $email => $info) {
+                $recipient_ops[$info["identifier"]] = $info["name"]. " <".$email.">";
+            }
   
-      $new["recipient_editor"] = "<span class='nobr' style='width:100%;display:inline;' class='recipient_editor'>";
+            $new["recipient_editor"] = "<span class='nobr' style='width:100%;display:inline;' class='recipient_editor'>";
 
-      $new["recipient_editor"].= "<span class='noprint hidden' id='recipient_dropdown_".$new["commentID"]."'>
+            $new["recipient_editor"].= "<span class='noprint hidden' id='recipient_dropdown_".$new["commentID"]."'>
                                     <form action='".$TPL["url_alloc_updateRecipients"]."' method='post'>
                                       <select name='comment_recipients[]' multiple='true' data-callback='save_recipients'>
-                                      ".page::select_options($recipient_ops,$recipient_selected)."
+                                      ".page::select_options($recipient_ops, $recipient_selected)."
                                       </select>
                                       <input type='hidden' name='commentID' value='".$new["commentID"]."'>
                                       <input type='submit' value='Go' style='display:none'>
                                     </form>
                                   </span>";
 
-      $new["recipient_editor"].= "<a class='magic recipient_editor_link' id='r_e_".$new["commentID"]."' style='text-decoration:none' href='#x'>".$label."</a>";
+            $new["recipient_editor"].= "<a class='magic recipient_editor_link' id='r_e_".$new["commentID"]."' style='text-decoration:none' href='#x'>".$label."</a>";
 
-      $new["recipient_editor"].= "</span>";
+            $new["recipient_editor"].= "</span>";
 
-      $new["reply"] = '<a href="" class="noprint commentreply">reply</a>';
-    }
+            $new["reply"] = '<a href="" class="noprint commentreply">reply</a>';
+        }
 
-    if ($v["timeSheetID"]) {
-      $timeSheet = new timeSheet();
-      $timeSheet->set_id($v["timeSheetID"]);
-      $v["ts_label"] = " (Time Sheet #".$timeSheet->get_id().")";
-    }
+        if ($v["timeSheetID"]) {
+            $timeSheet = new timeSheet();
+            $timeSheet->set_id($v["timeSheetID"]);
+            $v["ts_label"] = " (Time Sheet #".$timeSheet->get_id().")";
+        }
 
-    $new["attribution"] = comment::get_comment_attribution($v);
-    $new["commentCreatedUserEmail"] = comment::get_comment_author_email($v);
-    $s = commentTemplate::populate_string(config::get_config_item("emailSubject_taskComment"), $entity, $id);
-    $new["commentEmailSubject"] = $s." ".$new["hashKey"];
+        $new["attribution"] = comment::get_comment_attribution($v);
+        $new["commentCreatedUserEmail"] = comment::get_comment_author_email($v);
+        $s = commentTemplate::populate_string(config::get_config_item("emailSubject_taskComment"), $entity, $id);
+        $new["commentEmailSubject"] = $s." ".$new["hashKey"];
 
-    if (!$_GET["commentID"] || $_GET["commentID"] != $v["commentID"]) {
-
-      if ($options["showEditButtons"] && $new["comment_buttons"]) {
-        $new["form"] = '<form action="'.$TPL["url_alloc_comment"].'" method="post">';
-        $new["form"].= '<input type="hidden" name="entity" value="'.$v["commentType"].'">';
-        $new["form"].= '<input type="hidden" name="entityID" value="'.$v["commentLinkID"].'">';
-        $new["form"].= '<input type="hidden" name="commentID" value="'.$v["commentID"].'">';
-        $new["form"].= '<input type="hidden" name="comment_id" value="'.$v["commentID"].'">';
-        $new["form"].= $new["comment_buttons"];
-        $new["form"].= '<input type="hidden" name="sessID" value="'.$TPL["sessID"].'">';
-        $new["form"].= '</form>';
-      }
+        if (!$_GET["commentID"] || $_GET["commentID"] != $v["commentID"]) {
+            if ($options["showEditButtons"] && $new["comment_buttons"]) {
+                $new["form"] = '<form action="'.$TPL["url_alloc_comment"].'" method="post">';
+                $new["form"].= '<input type="hidden" name="entity" value="'.$v["commentType"].'">';
+                $new["form"].= '<input type="hidden" name="entityID" value="'.$v["commentLinkID"].'">';
+                $new["form"].= '<input type="hidden" name="commentID" value="'.$v["commentID"].'">';
+                $new["form"].= '<input type="hidden" name="comment_id" value="'.$v["commentID"].'">';
+                $new["form"].= $new["comment_buttons"];
+                $new["form"].= '<input type="hidden" name="sessID" value="'.$TPL["sessID"].'">';
+                $new["form"].= '</form>';
+            }
   
-      $v["commentMimeParts"] and $files = unserialize($v["commentMimeParts"]);
-      if (is_array($files)) {
-        foreach($files as $file) {
-          $new["files"].= '<div align="center" style="float:left; display:inline; margin-right:14px;">';
-          $new["files"].= "<a href=\"".$TPL["url_alloc_getMimePart"]."part=".$file["part"]."&entity=comment&id=".$v["commentID"]."\">";
-          $new["files"].= get_file_type_image($file["name"])."<br>".page::htmlentities($file["name"]);
-          $new["files"].= " (".get_size_label($file["size"]).")</a>";
-          $new["files"].= '</div>';
+            $v["commentMimeParts"] and $files = unserialize($v["commentMimeParts"]);
+            if (is_array($files)) {
+                foreach ($files as $file) {
+                    $new["files"].= '<div align="center" style="float:left; display:inline; margin-right:14px;">';
+                    $new["files"].= "<a href=\"".$TPL["url_alloc_getMimePart"]."part=".$file["part"]."&entity=comment&id=".$v["commentID"]."\">";
+                    $new["files"].= get_file_type_image($file["name"])."<br>".page::htmlentities($file["name"]);
+                    $new["files"].= " (".get_size_label($file["size"]).")</a>";
+                    $new["files"].= '</div>';
+                }
+            }
+
+            $v["commentEmailRecipients"] and $new["emailed"] = 'Emailed to '.page::htmlentities($v["commentEmailRecipients"]);
         }
-      }
-
-      $v["commentEmailRecipients"] and $new["emailed"] = 'Emailed to '.page::htmlentities($v["commentEmailRecipients"]);
-    }
-    return (array)$new;
-  }
-
-  function util_get_comments_array($entity, $id, $options=array()) {
-    global $TPL;
-    $current_user = &singleton("current_user");
-    $rows = array();
-    $new_rows = array();
-    // Need to get timeSheet comments too for task comments
-    if ($entity == "task") {
-      $rows = comment::get_comments($entity,$id);
-      has("time") and $rows2 = timeSheetItem::get_timeSheetItemComments($id);
-      $rows or $rows = array();
-      $rows2 or $rows2 = array();
-      $rows = array_merge($rows,$rows2);
-      if (is_array($rows)) {
-        usort($rows, array("comment","sort_task_comments_callback_func"));
-      }
-    } else {
-      $rows = comment::get_comments($entity,$id);
+        return (array)$new;
     }
 
-    $e = new $entity;
-    $e->set_id($id);
-    $e->select();
-    $all_parties = $e->get_all_parties();
-      
-    foreach ((array)$rows as $v) {
-      unset($children);
-      foreach ((array)$v["children"] as $c) {
-        $children[] = comment::get_one_comment_array($c,$all_parties);
-      }
-      $children and $v["children"] = $children;
-      $new_rows[] = comment::get_one_comment_array($v,$all_parties);
-    }
-    return (array)$new_rows;
-  }
-
-  function util_get_comments($entity, $id, $options=array()) {
-    global $TPL;
-    $current_user = &singleton("current_user");
-    $rows = comment::util_get_comments_array($entity, $id, $options);
-    foreach ((array)$rows as $row) {
-      $rtn.= comment::get_comment_html_table($row);
-    }
-    return $rtn;
-  }
-
-  function get_comment_html_table($row=array()) {
-    global $TPL;
-    $comment = comment::add_shrinky_divs(page::htmlentities($row["comment"]),$row["commentID"]);
-    $onClick = "return set_grow_shrink('comment_".$row["commentID"]."','button_comment_".$row["commentID"]."','true');";
-    $rtn[] = '<div class="panel'.$row["external"].' corner pcomment" data-comment-id="'.$row["commentID"].'">';
-    $rtn[] = '<table width="100%" cellspacing="0" border="0">';
-    $rtn[] = '<tr>';
-    $rtn[] = '  <td style="padding-bottom:0px; white-space:normal" onClick="'.$onClick.'">'.$row["attribution"].$row["hashHTML"].'</td>';
-    $rtn[] = '  <td align="right" style="padding-bottom:0px;" class="nobr">'.$row["form"].$row["recipient_editor"].'</td>';
-    if ($row["commentID"]) {
-      $rtn[] = '  <td align="right" width="1%">'.page::star("comment",$row["commentID"]).'</td>';
-    } else if ($row["timeSheetItemID"]){
-      $rtn[] = '  <td align="right" width="1%">'.page::star("timeSheetItem",$row["timeSheetItemID"]).'</td>';
-    }
-    $rtn[] = '</tr>';
-    $rtn[] = '<tr>';
-    $rtn[] = '  <td colspan="3" style="padding-top:0px; white-space:normal;">'.preg_replace("/<[^>]>/","",$row["emailed"])."</td>";
-    $rtn[] = '</tr>';
-    $rtn[] = '<tr>';
-    $rtn[] = '  <td colspan="3" onClick="'.$onClick.'"><div><pre class="comment">'.$comment.'</pre></div></td>';
-    $rtn[] = '</tr>';
-    $row["children"] and $rtn[] = comment::get_comment_children($row["children"]);
-    if ($row["files"] || $row["reply"]) {
-      $rtn[] = '<tr>';
-      $row["files"] and $rtn[] = '  <td valign="bottom" align="left">'.$row["files"].'</td>';
-      $cs = 2;
-      $row["files"] or $cs = 3;
-      $row["reply"] and $rtn[] = '  <td valign="bottom" align="right" colspan="'.$cs.'">'.$row["reply"].'</td>';
-      $rtn[] = '</tr>';
-    }
-    $rtn[] = '</table>';
-    $rtn[] = '</div>';
-    return implode("\n",$rtn);
-  }
-
-  function get_comment_attribution($comment=array()) {
-    $d = $comment["date"];
-    strlen($comment["date"]) > 10 and $d = format_date("Y-m-d g:ia",$comment["date"]);
-    $str = '<b>'.comment::get_comment_author($comment).'</b> <span class="comment_date">'.$d."</span>";
-      if ($comment["commentModifiedTime"] || $comment["commentModifiedUser"]) {
-        $str.= ", last modified by <b>".person::get_fullname($comment["commentModifiedUser"])."</b> ".format_date("Y-m-d g:ia",$comment["commentModifiedTime"]);
-      }
-      $str.= $comment["ts_label"];
-    return $str;
-  }
-
-  function add_shrinky_divs($html="", $commentID) {
-    if ($_GET["media"] == "print") return $html;
-    $class = "comment_".$commentID;
-    $lines = explode("\n","\n".$html."\n");
-    foreach ($lines as $k => $line) {
-      if (!$started && preg_match("/^&gt;/",$line)) {
-        $started = true;
-        $start_position = $k;
-        $new_lines[$k] = $line;
-
-      } else if ($started && !preg_match("/^&gt;/",$line)){
-    
-        $num_lines_hidden = $k-$start_position;
-
-        if ($num_lines_hidden > 3) {
-          $new_lines[$start_position-1].= "<div class=\"hidden_text button_".$class."\"> --- ".$num_lines_hidden." lines hidden --- </div>";
-          $new_lines[$start_position-1].= "<div style=\"display:none;\" class=\"hidden_text ".$class."\">";
-          $new_lines[$k] = "</div>".$line;
-    
+    function util_get_comments_array($entity, $id, $options = array())
+    {
+        global $TPL;
+        $current_user = &singleton("current_user");
+        $rows = array();
+        $new_rows = array();
+      // Need to get timeSheet comments too for task comments
+        if ($entity == "task") {
+            $rows = comment::get_comments($entity, $id);
+            has("time") and $rows2 = timeSheetItem::get_timeSheetItemComments($id);
+            $rows or $rows = array();
+            $rows2 or $rows2 = array();
+            $rows = array_merge($rows, $rows2);
+            if (is_array($rows)) {
+                usort($rows, array("comment","sort_task_comments_callback_func"));
+            }
         } else {
-          $new_lines[$start_position-1].= "<div style=\"display:inline;\" class=\"hidden_text\">";
-          $new_lines[$k] = "</div>".$line;
+            $rows = comment::get_comments($entity, $id);
         }
 
-        $started = false;
-
-      } else {
-        $new_lines[$k] = $line;
-      }
+        $e = new $entity;
+        $e->set_id($id);
+        $e->select();
+        $all_parties = $e->get_all_parties();
+      
+        foreach ((array)$rows as $v) {
+            unset($children);
+            foreach ((array)$v["children"] as $c) {
+                $children[] = comment::get_one_comment_array($c, $all_parties);
+            }
+            $children and $v["children"] = $children;
+            $new_rows[] = comment::get_one_comment_array($v, $all_parties);
+        }
+        return (array)$new_rows;
     }
 
-    // Hide signature too
-    foreach ($new_lines as $k => $line) {
-      if (!$sig_started && preg_match("/^--(\s|\n|\r|<br>|<br \/>)*$/",$line)) {
-        $sig_started = true;
-        $sig_start_position = $k;
-      } 
-      $new_lines2[$k] = $line;
+    function util_get_comments($entity, $id, $options = array())
+    {
+        global $TPL;
+        $current_user = &singleton("current_user");
+        $rows = comment::util_get_comments_array($entity, $id, $options);
+        foreach ((array)$rows as $row) {
+            $rtn.= comment::get_comment_html_table($row);
+        }
+        return $rtn;
     }
 
-    $sig_num_lines_hidden = count($new_lines2)-1-$sig_start_position;
+    function get_comment_html_table($row = array())
+    {
+        global $TPL;
+        $comment = comment::add_shrinky_divs(page::htmlentities($row["comment"]), $row["commentID"]);
+        $onClick = "return set_grow_shrink('comment_".$row["commentID"]."','button_comment_".$row["commentID"]."','true');";
+        $rtn[] = '<div class="panel'.$row["external"].' corner pcomment" data-comment-id="'.$row["commentID"].'">';
+        $rtn[] = '<table width="100%" cellspacing="0" border="0">';
+        $rtn[] = '<tr>';
+        $rtn[] = '  <td style="padding-bottom:0px; white-space:normal" onClick="'.$onClick.'">'.$row["attribution"].$row["hashHTML"].'</td>';
+        $rtn[] = '  <td align="right" style="padding-bottom:0px;" class="nobr">'.$row["form"].$row["recipient_editor"].'</td>';
+        if ($row["commentID"]) {
+            $rtn[] = '  <td align="right" width="1%">'.page::star("comment", $row["commentID"]).'</td>';
+        } else if ($row["timeSheetItemID"]) {
+            $rtn[] = '  <td align="right" width="1%">'.page::star("timeSheetItem", $row["timeSheetItemID"]).'</td>';
+        }
+        $rtn[] = '</tr>';
+        $rtn[] = '<tr>';
+        $rtn[] = '  <td colspan="3" style="padding-top:0px; white-space:normal;">'.preg_replace("/<[^>]>/", "", $row["emailed"])."</td>";
+        $rtn[] = '</tr>';
+        $rtn[] = '<tr>';
+        $rtn[] = '  <td colspan="3" onClick="'.$onClick.'"><div><pre class="comment">'.$comment.'</pre></div></td>';
+        $rtn[] = '</tr>';
+        $row["children"] and $rtn[] = comment::get_comment_children($row["children"]);
+        if ($row["files"] || $row["reply"]) {
+            $rtn[] = '<tr>';
+            $row["files"] and $rtn[] = '  <td valign="bottom" align="left">'.$row["files"].'</td>';
+            $cs = 2;
+            $row["files"] or $cs = 3;
+            $row["reply"] and $rtn[] = '  <td valign="bottom" align="right" colspan="'.$cs.'">'.$row["reply"].'</td>';
+            $rtn[] = '</tr>';
+        }
+        $rtn[] = '</table>';
+        $rtn[] = '</div>';
+        return implode("\n", $rtn);
+    }
+
+    function get_comment_attribution($comment = array())
+    {
+        $d = $comment["date"];
+        strlen($comment["date"]) > 10 and $d = format_date("Y-m-d g:ia", $comment["date"]);
+        $str = '<b>'.comment::get_comment_author($comment).'</b> <span class="comment_date">'.$d."</span>";
+        if ($comment["commentModifiedTime"] || $comment["commentModifiedUser"]) {
+            $str.= ", last modified by <b>".person::get_fullname($comment["commentModifiedUser"])."</b> ".format_date("Y-m-d g:ia", $comment["commentModifiedTime"]);
+        }
+        $str.= $comment["ts_label"];
+        return $str;
+    }
+
+    function add_shrinky_divs($html = "", $commentID)
+    {
+        if ($_GET["media"] == "print") {
+            return $html;
+        }
+        $class = "comment_".$commentID;
+        $lines = explode("\n", "\n".$html."\n");
+        foreach ($lines as $k => $line) {
+            if (!$started && preg_match("/^&gt;/", $line)) {
+                $started = true;
+                $start_position = $k;
+                $new_lines[$k] = $line;
+            } else if ($started && !preg_match("/^&gt;/", $line)) {
+                $num_lines_hidden = $k-$start_position;
+
+                if ($num_lines_hidden > 3) {
+                    $new_lines[$start_position-1].= "<div class=\"hidden_text button_".$class."\"> --- ".$num_lines_hidden." lines hidden --- </div>";
+                    $new_lines[$start_position-1].= "<div style=\"display:none;\" class=\"hidden_text ".$class."\">";
+                    $new_lines[$k] = "</div>".$line;
+                } else {
+                    $new_lines[$start_position-1].= "<div style=\"display:inline;\" class=\"hidden_text\">";
+                    $new_lines[$k] = "</div>".$line;
+                }
+
+                $started = false;
+            } else {
+                $new_lines[$k] = $line;
+            }
+        }
+
+      // Hide signature too
+        foreach ($new_lines as $k => $line) {
+            if (!$sig_started && preg_match("/^--(\s|\n|\r|<br>|<br \/>)*$/", $line)) {
+                $sig_started = true;
+                $sig_start_position = $k;
+            }
+            $new_lines2[$k] = $line;
+        }
+
+        $sig_num_lines_hidden = count($new_lines2)-1-$sig_start_position;
   
-    if ($sig_started && $sig_num_lines_hidden > 1){
-      $new_lines2[$sig_start_position-1].= "<div style=\"display:inline;\" class=\"hidden_text button_".$class."\"> --- ".$sig_num_lines_hidden." lines hidden (signature) --- <br></div>";
-      $new_lines2[$sig_start_position-1].= "<div style=\"display:none;\" class=\"hidden_text ".$class."\">"; 
-      $new_lines2[count($new_lines2)].= "</div>";
-    } else if ($sig_started) {
-    }
-
-    return ltrim(rtrim(implode("\n",$new_lines2)));
-  }
-
-  function get_comment_children($children=array(), $padding=1) {
-    $rtn = array();
-    foreach($children as $child) {
-      // style=\"padding:0px; padding-left:".($padding*15+5)."px; padding-right:6px;\"
-      $rtn[] = "<tr><td colspan=\"3\" style=\"padding:0px; padding-left:6px; padding-right:6px;\">".comment::get_comment_html_table($child)."</td></tr>";
-      if (is_array($child["children"]) && count($child["children"])) {
-        $padding += 1;
-        $rtn[] = comment::get_comment_children($child["children"],$padding);
-        $padding -= 1;
-      } 
-    } 
-    return implode("\n",$rtn);
-  }
-
-  function get_comment_author($comment=array()) {
-    if ($comment["commentCreatedUserText"]) {
-      $author = page::htmlentities($comment["commentCreatedUserText"]);
-    } else if ($comment["clientContactID"]) {
-      $cc = new clientContact();
-      $cc->set_id($comment["clientContactID"]);
-      $cc->select();
-      #$author = " <a href=\"".$TPL["url_alloc_client"]."clientID=".$cc->get_value("clientID")."\">".$cc->get_value("clientContactName")."</a>";
-      $author = $cc->get_value("clientContactName");
-    } else if ($comment["personID"]) {
-      $author = person::get_fullname($comment["personID"]);
-    }
-    return $author;
-  }
-
-  function get_comment_author_email($comment=array()) {
-    if ($comment["commentCreatedUser"]) {
-      $personID = $comment["commentCreatedUser"];
-      $p = new person();
-      $p->set_id($personID);
-      $p->select();
-      $email = $p->get_from();
-    } else if ($comment["clientContactID"]) {
-      $cc = new clientContact();
-      $cc->set_id($comment["clientContactID"]);
-      $cc->select();
-      $email = $cc->get_value("clientContactEmail");
-    } else {
-      $p= new person();
-      $p->set_id($comment["personID"]);
-      $p->select();
-      $email = $p->get_from();
-    }
-    return $email;
-  }
-
-  function sort_task_comments_callback_func($a, $b) {
-    return strtotime($a["date"]) > strtotime($b["date"]);
-  }
-
-  function make_token_add_comment_from_email() {
-    $current_user = &singleton("current_user");
-    if (!is_object($current_user) || !$current_user->get_id()) {
-      alloc_error("Cannot make token, current_user is not set.",true);
-    }
-    $token = new token();
-    $token->set_value("tokenEntity","comment");
-    $token->set_value("tokenEntityID",$this->get_id());
-    $token->set_value("tokenActionID",2);
-    $token->set_value("tokenActive",1);
-    $token->set_value("tokenCreatedBy",$current_user->get_id());
-    $token->set_value("tokenCreatedDate",date("Y-m-d H:i:s"));
-    $hash = $token->generate_hash();
-    $token->set_value("tokenHash",$hash);
-    $token->save();
-    return $hash;
-  }
-
-  function add_comment_from_email($email_receive,$entity) {
-    $current_user = &singleton("current_user");
-
-    $commentID = comment::add_comment($entity->classname,$entity->get_id(),$email_receive->get_converted_encoding());
-    $commentID or alloc_error("Unable to create an alloc comment (".$entity->classname.":".$entity->get_id().") from email.");
-
-    $comment = new comment();
-    $comment->set_id($commentID);
-    $comment->select();
-    $comment->set_value("commentEmailUID",$email_receive->msg_uid);
-    $comment->set_value("commentEmailMessageID",$email_receive->mail_headers["message-id"]);
-
-    $comment->rename_email_attachment_dir($email_receive->dir);
-
-    // Try figure out and populate the commentCreatedUser/commentCreatedUserClientContactID fields
-    list($from_address,$from_name) = parse_email_address($email_receive->mail_headers["from"]);
-    list($personID,$clientContactID,$from_name) = comment::get_person_and_client($from_address,$from_name,$entity->get_project_id());
-    $personID and $comment->set_value('commentCreatedUser', $personID);
-    $clientContactID and $comment->set_value('commentCreatedUserClientContactID', $clientContactID);
-
-    $comment->set_value("commentCreatedUserText",$email_receive->mail_headers["from"]);
-    $comment->set_value("commentEmailMessageID",$email_receive->mail_headers["message-id"]);
-    $comment->updateSearchIndexLater = true;
-    $comment->skip_modified_fields = true;
-    $comment->save();
-
-    if ($email_receive->mimebits) {
-      comment::update_mime_parts($comment->get_id(),$email_receive->mimebits);
-    }
-
-    // CYBER-ONLY: Re-open task, if comment has been made by an external party.
-    if (config::for_cyber() && !$comment->get_value('commentCreatedUser')) {
-      $e = $entity->get_parent_object();
-      if ($e->classname == "task" && substr($e->get_value("taskStatus"),0,4) != "open") {
-        $tmp = $current_user;
-        $current_user = new person();
-        $personID = $e->get_value("managerID") or $personID = $e->get_value("personID") or $personID = $e->get_value("creatorID");
-        $current_user->load_current_user($personID); // fake identity
-        singleton("current_user",$current_user);
-        $e->set_value("taskStatus","open_inprogress");
-        $e->save();
-        $current_user = $tmp;
-      }
-    }
-
-    return $comment;
-  }
-
-  function get_email_recipients($options=array(),$entity,$entityID) {
-    $recipients = array();
-    $people =& get_cached_table("person");
-
-    foreach ($options as $selected_option) {
-
-      // Determine recipients 
-      if ($selected_option == "interested") {
-        $db = new db_alloc();
-        if ($entity && $entityID) {
-          $q = prepare("SELECT * FROM interestedParty WHERE entity = '%s' AND entityID = %d AND interestedPartyActive = 1",$entity,$entityID);
-        }
-        $db->query($q);
-        while($row = $db->next_record()) {
-          $row["isCC"] = true;
-          $row["name"] = $row["fullName"];
-          $recipients[] = $row;
-        }
-      } else if (is_int($selected_option)){
-        $recipients[] = $people[$selected_option];
-
-      } else if (is_string($selected_option) && preg_match("/@/",$selected_option)) {
-        list($email, $name) = parse_email_address($selected_option);
-        $email and $recipients[] = array("name"=>$name,"emailAddress"=>$email);
-      }
-    }
-    return $recipients;
-  }
-
-  function get_email_recipient_headers($recipients, $from_address) {
-    $current_user = &singleton("current_user");
-
-    $emailMethod = config::get_config_item("allocEmailAddressMethod");
-
-    // Build up To: and Bcc: headers
-    foreach ($recipients as $recipient) {
-      unset($recipient_full_name);
-
-      if ($recipient["firstName"] && $recipient["surname"]) {
-        $recipient_full_name = $recipient["firstName"]." ".$recipient["surname"];
-      } else if ($recipient["fullName"]) {
-        $recipient_full_name = $recipient["fullName"];
-      } else if ($recipient["name"]) {
-        $recipient_full_name = $recipient["name"];
-      }
-
-      if ($recipient["emailAddress"] && !$done[$recipient["emailAddress"]]) {
-
-        // If the person does *not* want to receive their own emails, skip adding them as a recipient
-        if (is_object($current_user) && $current_user->get_id() && !$current_user->prefs["receiveOwnTaskComments"] && same_email_address($recipient["emailAddress"],$from_address)) {
-          continue;
-        } else if ((!is_object($current_user) || !$current_user->get_id()) && same_email_address($recipient["emailAddress"],$from_address)) {
-          continue;
+        if ($sig_started && $sig_num_lines_hidden > 1) {
+            $new_lines2[$sig_start_position-1].= "<div style=\"display:inline;\" class=\"hidden_text button_".$class."\"> --- ".$sig_num_lines_hidden." lines hidden (signature) --- <br></div>";
+            $new_lines2[$sig_start_position-1].= "<div style=\"display:none;\" class=\"hidden_text ".$class."\">";
+            $new_lines2[count($new_lines2)].= "</div>";
+        } else if ($sig_started) {
         }
 
-        $done[$recipient["emailAddress"]] = true;
+        return ltrim(rtrim(implode("\n", $new_lines2)));
+    }
 
-        $name = $recipient_full_name or $name = $recipient["emailAddress"];
-        $email_without_name = $recipient["emailAddress"];
-        if ($recipient_full_name) {
-          $name_and_email = $recipient_full_name." <".$recipient["emailAddress"].">";
+    function get_comment_children($children = array(), $padding = 1)
+    {
+        $rtn = array();
+        foreach ($children as $child) {
+          // style=\"padding:0px; padding-left:".($padding*15+5)."px; padding-right:6px;\"
+            $rtn[] = "<tr><td colspan=\"3\" style=\"padding:0px; padding-left:6px; padding-right:6px;\">".comment::get_comment_html_table($child)."</td></tr>";
+            if (is_array($child["children"]) && count($child["children"])) {
+                $padding += 1;
+                $rtn[] = comment::get_comment_children($child["children"], $padding);
+                $padding -= 1;
+            }
+        }
+        return implode("\n", $rtn);
+    }
+
+    function get_comment_author($comment = array())
+    {
+        if ($comment["commentCreatedUserText"]) {
+            $author = page::htmlentities($comment["commentCreatedUserText"]);
+        } else if ($comment["clientContactID"]) {
+            $cc = new clientContact();
+            $cc->set_id($comment["clientContactID"]);
+            $cc->select();
+          #$author = " <a href=\"".$TPL["url_alloc_client"]."clientID=".$cc->get_value("clientID")."\">".$cc->get_value("clientContactName")."</a>";
+            $author = $cc->get_value("clientContactName");
+        } else if ($comment["personID"]) {
+            $author = person::get_fullname($comment["personID"]);
+        }
+        return $author;
+    }
+
+    function get_comment_author_email($comment = array())
+    {
+        if ($comment["commentCreatedUser"]) {
+            $personID = $comment["commentCreatedUser"];
+            $p = new person();
+            $p->set_id($personID);
+            $p->select();
+            $email = $p->get_from();
+        } else if ($comment["clientContactID"]) {
+            $cc = new clientContact();
+            $cc->set_id($comment["clientContactID"]);
+            $cc->select();
+            $email = $cc->get_value("clientContactEmail");
         } else {
-          $name_and_email = $recipient["emailAddress"];
+            $p= new person();
+            $p->set_id($comment["personID"]);
+            $p->select();
+            $email = $p->get_from();
         }
-
-        if ($emailMethod == "to") {
-          $to_address[] = $name_and_email;
-          $successful_recipients[] = $name_and_email;
-
-        } else if ($emailMethod == "bcc") {
-          $bcc[] = $email_without_name;
-          $successful_recipients[] = $name_and_email;
-
-        // The To address contains no actual email addresses, ie "Alex Lance": ; all the real recipients are in the Bcc.
-        } else if ($emailMethod == "tobcc") {
-          if (!same_email_address(ALLOC_DEFAULT_FROM_ADDRESS,$email_without_name)) {
-            $to_address[] = '"'.$name.'": ;';
-            $successful_recipients[] = $name_and_email;
-          }
-          $bcc[] = $email_without_name;
-        }
-
-      }
-    }
-    return array(implode(", ",(array)$to_address), implode(", ",(array)$bcc), implode(", ",(array)$successful_recipients));
-  }
-
-  function send_emails($selected_option, $email_receive=false, $hash="", $is_a_reply_comment=false, $files=array()) {
-    $current_user = &singleton("current_user");
-
-    $e = $this->get_parent_object();
-    $type = $e->classname."_comments";
-    $body = $this->get_value("comment");
-
-    if (is_object($email_receive)) {
-      list($from_address,$from_name) = parse_email_address($email_receive->mail_headers["from"]);
+        return $email;
     }
 
-    if ($is_a_reply_comment) {
-      $id = $this->get_value("commentLinkID");
-    } else {
-      $id = $this->get_id();
-    } 
+    function sort_task_comments_callback_func($a, $b)
+    {
+        return strtotime($a["date"]) > strtotime($b["date"]);
+    }
 
-    $recipients = comment::get_email_recipients($selected_option,"comment",$id);
-    list($to_address,$bcc,$successful_recipients) = comment::get_email_recipient_headers($recipients, $from_address);
+    function make_token_add_comment_from_email()
+    {
+        $current_user = &singleton("current_user");
+        if (!is_object($current_user) || !$current_user->get_id()) {
+            alloc_error("Cannot make token, current_user is not set.", true);
+        }
+        $token = new token();
+        $token->set_value("tokenEntity", "comment");
+        $token->set_value("tokenEntityID", $this->get_id());
+        $token->set_value("tokenActionID", 2);
+        $token->set_value("tokenActive", 1);
+        $token->set_value("tokenCreatedBy", $current_user->get_id());
+        $token->set_value("tokenCreatedDate", date("Y-m-d H:i:s"));
+        $hash = $token->generate_hash();
+        $token->set_value("tokenHash", $hash);
+        $token->save();
+        return $hash;
+    }
 
-    if ($to_address || $bcc || $successful_recipients) {
-      $email = new email_send();
+    function add_comment_from_email($email_receive, $entity)
+    {
+        $current_user = &singleton("current_user");
 
-      if ($email_receive) {
-        list($email_receive_header,$email_receive_body) = $email_receive->get_raw_header_and_body();
-        $email->set_headers($email_receive_header); 
-        $email->set_body($email_receive_body,$email_receive->mail_text); 
-        // Remove any existing To/Cc header, to prevent the email getting sent to the same recipients again.
-        $email->del_header("To");
-        $email->del_header("Cc");
-        $subject = $email->get_header("subject");
-        $subject = trim(preg_replace("/{Key:[^}]*}.*$/i","",$subject));
-      } else {
-        $email->set_body($body);
-        if ($files) {
-          // (if we're bouncing a complete email body the attachments are already included, else do this...)
-          foreach ((array)$files as $file) {
-            $email->add_attachment($file["fullpath"]);
-          }
+        $commentID = comment::add_comment($entity->classname, $entity->get_id(), $email_receive->get_converted_encoding());
+        $commentID or alloc_error("Unable to create an alloc comment (".$entity->classname.":".$entity->get_id().") from email.");
+
+        $comment = new comment();
+        $comment->set_id($commentID);
+        $comment->select();
+        $comment->set_value("commentEmailUID", $email_receive->msg_uid);
+        $comment->set_value("commentEmailMessageID", $email_receive->mail_headers["message-id"]);
+
+        $comment->rename_email_attachment_dir($email_receive->dir);
+
+      // Try figure out and populate the commentCreatedUser/commentCreatedUserClientContactID fields
+        list($from_address,$from_name) = parse_email_address($email_receive->mail_headers["from"]);
+        list($personID,$clientContactID,$from_name) = comment::get_person_and_client($from_address, $from_name, $entity->get_project_id());
+        $personID and $comment->set_value('commentCreatedUser', $personID);
+        $clientContactID and $comment->set_value('commentCreatedUserClientContactID', $clientContactID);
+
+        $comment->set_value("commentCreatedUserText", $email_receive->mail_headers["from"]);
+        $comment->set_value("commentEmailMessageID", $email_receive->mail_headers["message-id"]);
+        $comment->updateSearchIndexLater = true;
+        $comment->skip_modified_fields = true;
+        $comment->save();
+
+        if ($email_receive->mimebits) {
+            comment::update_mime_parts($comment->get_id(), $email_receive->mimebits);
+        }
+
+      // CYBER-ONLY: Re-open task, if comment has been made by an external party.
+        if (config::for_cyber() && !$comment->get_value('commentCreatedUser')) {
+            $e = $entity->get_parent_object();
+            if ($e->classname == "task" && substr($e->get_value("taskStatus"), 0, 4) != "open") {
+                $tmp = $current_user;
+                $current_user = new person();
+                $personID = $e->get_value("managerID") or $personID = $e->get_value("personID") or $personID = $e->get_value("creatorID");
+                $current_user->load_current_user($personID); // fake identity
+                singleton("current_user", $current_user);
+                $e->set_value("taskStatus", "open_inprogress");
+                $e->save();
+                $current_user = $tmp;
+            }
+        }
+
+        return $comment;
+    }
+
+    function get_email_recipients($options = array(), $entity, $entityID)
+    {
+        $recipients = array();
+        $people =& get_cached_table("person");
+
+        foreach ($options as $selected_option) {
+          // Determine recipients
+            if ($selected_option == "interested") {
+                $db = new db_alloc();
+                if ($entity && $entityID) {
+                    $q = prepare("SELECT * FROM interestedParty WHERE entity = '%s' AND entityID = %d AND interestedPartyActive = 1", $entity, $entityID);
+                }
+                $db->query($q);
+                while ($row = $db->next_record()) {
+                    $row["isCC"] = true;
+                    $row["name"] = $row["fullName"];
+                    $recipients[] = $row;
+                }
+            } else if (is_int($selected_option)) {
+                $recipients[] = $people[$selected_option];
+            } else if (is_string($selected_option) && preg_match("/@/", $selected_option)) {
+                list($email, $name) = parse_email_address($selected_option);
+                $email and $recipients[] = array("name"=>$name,"emailAddress"=>$email);
+            }
+        }
+        return $recipients;
+    }
+
+    function get_email_recipient_headers($recipients, $from_address)
+    {
+        $current_user = &singleton("current_user");
+
+        $emailMethod = config::get_config_item("allocEmailAddressMethod");
+
+      // Build up To: and Bcc: headers
+        foreach ($recipients as $recipient) {
+            unset($recipient_full_name);
+
+            if ($recipient["firstName"] && $recipient["surname"]) {
+                $recipient_full_name = $recipient["firstName"]." ".$recipient["surname"];
+            } else if ($recipient["fullName"]) {
+                $recipient_full_name = $recipient["fullName"];
+            } else if ($recipient["name"]) {
+                $recipient_full_name = $recipient["name"];
+            }
+
+            if ($recipient["emailAddress"] && !$done[$recipient["emailAddress"]]) {
+                // If the person does *not* want to receive their own emails, skip adding them as a recipient
+                if (is_object($current_user) && $current_user->get_id() && !$current_user->prefs["receiveOwnTaskComments"] && same_email_address($recipient["emailAddress"], $from_address)) {
+                    continue;
+                } else if ((!is_object($current_user) || !$current_user->get_id()) && same_email_address($recipient["emailAddress"], $from_address)) {
+                    continue;
+                }
+
+                $done[$recipient["emailAddress"]] = true;
+
+                $name = $recipient_full_name or $name = $recipient["emailAddress"];
+                $email_without_name = $recipient["emailAddress"];
+                if ($recipient_full_name) {
+                    $name_and_email = $recipient_full_name." <".$recipient["emailAddress"].">";
+                } else {
+                    $name_and_email = $recipient["emailAddress"];
+                }
+
+                if ($emailMethod == "to") {
+                    $to_address[] = $name_and_email;
+                    $successful_recipients[] = $name_and_email;
+                } else if ($emailMethod == "bcc") {
+                    $bcc[] = $email_without_name;
+                    $successful_recipients[] = $name_and_email;
+
+                // The To address contains no actual email addresses, ie "Alex Lance": ; all the real recipients are in the Bcc.
+                } else if ($emailMethod == "tobcc") {
+                    if (!same_email_address(ALLOC_DEFAULT_FROM_ADDRESS, $email_without_name)) {
+                        $to_address[] = '"'.$name.'": ;';
+                        $successful_recipients[] = $name_and_email;
+                    }
+                    $bcc[] = $email_without_name;
+                }
+            }
+        }
+        return array(implode(", ", (array)$to_address), implode(", ", (array)$bcc), implode(", ", (array)$successful_recipients));
+    }
+
+    function send_emails($selected_option, $email_receive = false, $hash = "", $is_a_reply_comment = false, $files = array())
+    {
+        $current_user = &singleton("current_user");
+
+        $e = $this->get_parent_object();
+        $type = $e->classname."_comments";
+        $body = $this->get_value("comment");
+
+        if (is_object($email_receive)) {
+            list($from_address,$from_name) = parse_email_address($email_receive->mail_headers["from"]);
+        }
+
+        if ($is_a_reply_comment) {
+            $id = $this->get_value("commentLinkID");
         } else {
-          $email->set_content_type();
+            $id = $this->get_id();
         }
-      }
 
-      $bcc && $email->add_header("Bcc",$bcc);
+        $recipients = comment::get_email_recipients($selected_option, "comment", $id);
+        list($to_address,$bcc,$successful_recipients) = comment::get_email_recipient_headers($recipients, $from_address);
 
-      // nuke bounce headers - mail won't send properly otherwise
-      $email->del_header("Resent-From");
-      $email->del_header("Resent-Date");
-      $email->del_header("Resent-Message-ID");
-      $email->del_header("Resent-To");
+        if ($to_address || $bcc || $successful_recipients) {
+            $email = new email_send();
+
+            if ($email_receive) {
+                list($email_receive_header,$email_receive_body) = $email_receive->get_raw_header_and_body();
+                $email->set_headers($email_receive_header);
+                $email->set_body($email_receive_body, $email_receive->mail_text);
+                // Remove any existing To/Cc header, to prevent the email getting sent to the same recipients again.
+                $email->del_header("To");
+                $email->del_header("Cc");
+                $subject = $email->get_header("subject");
+                $subject = trim(preg_replace("/{Key:[^}]*}.*$/i", "", $subject));
+            } else {
+                $email->set_body($body);
+                if ($files) {
+                  // (if we're bouncing a complete email body the attachments are already included, else do this...)
+                    foreach ((array)$files as $file) {
+                        $email->add_attachment($file["fullpath"]);
+                    }
+                } else {
+                    $email->set_content_type();
+                }
+            }
+
+            $bcc && $email->add_header("Bcc", $bcc);
+
+          // nuke bounce headers - mail won't send properly otherwise
+            $email->del_header("Resent-From");
+            $email->del_header("Resent-Date");
+            $email->del_header("Resent-Message-ID");
+            $email->del_header("Resent-To");
       
-      $email->add_header("X-Alloc-CommentID", $this->get_id());
-      if (is_object($e) && method_exists($e,"get_name")) {
-        $email->add_header("X-Alloc-".ucwords($e->classname), $e->get_name());
-        $email->add_header("X-Alloc-".ucwords($e->key_field->get_name()), $e->get_id());
-      }
+            $email->add_header("X-Alloc-CommentID", $this->get_id());
+            if (is_object($e) && method_exists($e, "get_name")) {
+                $email->add_header("X-Alloc-".ucwords($e->classname), $e->get_name());
+                $email->add_header("X-Alloc-".ucwords($e->key_field->get_name()), $e->get_id());
+            }
 
-      // Add project header too, if possible
-      if (has("project") && $e->classname != "project" && isset($e->data_fields["projectID"])) {
-        $p = $e->get_foreign_object("project");
-        $email->add_header("X-Alloc-Project", $p->get_value("projectName"));
-        $email->add_header("X-Alloc-ProjectID", $p->get_id());
-      }
+          // Add project header too, if possible
+            if (has("project") && $e->classname != "project" && isset($e->data_fields["projectID"])) {
+                $p = $e->get_foreign_object("project");
+                $email->add_header("X-Alloc-Project", $p->get_value("projectName"));
+                $email->add_header("X-Alloc-ProjectID", $p->get_id());
+            }
       
-      $email->set_to_address($to_address);
-      $messageid = $email->set_message_id($hash);
-      $subject_extra = "{Key:".$hash."}";
-      $email->set_date();
+            $email->set_to_address($to_address);
+            $messageid = $email->set_message_id($hash);
+            $subject_extra = "{Key:".$hash."}";
+            $email->set_date();
 
-      if (!$subject) {
-        $tpl = config::get_config_item("emailSubject_".$e->classname."Comment");
-        $tpl and $subject = commentTemplate::populate_string($tpl, $e->classname, $e->get_id());
-        $e->classname != "task" and $prefix = ucwords($e->classname)." Comment: ";
-        $subject or $subject = $prefix.$e->get_id()." ".$e->get_name(DST_VARIABLE);
-      }
+            if (!$subject) {
+                $tpl = config::get_config_item("emailSubject_".$e->classname."Comment");
+                $tpl and $subject = commentTemplate::populate_string($tpl, $e->classname, $e->get_id());
+                $e->classname != "task" and $prefix = ucwords($e->classname)." Comment: ";
+                $subject or $subject = $prefix.$e->get_id()." ".$e->get_name(DST_VARIABLE);
+            }
 
-      $email->set_subject($subject." ".$subject_extra);
-      $email->set_message_type($type);
+            $email->set_subject($subject." ".$subject_extra);
+            $email->set_message_type($type);
 
-      // If from name is empty, then use the email address instead
-      // eg: From: jon@jonny.com -> From: "jon@jonny.com via allocPSA" <alloc@cyber.com>
-      $from_name or $from_name = $from_address;
-      is_object($current_user) && !$from_name and $from_name = $current_user->get_name();
+          // If from name is empty, then use the email address instead
+          // eg: From: jon@jonny.com -> From: "jon@jonny.com via allocPSA" <alloc@cyber.com>
+            $from_name or $from_name = $from_address;
+            is_object($current_user) && !$from_name and $from_name = $current_user->get_name();
 
-      if (defined("ALLOC_DEFAULT_FROM_ADDRESS") && ALLOC_DEFAULT_FROM_ADDRESS) {
-        if (config::for_cyber()) {
-          $email->set_reply_to('"All parties via allocPSA" '.ALLOC_DEFAULT_FROM_ADDRESS);
-          $email->set_from('"'.str_replace('"','',$from_name).' via allocPSA" '.ALLOC_DEFAULT_FROM_ADDRESS);
-        } else {
-          $email->set_reply_to('"All parties" '.ALLOC_DEFAULT_FROM_ADDRESS);
-          $email->set_from('"'.str_replace('"','',$from_name).'" '.ALLOC_DEFAULT_FROM_ADDRESS);
+            if (defined("ALLOC_DEFAULT_FROM_ADDRESS") && ALLOC_DEFAULT_FROM_ADDRESS) {
+                if (config::for_cyber()) {
+                    $email->set_reply_to('"All parties via allocPSA" '.ALLOC_DEFAULT_FROM_ADDRESS);
+                    $email->set_from('"'.str_replace('"', '', $from_name).' via allocPSA" '.ALLOC_DEFAULT_FROM_ADDRESS);
+                } else {
+                    $email->set_reply_to('"All parties" '.ALLOC_DEFAULT_FROM_ADDRESS);
+                    $email->set_from('"'.str_replace('"', '', $from_name).'" '.ALLOC_DEFAULT_FROM_ADDRESS);
+                }
+            } else {
+                if (is_object($current_user) && $current_user->get_from()) {
+                    $f = $current_user->get_from();
+                } else {
+                    $f = config::get_config_item("allocEmailAdmin");
+                }
+                $email->set_reply_to($f);
+                $email->set_from($f);
+            }
+
+            if ($email->send(false)) {
+                return array($successful_recipients,$messageid);
+            }
         }
-      } else {
-        if (is_object($current_user) && $current_user->get_from()) {
-          $f = $current_user->get_from();
-        } else {
-          $f = config::get_config_item("allocEmailAdmin");
+    }
+
+    function get_list_filter($filter = array())
+    {
+        $current_user = &singleton("current_user");
+
+      // If they want starred, load up the commentID filter element
+        if ($filter["starred"]) {
+            foreach ((array)$current_user->prefs["stars"]["comment"] as $k => $v) {
+                $filter["commentID"][] = $k;
+            }
+            is_array($filter["commentID"]) or $filter["commentID"][] = -1;
         }
-        $email->set_reply_to($f);
-        $email->set_from($f);
-      }
 
-      if ($email->send(false)) {
-        return array($successful_recipients,$messageid);
-      }
-    }   
-  }
+      // Filter ocommentID
+        if ($filter["commentID"] && is_array($filter["commentID"])) {
+            $sql[] = prepare("(comment.commentID in (%s))", $filter["commentID"]);
+        } else if ($filter["commentID"]) {
+            $sql[] = prepare("(comment.commentID = %d)", $filter["commentID"]);
+        }
 
-  function get_list_filter($filter=array()) {
-    $current_user = &singleton("current_user");
-
-    // If they want starred, load up the commentID filter element
-    if ($filter["starred"]) {
-      foreach ((array)$current_user->prefs["stars"]["comment"] as $k=>$v) {
-        $filter["commentID"][] = $k;
-      }
-      is_array($filter["commentID"]) or $filter["commentID"][] = -1;
+      // No point continuing if primary key specified, so return
+        if ($filter["commentID"] || $filter["starred"]) {
+            return $sql;
+        }
     }
 
-    // Filter ocommentID
-    if ($filter["commentID"] && is_array($filter["commentID"])) {
-      $sql[] = prepare("(comment.commentID in (%s))",$filter["commentID"]);
-    } else if ($filter["commentID"]) {     
-      $sql[] = prepare("(comment.commentID = %d)", $filter["commentID"]);
-    }
+    public static function get_list($_FORM = array())
+    {
 
-    // No point continuing if primary key specified, so return
-    if ($filter["commentID"] || $filter["starred"]) {
-      return $sql;
-    }
-  }
+      // Two modes, 1: get all comments for an entity, eg a task
+        if ($_FORM["entity"] && in_array($_FORM["entity"], array("project","client","task","timeSheet")) && $_FORM["entityID"]) {
+            $e = new $_FORM["entity"];
+            $e->set_id($_FORM["entityID"]);
+            if ($e->select()) { // this ensures that the user can read the entity
+                return comment::util_get_comments_array($_FORM["entity"], $_FORM["entityID"], $_FORM);
+            }
 
-  public static function get_list($_FORM=array()) {
+        // Or 2: get all starred comments
+        } else if ($_FORM["starred"]) {
+            $filter = comment::get_list_filter($_FORM);
+            if (is_array($filter) && count($filter)) {
+                $filter = " WHERE ".implode(" AND ", $filter);
+            }
 
-    // Two modes, 1: get all comments for an entity, eg a task
-    if ($_FORM["entity"] && in_array($_FORM["entity"],array("project","client","task","timeSheet")) && $_FORM["entityID"]) {
-      $e = new $_FORM["entity"];
-      $e->set_id($_FORM["entityID"]);
-      if ($e->select()) { // this ensures that the user can read the entity
-        return comment::util_get_comments_array($_FORM["entity"],$_FORM["entityID"],$_FORM);
-      }
-
-    // Or 2: get all starred comments
-    } else if ($_FORM["starred"]){
-      $filter = comment::get_list_filter($_FORM);
-      if (is_array($filter) && count($filter)) {
-        $filter = " WHERE ".implode(" AND ",$filter);
-      }
-
-      $q = "SELECT comment.*, commentCreatedUser as personID, clientContact.clientContactName
+            $q = "SELECT comment.*, commentCreatedUser as personID, clientContact.clientContactName
               FROM comment 
          LEFT JOIN clientContact on comment.commentCreatedUserClientContactID = clientContact.clientContactID
                  ".$filter." 
           ORDER BY commentCreatedTime";
-      $db = new db_alloc();
-      $db->query($q);
-      $people =& get_cached_table("person");
-      while ($row = $db->next_record()) {
-        $e = new $row["commentMaster"];
-        $e->set_id($row["commentMasterID"]);
-        $e->select();
-        $row["entity_link"] = $e->get_link();
-        $row["personID"] and $row["person"] = $people[$row["personID"]]["name"];
-        $row["clientContactName"] and $row["person"] = $row["clientContactName"];
-        $rows[] = $row;
-      }
-      has("timeSheetItem") and $tsi_rows = timeSheetItem::get_timeSheetItemComments(null,true);
-      foreach ((array)$tsi_rows as $row) {
-        $t = new task();
-        $t->set_id($row["taskID"]);
-        $t->select();
-        $row["entity_link"] = $t->get_link();
-        $row["commentMaster"] = "Task";
-        $row["commentMasterID"] = $row["taskID"];
-        $row["commentCreatedTime"] = $row["date"];
-        $row["personID"] and $row["person"] = $people[$row["personID"]]["name"];
-        $rows[] = $row;
-      }
+            $db = new db_alloc();
+            $db->query($q);
+            $people =& get_cached_table("person");
+            while ($row = $db->next_record()) {
+                $e = new $row["commentMaster"];
+                $e->set_id($row["commentMasterID"]);
+                $e->select();
+                $row["entity_link"] = $e->get_link();
+                $row["personID"] and $row["person"] = $people[$row["personID"]]["name"];
+                $row["clientContactName"] and $row["person"] = $row["clientContactName"];
+                $rows[] = $row;
+            }
+            has("timeSheetItem") and $tsi_rows = timeSheetItem::get_timeSheetItemComments(null, true);
+            foreach ((array)$tsi_rows as $row) {
+                $t = new task();
+                $t->set_id($row["taskID"]);
+                $t->select();
+                $row["entity_link"] = $t->get_link();
+                $row["commentMaster"] = "Task";
+                $row["commentMasterID"] = $row["taskID"];
+                $row["commentCreatedTime"] = $row["date"];
+                $row["personID"] and $row["person"] = $people[$row["personID"]]["name"];
+                $rows[] = $row;
+            }
 
-      return (array)$rows;
+            return (array)$rows;
+        }
     }
-  }
 
-  function get_list_html($rows=array(),$ops=array()) {
-    global $TPL;
-    $TPL["commentListRows"] = $rows;
-    $TPL["_FORM"] = $ops;
-    include_template(dirname(__FILE__)."/../templates/commentListS.tpl");
-  }
+    function get_list_html($rows = array(), $ops = array())
+    {
+        global $TPL;
+        $TPL["commentListRows"] = $rows;
+        $TPL["_FORM"] = $ops;
+        include_template(dirname(__FILE__)."/../templates/commentListS.tpl");
+    }
 
-  function get_list_vars() {
-    return array("entity"            => "The entity whose comments you want to fetch, eg: project | client | task | timeSheet"
+    function get_list_vars()
+    {
+        return array("entity"            => "The entity whose comments you want to fetch, eg: project | client | task | timeSheet"
                 ,"entityID"          => "The ID of the particular entity"
                 ,"showEditButtons"   => "Will fetch a form with edit comment buttons"
                 );
-  }
-
-  function get_parent_object() {
-    if (class_exists($this->get_value("commentMaster"))) {
-      $parent_type = $this->get_value("commentMaster");
-      $o = new $parent_type;
-      $o->set_id($this->get_value("commentMasterID"));
-      $o->select();
-      return $o;
-    }
-  }
-
-  function update_search_index_doc(&$index) {
-    $arr["commentCreatedUserText"] = $this->get_value("commentCreatedUserText");
-    $arr["clientContactID"]        = $this->get_value("commentCreatedUserClientContactID");
-    $arr["personID"]               = $this->get_value("commentCreatedUser");
-
-    $name = $this->get_value("commentCreatedTime")." ";
-    $author = comment::get_comment_author($arr);
-    $name.= $author;
-
-    $entity = $this->get_value("commentType");
-    $entity_id = $this->get_value("commentLinkID");
-    if (!class_exists($entity)) {
-      return false;
-    }
-    $e = new $entity;
-    $e->set_id($entity_id);
-    $e->select();
-    $entity_name = $e->get_name();
-    // If the parent is a comment, then go up one more level
-    if ($entity == "comment") {
-      $entity = $e->get_value("commentType");
-      $entity_id = $e->get_value("commentLinkID");
-      $f = new $entity;
-      $f->set_id($entity_id);
-      $f->select();
-      $entity_name = $f->get_name();
     }
 
-    $doc = new Zend_Search_Lucene_Document();
-    $doc->addField(Zend_Search_Lucene_Field::Keyword('id'   ,$this->get_id()));
-    $doc->addField(Zend_Search_Lucene_Field::Text('name'    ,$name,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('type'    ,$entity,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('typeid'  ,$entity_id,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('typename',$entity_name,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('desc'    ,$this->get_value("comment"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('creator' ,$author,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateCreated',str_replace("-","",$this->get_value("commentCreatedTime")),"utf-8"));
-    $index->addDocument($doc);
-  }
+    function get_parent_object()
+    {
+        if (class_exists($this->get_value("commentMaster"))) {
+            $parent_type = $this->get_value("commentMaster");
+            $o = new $parent_type;
+            $o->set_id($this->get_value("commentMasterID"));
+            $o->select();
+            return $o;
+        }
+    }
 
-  function get_list_summary_filter($filter=array()) {
+    function update_search_index_doc(&$index)
+    {
+        $arr["commentCreatedUserText"] = $this->get_value("commentCreatedUserText");
+        $arr["clientContactID"]        = $this->get_value("commentCreatedUserClientContactID");
+        $arr["personID"]               = $this->get_value("commentCreatedUser");
+
+        $name = $this->get_value("commentCreatedTime")." ";
+        $author = comment::get_comment_author($arr);
+        $name.= $author;
+
+        $entity = $this->get_value("commentType");
+        $entity_id = $this->get_value("commentLinkID");
+        if (!class_exists($entity)) {
+            return false;
+        }
+        $e = new $entity;
+        $e->set_id($entity_id);
+        $e->select();
+        $entity_name = $e->get_name();
+      // If the parent is a comment, then go up one more level
+        if ($entity == "comment") {
+            $entity = $e->get_value("commentType");
+            $entity_id = $e->get_value("commentLinkID");
+            $f = new $entity;
+            $f->set_id($entity_id);
+            $f->select();
+            $entity_name = $f->get_name();
+        }
+
+        $doc = new Zend_Search_Lucene_Document();
+        $doc->addField(Zend_Search_Lucene_Field::Keyword('id', $this->get_id()));
+        $doc->addField(Zend_Search_Lucene_Field::Text('name', $name, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('type', $entity, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('typeid', $entity_id, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('typename', $entity_name, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('desc', $this->get_value("comment"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('creator', $author, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateCreated', str_replace("-", "", $this->get_value("commentCreatedTime")), "utf-8"));
+        $index->addDocument($doc);
+    }
+
+    function get_list_summary_filter($filter = array())
+    {
     
-    // This takes care of projectID singular and plural
-    has("project") and $projectIDs = project::get_projectID_sql($filter,"task");
-    $projectIDs and $sql1["projectIDs"] = $projectIDs;
-    $projectIDs and $sql2["projectIDs"] = $projectIDs;
-    $filter['taskID'] and $sql1[] = prepare("(task.taskID = %d)", $filter["taskID"]);
-    $filter['taskID'] and $sql2[] = prepare("(task.taskID = %d)", $filter["taskID"]);
-    $filter['taskID'] and $sql3[] = prepare("(tsiHint.taskID = %d)", $filter["taskID"]);
-    $filter["fromDate"] and $sql1[] = prepare("(date(commentCreatedTime) >= '%s')", $filter["fromDate"]);
-    $filter["fromDate"] and $sql2[] = prepare("(dateTimeSheetItem >= '%s')", $filter["fromDate"]);
-    $filter["fromDate"] and $sql3[] = prepare("(tsiHint.date >= '%s')", $filter["fromDate"]);
-    $filter["toDate"] and $sql1[] = prepare("(date(commentCreatedTime) < '%s')", $filter["toDate"]);
-    $filter["toDate"] and $sql2[] = prepare("(dateTimeSheetItem < '%s')", $filter["toDate"]);
-    $filter["toDate"] and $sql3[] = prepare("(tsiHint.date < '%s')", $filter["toDate"]);
-    $filter["personID"] and $sql1["personID"] = prepare("(comment.commentCreatedUser IN (%s))",$filter["personID"]);
-    $filter["personID"] and $sql2[] = prepare("(timeSheetItem.personID IN (%s))",$filter["personID"]);
-    $filter["personID"] and $sql3[] = prepare("(tsiHint.personID IN (%s))",$filter["personID"]);
-    $filter["clients"] or $sql1[] = "(commentCreatedUser IS NOT NULL)";
-    $filter["clients"] && $filter["personID"] and $sql1["personID"] = prepare("(comment.commentCreatedUser IN (%s) OR comment.commentCreatedUser IS NULL)",$filter["personID"]);
+      // This takes care of projectID singular and plural
+        has("project") and $projectIDs = project::get_projectID_sql($filter, "task");
+        $projectIDs and $sql1["projectIDs"] = $projectIDs;
+        $projectIDs and $sql2["projectIDs"] = $projectIDs;
+        $filter['taskID'] and $sql1[] = prepare("(task.taskID = %d)", $filter["taskID"]);
+        $filter['taskID'] and $sql2[] = prepare("(task.taskID = %d)", $filter["taskID"]);
+        $filter['taskID'] and $sql3[] = prepare("(tsiHint.taskID = %d)", $filter["taskID"]);
+        $filter["fromDate"] and $sql1[] = prepare("(date(commentCreatedTime) >= '%s')", $filter["fromDate"]);
+        $filter["fromDate"] and $sql2[] = prepare("(dateTimeSheetItem >= '%s')", $filter["fromDate"]);
+        $filter["fromDate"] and $sql3[] = prepare("(tsiHint.date >= '%s')", $filter["fromDate"]);
+        $filter["toDate"] and $sql1[] = prepare("(date(commentCreatedTime) < '%s')", $filter["toDate"]);
+        $filter["toDate"] and $sql2[] = prepare("(dateTimeSheetItem < '%s')", $filter["toDate"]);
+        $filter["toDate"] and $sql3[] = prepare("(tsiHint.date < '%s')", $filter["toDate"]);
+        $filter["personID"] and $sql1["personID"] = prepare("(comment.commentCreatedUser IN (%s))", $filter["personID"]);
+        $filter["personID"] and $sql2[] = prepare("(timeSheetItem.personID IN (%s))", $filter["personID"]);
+        $filter["personID"] and $sql3[] = prepare("(tsiHint.personID IN (%s))", $filter["personID"]);
+        $filter["clients"] or $sql1[] = "(commentCreatedUser IS NOT NULL)";
+        $filter["clients"] && $filter["personID"] and $sql1["personID"] = prepare("(comment.commentCreatedUser IN (%s) OR comment.commentCreatedUser IS NULL)", $filter["personID"]);
 
-    $filter["taskStatus"] and $sql1[] = task::get_taskStatus_sql($filter["taskStatus"]);
-    $filter["taskStatus"] and $sql2[] = task::get_taskStatus_sql($filter["taskStatus"]);
+        $filter["taskStatus"] and $sql1[] = task::get_taskStatus_sql($filter["taskStatus"]);
+        $filter["taskStatus"] and $sql2[] = task::get_taskStatus_sql($filter["taskStatus"]);
 
-    return array($sql1,$sql2,$sql3);
-  }
-
-  function get_list_summary($_FORM=array()) {
-
-    //$_FORM["fromDate"] = "2010-08-20";
-    //$_FORM["projectID"] = "22";
-
-    $_FORM["maxCommentLength"] or $_FORM["maxCommentLength"] = 500;
-
-    list($filter1,$filter2,$filter3) = comment::get_list_summary_filter($_FORM);
-
-    is_array($filter1) && count($filter1) and $filter1 = " AND ".implode(" AND ",$filter1);
-    is_array($filter2) && count($filter2) and $filter2 = " AND ".implode(" AND ",$filter2);
-    is_array($filter3) && count($filter3) and $filter3 = " AND ".implode(" AND ",$filter3);
-
-    if ($_FORM["clients"]) {
-      $client_join = " LEFT JOIN clientContact on comment.commentCreatedUserClientContactID = clientContact.clientContactID";
-      $client_fields = " , clientContact.clientContactName";
+        return array($sql1,$sql2,$sql3);
     }
 
-    $q = prepare("SELECT commentID as id
+    function get_list_summary($_FORM = array())
+    {
+
+      //$_FORM["fromDate"] = "2010-08-20";
+      //$_FORM["projectID"] = "22";
+
+        $_FORM["maxCommentLength"] or $_FORM["maxCommentLength"] = 500;
+
+        list($filter1,$filter2,$filter3) = comment::get_list_summary_filter($_FORM);
+
+        is_array($filter1) && count($filter1) and $filter1 = " AND ".implode(" AND ", $filter1);
+        is_array($filter2) && count($filter2) and $filter2 = " AND ".implode(" AND ", $filter2);
+        is_array($filter3) && count($filter3) and $filter3 = " AND ".implode(" AND ", $filter3);
+
+        if ($_FORM["clients"]) {
+            $client_join = " LEFT JOIN clientContact on comment.commentCreatedUserClientContactID = clientContact.clientContactID";
+            $client_fields = " , clientContact.clientContactName";
+        }
+
+        $q = prepare(
+            "SELECT commentID as id
                        , commentCreatedUser as personID
                        , UNIX_TIMESTAMP(commentCreatedTime) as sortDate
                        , date(commentCreatedTime) as date
@@ -887,33 +913,35 @@ class comment extends db_entity {
                          ".$client_join."
                    WHERE commentMaster = 'task'
                          ".$filter1."
-                ORDER BY commentCreatedTime, commentCreatedUser"
-                ,$_FORM["maxCommentLength"]);
-    $q.= " ";
+                ORDER BY commentCreatedTime, commentCreatedUser",
+            $_FORM["maxCommentLength"]
+        );
+        $q.= " ";
               
-    $people =& get_cached_table("person");
+        $people =& get_cached_table("person");
 
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $row["icon"] = 'icon-comments-alt';
-      $row["id"] = "comment_".$row["id"];
-      $row["personID"] and $row["person"] = $people[$row["personID"]]["name"];
-      $row["clientContactName"] and $row["person"] = $row["clientContactName"];
-      $row["person"] or list($e,$row["person"]) = parse_email_address($row["commentCreatedUserText"]);
-      $row["displayDate"] = format_date("Y-m-d g:ia",$row["displayDate"]);
-      if (!$tasks[$row["taskID"]]) {
-        $t = new task();
-        $t->set_id($row["taskID"]);
-        $t->set_value("taskName",$row["taskName"]);
-        $tasks[$row["taskID"]] = $t->get_task_link(array("prefixTaskID"=>true));
-      }
-      $rows[$row["taskID"]][$row["sortDate"]][] = $row;
-    }
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $row["icon"] = 'icon-comments-alt';
+            $row["id"] = "comment_".$row["id"];
+            $row["personID"] and $row["person"] = $people[$row["personID"]]["name"];
+            $row["clientContactName"] and $row["person"] = $row["clientContactName"];
+            $row["person"] or list($e,$row["person"]) = parse_email_address($row["commentCreatedUserText"]);
+            $row["displayDate"] = format_date("Y-m-d g:ia", $row["displayDate"]);
+            if (!$tasks[$row["taskID"]]) {
+                $t = new task();
+                $t->set_id($row["taskID"]);
+                $t->set_value("taskName", $row["taskName"]);
+                $tasks[$row["taskID"]] = $t->get_task_link(array("prefixTaskID"=>true));
+            }
+            $rows[$row["taskID"]][$row["sortDate"]][] = $row;
+        }
 
-    // Note that timeSheetItemID is selected twice so that the perms checking can work
-    // timeSheetID is also used by the perms checking.
-    $q2 = prepare("SELECT timeSheetItemID as id
+      // Note that timeSheetItemID is selected twice so that the perms checking can work
+      // timeSheetID is also used by the perms checking.
+        $q2 = prepare(
+            "SELECT timeSheetItemID as id
                          ,timeSheetItemID
                          ,timeSheetID
                          ,timeSheetItem.personID
@@ -928,30 +956,33 @@ class comment extends db_entity {
                 LEFT JOIN task on timeSheetItem.taskID = task.taskID
                     WHERE 1
                           ".$filter2."
-                 ORDER BY dateTimeSheetItem"
-                 ,$_FORM["maxCommentLength"]);
+                 ORDER BY dateTimeSheetItem",
+            $_FORM["maxCommentLength"]
+        );
 
-    $db->query($q2);
-    while ($row = $db->row()) {
-      $timeSheetItem = new timeSheetItem();
-      if (!$timeSheetItem->read_row_record($row))
-        continue;
-      $row["icon"] = 'icon-time';
-      $row["id"] = "timeitem_".$row["id"];
-      $row["person"] = $people[$row["personID"]]["name"];
-      if (!$tasks[$row["taskID"]]) {
-        $t = new task();
-        $t->set_id($row["taskID"]);
-        $t->set_value("taskName",$row["taskName"]);
-        $tasks[$row["taskID"]] = $t->get_task_link(array("prefixTaskID"=>true));
-      }
-      $totals[$row["taskID"]] += $row["duration"];
-      $rows[$row["taskID"]][$row["sortDate"]][] = $row;
-    }
+        $db->query($q2);
+        while ($row = $db->row()) {
+            $timeSheetItem = new timeSheetItem();
+            if (!$timeSheetItem->read_row_record($row)) {
+                continue;
+            }
+            $row["icon"] = 'icon-time';
+            $row["id"] = "timeitem_".$row["id"];
+            $row["person"] = $people[$row["personID"]]["name"];
+            if (!$tasks[$row["taskID"]]) {
+                $t = new task();
+                $t->set_id($row["taskID"]);
+                $t->set_value("taskName", $row["taskName"]);
+                $tasks[$row["taskID"]] = $t->get_task_link(array("prefixTaskID"=>true));
+            }
+            $totals[$row["taskID"]] += $row["duration"];
+            $rows[$row["taskID"]][$row["sortDate"]][] = $row;
+        }
 
 
-    // get manager's guestimates about time worked from tsiHint table
-    $q3 = prepare("SELECT tsiHintID as id
+      // get manager's guestimates about time worked from tsiHint table
+        $q3 = prepare(
+            "SELECT tsiHintID as id
                          ,tsiHintID
                          ,tsiHint.personID
                          ,tsiHint.date
@@ -966,293 +997,309 @@ class comment extends db_entity {
                 LEFT JOIN task on tsiHint.taskID = task.taskID
                     WHERE 1
                           ".$filter3."
-                 ORDER BY tsiHint.date"
-                 ,$_FORM["maxCommentLength"]);
+                 ORDER BY tsiHint.date",
+            $_FORM["maxCommentLength"]
+        );
 
-    $db->query($q3);
-    while ($row = $db->row()) {
-      //$tsiHint = new tsiHint();
-      //if (!$tsiHint->read_row_record($row))
-      //  continue;
-      $row["icon"] = 'icon-bookmark-empty';
-      $row["id"] = "tsihint_".$row["id"];
-      $row["person"] = $people[$row["personID"]]["name"];
-      $row["comment_text"].= ' [by '.$people[$row["tsiHintCreatedUser"]]["name"].']';
-      if (!$tasks[$row["taskID"]]) {
-        $t = new task();
-        $t->set_id($row["taskID"]);
-        $t->set_value("taskName",$row["taskName"]);
-        $tasks[$row["taskID"]] = $t->get_task_link(array("prefixTaskID"=>true));
-      }
-      $totals_tsiHint[$row["taskID"]] += $row["duration"];
-      $rows[$row["taskID"]][$row["sortDate"]][] = $row;
-    }
-
-    // If there is a time sheet entry for 2010-10-10 but there is no comment entry
-    // for that date, then the time sheet entry will appear out of sequence i.e. at
-    // the very end of the whole list. So we need to manually sort them.
-    foreach ((array)$rows as $tid => $arr) {
-      ksort($arr,SORT_NUMERIC);
-      $rows[$tid] = $arr;
-    }
-
-    foreach ((array)$rows as $taskID => $dates) {
-      $rtn.= comment::get_list_summary_header($tasks[$taskID],$totals[$taskID],$totals_tsiHint[$taskID],$_FORM);
-      foreach ($dates as $date => $more_rows) {
-        foreach ($more_rows as $row) {
-          $rtn.= comment::get_list_summary_body($row);
+        $db->query($q3);
+        while ($row = $db->row()) {
+            //$tsiHint = new tsiHint();
+            //if (!$tsiHint->read_row_record($row))
+            //  continue;
+            $row["icon"] = 'icon-bookmark-empty';
+            $row["id"] = "tsihint_".$row["id"];
+            $row["person"] = $people[$row["personID"]]["name"];
+            $row["comment_text"].= ' [by '.$people[$row["tsiHintCreatedUser"]]["name"].']';
+            if (!$tasks[$row["taskID"]]) {
+                $t = new task();
+                $t->set_id($row["taskID"]);
+                $t->set_value("taskName", $row["taskName"]);
+                $tasks[$row["taskID"]] = $t->get_task_link(array("prefixTaskID"=>true));
+            }
+            $totals_tsiHint[$row["taskID"]] += $row["duration"];
+            $rows[$row["taskID"]][$row["sortDate"]][] = $row;
         }
-      }
-      $rtn.= comment::get_list_summary_footer($rows,$tasks);
-    }
-    return $rtn;
-  }
 
-  function get_list_summary_header($task,$totals,$totals_tsiHint,$_FORM=array()) {
+      // If there is a time sheet entry for 2010-10-10 but there is no comment entry
+      // for that date, then the time sheet entry will appear out of sequence i.e. at
+      // the very end of the whole list. So we need to manually sort them.
+        foreach ((array)$rows as $tid => $arr) {
+            ksort($arr, SORT_NUMERIC);
+            $rows[$tid] = $arr;
+        }
+
+        foreach ((array)$rows as $taskID => $dates) {
+            $rtn.= comment::get_list_summary_header($tasks[$taskID], $totals[$taskID], $totals_tsiHint[$taskID], $_FORM);
+            foreach ($dates as $date => $more_rows) {
+                foreach ($more_rows as $row) {
+                    $rtn.= comment::get_list_summary_body($row);
+                }
+            }
+            $rtn.= comment::get_list_summary_footer($rows, $tasks);
+        }
+        return $rtn;
+    }
+
+    function get_list_summary_header($task, $totals, $totals_tsiHint, $_FORM = array())
+    {
   
-    if ($_FORM["showTaskHeader"]) {
-      $rtn[] = "<table class='list' style='border-bottom:0;'>";
-      $rtn[] = "<tr>";
-      $rtn[] = "<td style='font-size:130%'>".$task."</td>";
-      $rtn[] = "<td class='right bold'>".sprintf("%0.2f",$totals)." / <span style='color:#888;'>".sprintf("%0.2f",$totals_tsiHint)."</span></td>";
-      $rtn[] = "</tr>";
-      $rtn[] = "</table>";
-    }
-    $rtn[] = "<table class=\"list sortable\" style='margin-bottom:10px'>";
-    $rtn[] = "<tr>";
-    $rtn[] = "<th>&nbsp;</th>";
-    $rtn[] = "<th>Date</th>";
-    $rtn[] = "<th>Person</th>";
-    $rtn[] = "<th>Comment</th>";
-    $rtn[] = "<th>Hours</th>";
-    $rtn[] ="</tr>";
-    return implode("\n",$rtn);
-  }
-
-  function get_list_summary_body($row) {
-    global $TPL;
-    $TPL["row"] = $row;
-    return include_template(dirname(__FILE__)."/../templates/summaryR.tpl", true);
-  }
-
-  function get_list_summary_footer($rows,$tasks) {
-    $rtn[] = "</table>";
-    return implode("\n",$rtn);
-  }
-
-  function get_project_id() {
-    $this->select();
-    if ($this->get_value("commentType") == "task" && $this->get_value("commentLinkID")) {
-      $t = new task();
-      $t->set_id($this->get_value("commentLinkID"));
-      $t->select();
-      $projectID = $t->get_value("projectID");
-    } else if ($this->get_value("commentType") == "project" && $this->get_value("commentLinkID")) {
-      $projectID = $this->get_value("commentLinkID");
-    } else if ($this->get_value("commentType") == "timeSheet" && $this->get_value("commentLinkID")) {
-      $t = new timeSheet();
-      $t->set_id($this->get_value("commentLinkID"));
-      $t->select();
-      $projectID = $t->get_value("projectID");
-    }
-    return $projectID;
-  }
-
-  function get_person_and_client($from_address,$from_name,$projectID=null) {
-    $current_user = &singleton("current_user");
-    $person = new person();
-    $personID = $person->find_by_email($from_address);
-    $personID or $personID = $person->find_by_name($from_name);
-
-    if (!$personID) {
-      $cc = new clientContact();
-      $clientContactID = $cc->find_by_email($from_address);
-      $clientContactID or $clientContactID = $cc->find_by_name($from_name, $projectID);
+        if ($_FORM["showTaskHeader"]) {
+            $rtn[] = "<table class='list' style='border-bottom:0;'>";
+            $rtn[] = "<tr>";
+            $rtn[] = "<td style='font-size:130%'>".$task."</td>";
+            $rtn[] = "<td class='right bold'>".sprintf("%0.2f", $totals)." / <span style='color:#888;'>".sprintf("%0.2f", $totals_tsiHint)."</span></td>";
+            $rtn[] = "</tr>";
+            $rtn[] = "</table>";
+        }
+        $rtn[] = "<table class=\"list sortable\" style='margin-bottom:10px'>";
+        $rtn[] = "<tr>";
+        $rtn[] = "<th>&nbsp;</th>";
+        $rtn[] = "<th>Date</th>";
+        $rtn[] = "<th>Person</th>";
+        $rtn[] = "<th>Comment</th>";
+        $rtn[] = "<th>Hours</th>";
+        $rtn[] ="</tr>";
+        return implode("\n", $rtn);
     }
 
-    // If we don't have a $from_name, but we do have a personID or clientContactID, get proper $from_name
-    if (!$from_name) {
-      if ($personID) {
-        $from_name = person::get_fullname($personID);
-      } else if ($clientContactID) {
-        $cc = new clientContact();
-        $cc->set_id($clientContactID);
-        $cc->select();
-        $from_name = $cc->get_value("clientContactName");
-      } else {
-        $from_name = $from_address;
-      }
+    function get_list_summary_body($row)
+    {
+        global $TPL;
+        $TPL["row"] = $row;
+        return include_template(dirname(__FILE__)."/../templates/summaryR.tpl", true);
     }
-    return array($personID,$clientContactID,$from_name);
-  }
 
-  function rename_email_attachment_dir($dir) {
-    if ($dir && is_dir($dir)) {
-      $b = basename($dir);
-      $newdir = dirname($dir).DIRECTORY_SEPARATOR.$this->get_id();
-      rename($dir, $newdir);
-      rmdir_if_empty($newdir);
+    function get_list_summary_footer($rows, $tasks)
+    {
+        $rtn[] = "</table>";
+        return implode("\n", $rtn);
     }
-  }
+
+    function get_project_id()
+    {
+        $this->select();
+        if ($this->get_value("commentType") == "task" && $this->get_value("commentLinkID")) {
+            $t = new task();
+            $t->set_id($this->get_value("commentLinkID"));
+            $t->select();
+            $projectID = $t->get_value("projectID");
+        } else if ($this->get_value("commentType") == "project" && $this->get_value("commentLinkID")) {
+            $projectID = $this->get_value("commentLinkID");
+        } else if ($this->get_value("commentType") == "timeSheet" && $this->get_value("commentLinkID")) {
+            $t = new timeSheet();
+            $t->set_id($this->get_value("commentLinkID"));
+            $t->select();
+            $projectID = $t->get_value("projectID");
+        }
+        return $projectID;
+    }
+
+    function get_person_and_client($from_address, $from_name, $projectID = null)
+    {
+        $current_user = &singleton("current_user");
+        $person = new person();
+        $personID = $person->find_by_email($from_address);
+        $personID or $personID = $person->find_by_name($from_name);
+
+        if (!$personID) {
+            $cc = new clientContact();
+            $clientContactID = $cc->find_by_email($from_address);
+            $clientContactID or $clientContactID = $cc->find_by_name($from_name, $projectID);
+        }
+
+      // If we don't have a $from_name, but we do have a personID or clientContactID, get proper $from_name
+        if (!$from_name) {
+            if ($personID) {
+                $from_name = person::get_fullname($personID);
+            } else if ($clientContactID) {
+                $cc = new clientContact();
+                $cc->set_id($clientContactID);
+                $cc->select();
+                $from_name = $cc->get_value("clientContactName");
+            } else {
+                $from_name = $from_address;
+            }
+        }
+        return array($personID,$clientContactID,$from_name);
+    }
+
+    function rename_email_attachment_dir($dir)
+    {
+        if ($dir && is_dir($dir)) {
+            $b = basename($dir);
+            $newdir = dirname($dir).DIRECTORY_SEPARATOR.$this->get_id();
+            rename($dir, $newdir);
+            rmdir_if_empty($newdir);
+        }
+    }
 
 
   // All you need to add a comment, add interested parties, attachments, and re-email it out
 
-  function add_comment($commentType,$commentLinkID,$comment_text,$commentMaster=null,$commentMasterID=null) {
-    if ($commentType && $commentLinkID) {
-      $comment = new comment();
-      $comment->updateSearchIndexLater = true;
-      $commentMaster   and $comment->set_value('commentMaster', $commentMaster);
-      $commentMasterID and $comment->set_value('commentMasterID', $commentMasterID);
-      $comment->set_value('commentType', $commentType);
-      $comment->set_value('commentLinkID', $commentLinkID);
-      $comment->set_value('comment', rtrim($comment_text));
-      $comment->save();
-      return $comment->get_id();
-    }
-  }
-
-  function add_interested_parties($commentID,$ip=array(),$op=array()) {
-
-    // We send this email to the default from address, so that a copy of the
-    // original email is kept. The receiveEmail.php script will see that this
-    // email is *from* the same address, and will then skip over it, when going
-    // through the new emails.
-    if (defined("ALLOC_DEFAULT_FROM_ADDRESS") && ALLOC_DEFAULT_FROM_ADDRESS) {
-      list($from_address,$from_name) = parse_email_address(ALLOC_DEFAULT_FROM_ADDRESS);
-      $emailRecipients[] = $from_address;
-    }
-
-    interestedParty::make_interested_parties("comment",$commentID,$ip);
-    $emailRecipients[] = "interested";
-
-    // Other parties that are added on-the-fly
-    foreach ((array)$op as $email => $info) {
-      if ($email && in_str("@",$email)) {
-        unset($lt,$gt); // used above
-        $str = $info["name"];
-        $str and $str.=" ";
-        $str and $lt = "<";
-        $str and $gt = ">";
-        $str.= $lt.str_replace(array("<",">"),"",$email).$gt;
-        $emailRecipients[] = $str;
-
-        // Add a new client contact
-        if ($info["addContact"] && $info["clientID"]) {
-          $q = prepare("SELECT * FROM clientContact WHERE clientID = %d AND clientContactEmail = '%s'"
-                      ,$info["clientID"],trim($email));
-          $db = new db_alloc();
-          if (!$db->qr($q)) {
-            $cc = new clientContact();
-            $cc->set_value("clientContactName",trim($info["name"]));
-            $cc->set_value("clientContactEmail",trim($email));
-            $cc->set_value("clientID",sprintf("%d",$info["clientID"]));
-            $cc->save();
-          }
+    function add_comment($commentType, $commentLinkID, $comment_text, $commentMaster = null, $commentMasterID = null)
+    {
+        if ($commentType && $commentLinkID) {
+            $comment = new comment();
+            $comment->updateSearchIndexLater = true;
+            $commentMaster   and $comment->set_value('commentMaster', $commentMaster);
+            $commentMasterID and $comment->set_value('commentMasterID', $commentMasterID);
+            $comment->set_value('commentType', $commentType);
+            $comment->set_value('commentLinkID', $commentLinkID);
+            $comment->set_value('comment', rtrim($comment_text));
+            $comment->save();
+            return $comment->get_id();
         }
-        // Add the person to the interested parties list
-        if ($info["addIP"] && !interestedParty::exists("comment",$commentID,trim($email))) {
-          $interestedParty = new interestedParty();
-          $interestedParty->set_value("fullName",trim($info["name"]));
-          $interestedParty->set_value("emailAddress",trim($email));
-          $interestedParty->set_value("entityID",$commentID);
-          $interestedParty->set_value("entity","comment");
-          $interestedParty->set_value("external",$info["internal"] ? "0" : "1");
-          $interestedParty->set_value("interestedPartyActive","1");
-          if (is_object($cc) && $cc->get_id()) {
-            $interestedParty->set_value("clientContactID",$cc->get_id());
-          }
-          $interestedParty->save();
+    }
+
+    function add_interested_parties($commentID, $ip = array(), $op = array())
+    {
+
+      // We send this email to the default from address, so that a copy of the
+      // original email is kept. The receiveEmail.php script will see that this
+      // email is *from* the same address, and will then skip over it, when going
+      // through the new emails.
+        if (defined("ALLOC_DEFAULT_FROM_ADDRESS") && ALLOC_DEFAULT_FROM_ADDRESS) {
+            list($from_address,$from_name) = parse_email_address(ALLOC_DEFAULT_FROM_ADDRESS);
+            $emailRecipients[] = $from_address;
         }
-      }
+
+        interestedParty::make_interested_parties("comment", $commentID, $ip);
+        $emailRecipients[] = "interested";
+
+      // Other parties that are added on-the-fly
+        foreach ((array)$op as $email => $info) {
+            if ($email && in_str("@", $email)) {
+                unset($lt, $gt); // used above
+                $str = $info["name"];
+                $str and $str.=" ";
+                $str and $lt = "<";
+                $str and $gt = ">";
+                $str.= $lt.str_replace(array("<",">"), "", $email).$gt;
+                $emailRecipients[] = $str;
+
+                // Add a new client contact
+                if ($info["addContact"] && $info["clientID"]) {
+                    $q = prepare(
+                        "SELECT * FROM clientContact WHERE clientID = %d AND clientContactEmail = '%s'",
+                        $info["clientID"],
+                        trim($email)
+                    );
+                    $db = new db_alloc();
+                    if (!$db->qr($q)) {
+                            $cc = new clientContact();
+                            $cc->set_value("clientContactName", trim($info["name"]));
+                            $cc->set_value("clientContactEmail", trim($email));
+                            $cc->set_value("clientID", sprintf("%d", $info["clientID"]));
+                            $cc->save();
+                    }
+                }
+                // Add the person to the interested parties list
+                if ($info["addIP"] && !interestedParty::exists("comment", $commentID, trim($email))) {
+                    $interestedParty = new interestedParty();
+                    $interestedParty->set_value("fullName", trim($info["name"]));
+                    $interestedParty->set_value("emailAddress", trim($email));
+                    $interestedParty->set_value("entityID", $commentID);
+                    $interestedParty->set_value("entity", "comment");
+                    $interestedParty->set_value("external", $info["internal"] ? "0" : "1");
+                    $interestedParty->set_value("interestedPartyActive", "1");
+                    if (is_object($cc) && $cc->get_id()) {
+                        $interestedParty->set_value("clientContactID", $cc->get_id());
+                    }
+                    $interestedParty->save();
+                }
+            }
+        }
+        return $emailRecipients;
     }
-    return $emailRecipients;
-  }
 
-  function send_comment($commentID, $emailRecipients, $email_receive=false, $files=array()) {
+    function send_comment($commentID, $emailRecipients, $email_receive = false, $files = array())
+    {
 
-    $comment = new comment();
-    $comment->set_id($commentID);
-    $comment->select();
+        $comment = new comment();
+        $comment->set_id($commentID);
+        $comment->select();
 
-    $token = new token();
+        $token = new token();
 
-    if ($comment->get_value("commentType") == "comment" && $comment->get_value("commentLinkID")) {
-      $c = new comment();
-      $c->set_id($comment->get_value("commentLinkID"));
-      $c->select();
-      $is_a_reply_comment = true;
-      if ($token->select_token_by_entity_and_action("comment",$c->get_id(),"add_comment_from_email")) {
-        $hash = $token->get_value("tokenHash");
-      }
+        if ($comment->get_value("commentType") == "comment" && $comment->get_value("commentLinkID")) {
+            $c = new comment();
+            $c->set_id($comment->get_value("commentLinkID"));
+            $c->select();
+            $is_a_reply_comment = true;
+            if ($token->select_token_by_entity_and_action("comment", $c->get_id(), "add_comment_from_email")) {
+                $hash = $token->get_value("tokenHash");
+            }
+        }
+
+        if (!$hash) {
+            if ($token->select_token_by_entity_and_action("comment", $comment->get_id(), "add_comment_from_email")) {
+                $hash = $token->get_value("tokenHash");
+            } else {
+                $hash = $comment->make_token_add_comment_from_email();
+            }
+        }
+
+        $rtn = $comment->send_emails($emailRecipients, $email_receive, $hash, $is_a_reply_comment, $files);
+        if (is_array($rtn)) {
+            $email_sent = true;
+            list($successful_recipients,$messageid) = $rtn;
+        }
+
+      // Append success to end of the comment
+        if ($successful_recipients) {
+            $append_comment_text = "Email sent to: ".$successful_recipients;
+            $message_good.= $append_comment_text;
+          //$comment->set_value("commentEmailMessageID",$messageid); that's the outbound message-id :-(
+            $comment->set_value("commentEmailRecipients", $successful_recipients);
+        }
+
+        $comment->skip_modified_fields = true;
+        $comment->updateSearchIndexLater = true;
+        $comment->save();
+
+        return $email_sent;
     }
 
-    if (!$hash) {
-      if ($token->select_token_by_entity_and_action("comment",$comment->get_id(),"add_comment_from_email")) {
-        $hash = $token->get_value("tokenHash");
-      } else {
-        $hash = $comment->make_token_add_comment_from_email();
-      }
-    }
-
-    $rtn = $comment->send_emails($emailRecipients,$email_receive,$hash,$is_a_reply_comment,$files);
-    if (is_array($rtn)) {
-      $email_sent = true;
-      list($successful_recipients,$messageid) = $rtn;
-    }
-
-    // Append success to end of the comment
-    if ($successful_recipients) {
-      $append_comment_text = "Email sent to: ".$successful_recipients;
-      $message_good.= $append_comment_text;
-      //$comment->set_value("commentEmailMessageID",$messageid); that's the outbound message-id :-(
-      $comment->set_value("commentEmailRecipients",$successful_recipients);
-    }
-
-    $comment->skip_modified_fields = true;
-    $comment->updateSearchIndexLater = true;
-    $comment->save();
-
-    return $email_sent;
-  }
-
-  function attach_timeSheet($commentID, $entityID, $options) {
-    // Begin buffering output to halt anything being sent to the web browser.
-    ob_start();
-    $t = new timeSheetPrint();
-    $ops = query_string_to_array($options);
-
-    $t->get_printable_timeSheet_file($entityID,$ops["timeSheetPrintMode"],$ops["printDesc"],$ops["format"]);
-
-    // Capture the output into $str
-    $str = (string)ob_get_clean();
-    $suffix = ".html";
-    $ops["format"] != "html" and $suffix = ".pdf";
-
-    $rtn["name"] = "timeSheet_".$entityID.$suffix;
-    $rtn["blob"] = $str;
-    $rtn["size"] = strlen($str);
-    return $rtn;
-  }
-
-  function attach_invoice($commentID,$entityID,$verbose) {
-    $invoice = new invoice();
-    $invoice->set_id($entityID);
-    $invoice->select();
-    $str = $invoice->generate_invoice_file($verbose,true);
-    $rtn["name"] = "invoice_".$entityID.".pdf";
-    $rtn["blob"] = $str;
-    $rtn["size"] = strlen($str);
-    return $rtn;
-  }
-
-  function attach_tasks($commentID, $projectID, $options) {
-    if ($projectID) {
+    function attach_timeSheet($commentID, $entityID, $options)
+    {
       // Begin buffering output to halt anything being sent to the web browser.
-      ob_start();
-      $t = new taskListPrint();
+        ob_start();
+        $t = new timeSheetPrint();
+        $ops = query_string_to_array($options);
+
+        $t->get_printable_timeSheet_file($entityID, $ops["timeSheetPrintMode"], $ops["printDesc"], $ops["format"]);
+
+      // Capture the output into $str
+        $str = (string)ob_get_clean();
+        $suffix = ".html";
+        $ops["format"] != "html" and $suffix = ".pdf";
+
+        $rtn["name"] = "timeSheet_".$entityID.$suffix;
+        $rtn["blob"] = $str;
+        $rtn["size"] = strlen($str);
+        return $rtn;
+    }
+
+    function attach_invoice($commentID, $entityID, $verbose)
+    {
+        $invoice = new invoice();
+        $invoice->set_id($entityID);
+        $invoice->select();
+        $str = $invoice->generate_invoice_file($verbose, true);
+        $rtn["name"] = "invoice_".$entityID.".pdf";
+        $rtn["blob"] = $str;
+        $rtn["size"] = strlen($str);
+        return $rtn;
+    }
+
+    function attach_tasks($commentID, $projectID, $options)
+    {
+        if ($projectID) {
+          // Begin buffering output to halt anything being sent to the web browser.
+            ob_start();
+            $t = new taskListPrint();
         
-      $defaults = array("showAssigned"=>true
+            $defaults = array("showAssigned"=>true
                        ,"showDate1"=>true
                        ,"showDate2"=>true
                        ,"showDate3"=>true
@@ -1265,125 +1312,123 @@ class comment extends db_entity {
                        ,"format"=>$options
                        );
 
-      if ($options == "pdf_plus" || $options == "html_plus") {
-        $defaults["showTimes"] = true;
-      }
+            if ($options == "pdf_plus" || $options == "html_plus") {
+                  $defaults["showTimes"] = true;
+            }
 
-      $t->get_printable_file($defaults);
+            $t->get_printable_file($defaults);
 
-      // Capture the output into $str
-      $str = (string)ob_get_clean();
+          // Capture the output into $str
+            $str = (string)ob_get_clean();
 
-      $suffix = ".html";
-      $options != "html" && $options != "html_plus" and $suffix = ".pdf";
+            $suffix = ".html";
+            $options != "html" && $options != "html_plus" and $suffix = ".pdf";
 
-      $rtn["name"] = "taskList_".$projectID.$suffix;
-      $rtn["blob"] = $str;
-      $rtn["size"] = strlen($str);
-      return $rtn;
+            $rtn["name"] = "taskList_".$projectID.$suffix;
+            $rtn["blob"] = $str;
+            $rtn["size"] = strlen($str);
+            return $rtn;
+        }
     }
-  }
 
-  function move_attachment($entity, $entityID) {
-    move_attachment($entity, $entityID);
-  }
+    function move_attachment($entity, $entityID)
+    {
+        move_attachment($entity, $entityID);
+    }
 
-  function find_email($debug=false,$get_blobs=false,$ignore_date=false) {
-    $info = inbox::get_mail_info();
-    $mailbox = $this->get_value("commentMaster").$this->get_value("commentMasterID");
-    $mail = new email_receive($info);
-    $mail->open_mailbox(config::get_config_item("allocEmailFolder")."/".$mailbox,OP_HALFOPEN+OP_READONLY);
-    $mail->check_mail();
-    $msg_nums = $mail->get_all_email_msg_uids(); 
-    $debug and print "<hr><br><b>find_email(): ".date("Y-m-d H:i:s")." found ".count($msg_nums)." emails for mailbox: ".$mailbox."</b>";
+    function find_email($debug = false, $get_blobs = false, $ignore_date = false)
+    {
+        $info = inbox::get_mail_info();
+        $mailbox = $this->get_value("commentMaster").$this->get_value("commentMasterID");
+        $mail = new email_receive($info);
+        $mail->open_mailbox(config::get_config_item("allocEmailFolder")."/".$mailbox, OP_HALFOPEN+OP_READONLY);
+        $mail->check_mail();
+        $msg_nums = $mail->get_all_email_msg_uids();
+        $debug and print "<hr><br><b>find_email(): ".date("Y-m-d H:i:s")." found ".count($msg_nums)." emails for mailbox: ".$mailbox."</b>";
 
-    // fetch and parse email
-    foreach ((array)$msg_nums as $num) {
-      $debug and print "<hr><br>Examining message number: ".$num;
-      unset($mimebits);
-      // this will stream output
-      $mail->set_msg($num);
-      $mail->get_msg_header();
-      $text = $mail->fetch_mail_text();
+      // fetch and parse email
+        foreach ((array)$msg_nums as $num) {
+            $debug and print "<hr><br>Examining message number: ".$num;
+            unset($mimebits);
+          // this will stream output
+            $mail->set_msg($num);
+            $mail->get_msg_header();
+            $text = $mail->fetch_mail_text();
 
-      list($from1,$e1n) = parse_email_address($mail->mail_headers["from"]);
-      list($from2,$e2n) = parse_email_address($this->get_value("commentCreatedUserText"));
-      if (!$from2 && $this->get_value("commentCreatedUser")) {
-        $p = new person();
-        $p->set_id($this->get_value("commentCreatedUser"));
-        $p->select();
-        $from2 = $p->get_value("emailAddress");
-      }
-      if (!$from2 && $this->get_value("commentCreatedUserClientContactID")) {
-        $p = new clientContact();
-        $p->set_id($this->get_value("commentCreatedUserClientContactID"));
-        $p->select();
-        $from2 = $p->get_value("clientContactEmail");
-      }
-      $text1 = str_replace(array("\s","\n","\r"),"",trim($text));
-      $text2 = str_replace(array("\s","\n","\r"),"",trim($this->get_value("comment")));
-      $date = format_date("U", $this->get_value("commentCreatedTime"));
-      $date1 = strtotime($mail->mail_headers["date"])-300;
-      $date3 = strtotime($mail->mail_headers["date"])+300;
+            list($from1,$e1n) = parse_email_address($mail->mail_headers["from"]);
+            list($from2,$e2n) = parse_email_address($this->get_value("commentCreatedUserText"));
+            if (!$from2 && $this->get_value("commentCreatedUser")) {
+                $p = new person();
+                $p->set_id($this->get_value("commentCreatedUser"));
+                $p->select();
+                $from2 = $p->get_value("emailAddress");
+            }
+            if (!$from2 && $this->get_value("commentCreatedUserClientContactID")) {
+                $p = new clientContact();
+                $p->set_id($this->get_value("commentCreatedUserClientContactID"));
+                $p->select();
+                $from2 = $p->get_value("clientContactEmail");
+            }
+            $text1 = str_replace(array("\s","\n","\r"), "", trim($text));
+            $text2 = str_replace(array("\s","\n","\r"), "", trim($this->get_value("comment")));
+            $date = format_date("U", $this->get_value("commentCreatedTime"));
+            $date1 = strtotime($mail->mail_headers["date"])-300;
+            $date3 = strtotime($mail->mail_headers["date"])+300;
 
-      similar_text($text1,$text2,$percent);
-      if ($percent >= 99 && ($from1 == $from2 || !$from2 || same_email_address($from1, config::get_config_item("AllocFromEmailAddress"))) && (($date > $date1 && $date < $date3)||$ignore_date)) {
-        $debug and print "<br><b style='color:green'>Found you! Msg no: ".$num." in mailbox: ".$mailbox." for commentID: ".$this->get_id()."</b>";
+            similar_text($text1, $text2, $percent);
+            if ($percent >= 99 && ($from1 == $from2 || !$from2 || same_email_address($from1, config::get_config_item("AllocFromEmailAddress"))) && (($date > $date1 && $date < $date3)||$ignore_date)) {
+                $debug and print "<br><b style='color:green'>Found you! Msg no: ".$num." in mailbox: ".$mailbox." for commentID: ".$this->get_id()."</b>";
 
-        foreach ((array)$mail->mail_parts as $v) {
-          $s = $v["part_object"]; // structure
-          $raw_data = imap_fetchbody($mail->connection, $mail->msg_uid, $v["part_number"],FT_UID | FT_PEEK);
-          $thing = $mail->decode_part($s->encoding,$raw_data);
-          $filename = $mail->get_parameter_attribute_value($s->parameters,"name");
-          $filename or $filename = $mail->get_parameter_attribute_value($s->parameters,"filename");
-          $filename or $filename = $mail->get_parameter_attribute_value($s->dparameters,"name");
-          $filename or $filename = $mail->get_parameter_attribute_value($s->dparameters,"filename");
-          $bits = array();
-          $bits["part"] = $v["part_number"];
-          $bits["name"] = $filename;
-          $bits["size"] = strlen($thing);
-          $get_blobs and $bits["blob"] = $thing;
-          $filename and $mimebits[] = $bits;
+                foreach ((array)$mail->mail_parts as $v) {
+                    $s = $v["part_object"]; // structure
+                    $raw_data = imap_fetchbody($mail->connection, $mail->msg_uid, $v["part_number"], FT_UID | FT_PEEK);
+                    $thing = $mail->decode_part($s->encoding, $raw_data);
+                    $filename = $mail->get_parameter_attribute_value($s->parameters, "name");
+                    $filename or $filename = $mail->get_parameter_attribute_value($s->parameters, "filename");
+                    $filename or $filename = $mail->get_parameter_attribute_value($s->dparameters, "name");
+                    $filename or $filename = $mail->get_parameter_attribute_value($s->dparameters, "filename");
+                    $bits = array();
+                    $bits["part"] = $v["part_number"];
+                    $bits["name"] = $filename;
+                    $bits["size"] = strlen($thing);
+                    $get_blobs and $bits["blob"] = $thing;
+                    $filename and $mimebits[] = $bits;
+                }
+                $mail->close();
+                return array($mail,$text,$mimebits);
+            } else {
+                similar_text($text1, $text2, $percent);
+                $debug and print "<br>TEXT: ".sprintf("%d", $text1 == $text2)." (".sprintf("%d", $percent)."%)";
+                #$debug and print "<br>Text1:<br>".$text1."<br>* * *<br>";
+                #$debug and print "Text2:<br>".$text2."<br>+ + +</br>";
+                $debug and print "<br>FROM: ".sprintf("%d", ($from1 == $from2 || !$from2 || same_email_address($from1, config::get_config_item("AllocFromEmailAddress"))));
+                $debug and print " From1: ".page::htmlentities($from1);
+                $debug and print " From2: ".page::htmlentities($from2);
+                $debug and print "<br>DATE: ".sprintf("%d", $date>$date1 && $date<$date3). " (".date("Y-m-d H:i:s", $date)." | ".date("Y-m-d H:i:s", $date1)." | ".date("Y-m-d H:i:s", $date3).")";
+                $debug and print "<br>";
+            }
         }
         $mail->close();
-        return array($mail,$text,$mimebits);
-      } else {
-        similar_text($text1,$text2,$percent);
-        $debug and print "<br>TEXT: ".sprintf("%d",$text1 == $text2)." (".sprintf("%d",$percent)."%)";
-        #$debug and print "<br>Text1:<br>".$text1."<br>* * *<br>";
-        #$debug and print "Text2:<br>".$text2."<br>+ + +</br>";
-        $debug and print "<br>FROM: ".sprintf("%d",($from1 == $from2 || !$from2 || same_email_address($from1, config::get_config_item("AllocFromEmailAddress"))));
-        $debug and print " From1: ".page::htmlentities($from1);
-        $debug and print " From2: ".page::htmlentities($from2);
-        $debug and print "<br>DATE: ".sprintf("%d",$date>$date1 && $date<$date3). " (".date("Y-m-d H:i:s",$date)." | ".date("Y-m-d H:i:s",$date1)." | ".date("Y-m-d H:i:s",$date3).")";
-        $debug and print "<br>";
-      }
-    }
-    $mail->close();
-    return array(false,false,false);
-  }
-
-  function update_mime_parts($commentID, $files) {
-    $x = 2; // mime part 1 will be the message text
-    foreach ((array)$files as $file) {
-      $bits = array();
-      $bits["part"] = $file["part"] or $bits["part"] = $x++;
-      $bits["name"] = $file["name"];
-      $bits["size"] = $file["size"];
-      $mimebits[] = $bits;
+        return array(false,false,false);
     }
 
-    if ($commentID && $mimebits) {
-      $comment = new comment($commentID);
-      $comment->set_value("commentMimeParts",serialize($mimebits));
-      $comment->skip_modified_fields = true;
-      $comment->updateSearchIndexLater = true;
-      $comment->save();
-    }
-  }
+    function update_mime_parts($commentID, $files)
+    {
+        $x = 2; // mime part 1 will be the message text
+        foreach ((array)$files as $file) {
+            $bits = array();
+            $bits["part"] = $file["part"] or $bits["part"] = $x++;
+            $bits["name"] = $file["name"];
+            $bits["size"] = $file["size"];
+            $mimebits[] = $bits;
+        }
 
+        if ($commentID && $mimebits) {
+            $comment = new comment($commentID);
+            $comment->set_value("commentMimeParts", serialize($mimebits));
+            $comment->skip_modified_fields = true;
+            $comment->updateSearchIndexLater = true;
+            $comment->save();
+        }
+    }
 }
-
-
-
-?>

--- a/comment/lib/commentTemplate.inc.php
+++ b/comment/lib/commentTemplate.inc.php
@@ -3,171 +3,170 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class commentTemplate extends db_entity {
-  public $data_table = "commentTemplate";
-  public $display_field_name = "commentTemplateName";
-  public $key_field = "commentTemplateID";
-  public $data_fields = array("commentTemplateName"
+class commentTemplate extends db_entity
+{
+    public $data_table = "commentTemplate";
+    public $display_field_name = "commentTemplateName";
+    public $key_field = "commentTemplateID";
+    public $data_fields = array("commentTemplateName"
                              ,"commentTemplateText"
                              ,"commentTemplateType"
                              ,"commentTemplateModifiedTime"
                              );
 
 
-  function get_populated_template($entity, $entityID=false) {
-    // Gets a populated template for this->commentTemplateName
-    $str = $this->get_value("commentTemplateText");
-    return commentTemplate::populate_string($str, $entity, $entityID);
-  }
+    function get_populated_template($entity, $entityID = false)
+    {
+      // Gets a populated template for this->commentTemplateName
+        $str = $this->get_value("commentTemplateText");
+        return commentTemplate::populate_string($str, $entity, $entityID);
+    }
 
-  function populate_string($str, $entity, $entityID=false) {
-    // Actually do the text substitution
-    $current_user = &singleton("current_user");
-    is_object($current_user) and $swap["cu"] = person::get_fullname($current_user->get_id());
+    function populate_string($str, $entity, $entityID = false)
+    {
+      // Actually do the text substitution
+        $current_user = &singleton("current_user");
+        is_object($current_user) and $swap["cu"] = person::get_fullname($current_user->get_id());
 
-    if ($entity == "timeSheet" && $entityID) {
-      $timeSheet = new timeSheet();
-      $timeSheet->set_id($entityID);
-      $timeSheet->select();
+        if ($entity == "timeSheet" && $entityID) {
+            $timeSheet = new timeSheet();
+            $timeSheet->set_id($entityID);
+            $timeSheet->select();
 
-      $timeSheet->load_pay_info();
-      foreach ($timeSheet->pay_info as $k => $v) {
-        $swap[$k] = $v;
-      }
+            $timeSheet->load_pay_info();
+            foreach ($timeSheet->pay_info as $k => $v) {
+                $swap[$k] = $v;
+            }
 
-      if ($timeSheet->get_value("approvedByManagerPersonID")) {
-        $swap["tm"] = person::get_fullname($timeSheet->get_value("approvedByManagerPersonID"));
-      } else {
-        $project = $timeSheet->get_foreign_object("project");
-        $projectManagers = $project->get_timeSheetRecipients();
-        if (is_array($projectManagers) && count($projectManagers)) {
-          $people =& get_cached_table("person");
-          foreach ($projectManagers as $pID) {
-            $swap["tm"].= $commar.$people[$pID]["name"];
-            $commar = ", ";
-          }
+            if ($timeSheet->get_value("approvedByManagerPersonID")) {
+                $swap["tm"] = person::get_fullname($timeSheet->get_value("approvedByManagerPersonID"));
+            } else {
+                $project = $timeSheet->get_foreign_object("project");
+                $projectManagers = $project->get_timeSheetRecipients();
+                if (is_array($projectManagers) && count($projectManagers)) {
+                    $people =& get_cached_table("person");
+                    foreach ($projectManagers as $pID) {
+                        $swap["tm"].= $commar.$people[$pID]["name"];
+                        $commar = ", ";
+                    }
+                }
+            }
+
+            if ($timeSheet->get_value("approvedByAdminPersonID")) {
+                $swap["tc"] = person::get_fullname($timeSheet->get_value("approvedByAdminPersonID"));
+            } else {
+                $people =& get_cached_table("person");
+                $timeSheetAdministrators = config::get_config_item('defaultTimeSheetAdminList');
+                if (count($timeSheetAdministrators)) {
+                    $swap["tc"] = "";
+                    $comma = "";
+                    foreach ($timeSheetAdministrators as $adminID) {
+                        $swap["tc"] .= $comma . $people[$adminID]["name"];
+                        $comma = ", ";
+                    }
+                } else {
+                    $swap["tc"] = 'no-one';
+                }
+            }
+
+            $swap["ti"] = $timeSheet->get_id();
+            $swap["to"] = person::get_fullname($timeSheet->get_value("personID"));
+            $swap["ta"] = person::get_fullname($timeSheet->get_value("personID"));
+            $swap["tf"] = $timeSheet->get_value("dateFrom");
+            $swap["tt"] = $timeSheet->get_value("dateTo");
+            $swap["ts"] = $timeSheet->get_timeSheet_status();
+            $swap["tu"] = config::get_config_item("allocURL")."time/timeSheet.php?timeSheetID=".$timeSheet->get_id();
+
+            $projectID = $timeSheet->get_value("projectID");
         }
-      }
 
-      if ($timeSheet->get_value("approvedByAdminPersonID")) {
-        $swap["tc"] = person::get_fullname($timeSheet->get_value("approvedByAdminPersonID"));
-      } else {
-        $people =& get_cached_table("person");
-        $timeSheetAdministrators = config::get_config_item('defaultTimeSheetAdminList');
-        if(count($timeSheetAdministrators)) {
-          $swap["tc"] = ""; $comma = "";
-          foreach($timeSheetAdministrators as $adminID) {
-            $swap["tc"] .= $comma . $people[$adminID]["name"];
-            $comma = ", ";
-          }
-        } else {
-          $swap["tc"] = 'no-one';
+        if ($entity == "task" && $entityID) {
+            $task = new task();
+            $task->set_id($entityID);
+            $task->select();
+            $swap["ti"] = $task->get_id();
+            $swap["to"] = person::get_fullname($task->get_value("creatorID"));
+            $swap["ta"] = person::get_fullname($task->get_value("personID"));
+            $swap["tm"] = person::get_fullname($task->get_value("managerID"));
+            $swap["tc"] = person::get_fullname($task->get_value("closerID"));
+            $swap["tn"] = $task->get_value("taskName");
+            $swap["td"] = $task->get_value("taskDescription");
+            $swap["tu"] = config::get_config_item("allocURL")."task/task.php?taskID=".$task->get_id();
+            $swap["tp"] = $task->get_priority_label();
+            $swap["ts"] = $task->get_task_status("label");
+
+            $swap["teb"] = $task->get_value("timeBest");
+            $swap["tem"] = $task->get_value("timeExpected");
+            $swap["tew"] = $task->get_value("timeWorst");
+            $swap["tep"] = person::get_fullname($task->get_value("estimatorID")); //time estimate person, when it's implemented
+
+            $projectID = $task->get_value("projectID");
         }
-      }
 
-      $swap["ti"] = $timeSheet->get_id();
-      $swap["to"] = person::get_fullname($timeSheet->get_value("personID"));
-      $swap["ta"] = person::get_fullname($timeSheet->get_value("personID"));
-      $swap["tf"] = $timeSheet->get_value("dateFrom");
-      $swap["tt"] = $timeSheet->get_value("dateTo");
-      $swap["ts"] = $timeSheet->get_timeSheet_status();
-      $swap["tu"] = config::get_config_item("allocURL")."time/timeSheet.php?timeSheetID=".$timeSheet->get_id();
+        if (($entity == "project" && $entityID) || $projectID) {
+            $project = new project();
+            if ($projectID) {
+                $project->set_id($projectID);
+            } else {
+                $project->set_id($entityID);
+            }
+            $project->select();
+            $swap["pn"] = $project->get_value("projectName");
+            $swap["pi"] = $project->get_id();
+            $clientID = $project->get_value("clientID");
+        }
 
-      $projectID = $timeSheet->get_value("projectID");
+        if (($entity == "client" && $entityID) || $clientID) {
+            $client = new client();
+            if ($clientID) {
+                $client->set_id($clientID);
+            } else {
+                $client->set_id($entityID);
+            }
+            $client->select();
+            $swap["li"] = $client->get_id();
+            $swap["cc"] = $client->get_value("clientName");
+        }
+
+        $swap["cd"] = config::get_config_item("companyContactAddress");
+        $swap["cd"].= " ".config::get_config_item("companyContactAddress2");
+        $swap["cd"].= " ".config::get_config_item("companyContactAddress3");
+        $swap["cd"].= "\nP: ".config::get_config_item("companyContactPhone");
+        $swap["cd"].= "\nF: ".config::get_config_item("companyContactFax");
+        $swap["cd"].= "\nE: ".config::get_config_item("companyContactEmail");
+        $swap["cd"].= "\nW: ".config::get_config_item("companyContactHomePage");
+
+        $swap["cn"] = config::get_config_item("companyName");
+
+        $swap["c1"] = config::get_config_item("companyContactAddress");
+        $swap["c2"] = config::get_config_item("companyContactAddress2");
+        $swap["c3"] = config::get_config_item("companyContactAddress3");
+        $swap["ce"] = config::get_config_item("companyContactEmail");
+        $swap["cp"] = config::get_config_item("companyContactPhone");
+        $swap["cf"] = config::get_config_item("companyContactFax");
+        $swap["cw"] = config::get_config_item("companyContactHomePage");
+
+        foreach ($swap as $k => $v) {
+            $str = str_replace("%".$k, $v, $str);
+        }
+        return $str;
     }
-
-    if ($entity == "task" && $entityID) {
-      $task = new task();
-      $task->set_id($entityID);
-      $task->select();
-      $swap["ti"] = $task->get_id();
-      $swap["to"] = person::get_fullname($task->get_value("creatorID"));
-      $swap["ta"] = person::get_fullname($task->get_value("personID"));
-      $swap["tm"] = person::get_fullname($task->get_value("managerID"));
-      $swap["tc"] = person::get_fullname($task->get_value("closerID"));
-      $swap["tn"] = $task->get_value("taskName");
-      $swap["td"] = $task->get_value("taskDescription");
-      $swap["tu"] = config::get_config_item("allocURL")."task/task.php?taskID=".$task->get_id();
-      $swap["tp"] = $task->get_priority_label();
-      $swap["ts"] = $task->get_task_status("label");
-
-      $swap["teb"] = $task->get_value("timeBest");
-      $swap["tem"] = $task->get_value("timeExpected");
-      $swap["tew"] = $task->get_value("timeWorst");
-      $swap["tep"] = person::get_fullname($task->get_value("estimatorID")); //time estimate person, when it's implemented
-
-      $projectID = $task->get_value("projectID");
-    }
-
-    if (($entity == "project" && $entityID) || $projectID) {
-      $project = new project();
-      if($projectID) {
-        $project->set_id($projectID);
-      } else {
-        $project->set_id($entityID);
-      }
-      $project->select();
-      $swap["pn"] = $project->get_value("projectName");
-      $swap["pi"] = $project->get_id();
-      $clientID = $project->get_value("clientID");
-    }
-
-    if (($entity == "client" && $entityID) || $clientID) {
-      $client = new client();
-      if($clientID) {
-        $client->set_id($clientID);
-      } else {
-        $client->set_id($entityID);
-      }
-      $client->select();
-      $swap["li"] = $client->get_id();
-      $swap["cc"] = $client->get_value("clientName");
-    }
-
-    $swap["cd"] = config::get_config_item("companyContactAddress");
-    $swap["cd"].= " ".config::get_config_item("companyContactAddress2");
-    $swap["cd"].= " ".config::get_config_item("companyContactAddress3");
-    $swap["cd"].= "\nP: ".config::get_config_item("companyContactPhone");
-    $swap["cd"].= "\nF: ".config::get_config_item("companyContactFax");
-    $swap["cd"].= "\nE: ".config::get_config_item("companyContactEmail");
-    $swap["cd"].= "\nW: ".config::get_config_item("companyContactHomePage");
-
-    $swap["cn"] = config::get_config_item("companyName");
-
-    $swap["c1"] = config::get_config_item("companyContactAddress");
-    $swap["c2"] = config::get_config_item("companyContactAddress2");
-    $swap["c3"] = config::get_config_item("companyContactAddress3");
-    $swap["ce"] = config::get_config_item("companyContactEmail");
-    $swap["cp"] = config::get_config_item("companyContactPhone");
-    $swap["cf"] = config::get_config_item("companyContactFax");
-    $swap["cw"] = config::get_config_item("companyContactHomePage");
-
-    foreach ($swap as $k => $v) {
-      $str = str_replace("%".$k,$v,$str);
-    }
-    return $str;
-  }
-
-
-
-
 }
-?>

--- a/comment/lib/init.php
+++ b/comment/lib/init.php
@@ -3,26 +3,26 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class comment_module extends module {
-  var $module = "comment";
-  var $db_entities = array("comment","commentTemplate");
+class comment_module extends module
+{
+    var $module = "comment";
+    var $db_entities = array("comment","commentTemplate");
 }
-?>

--- a/comment/summary.php
+++ b/comment/summary.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -24,12 +24,10 @@
 require_once("../alloc.php");
 
 if ($_REQUEST["filter"]) {
-  $current_user->prefs["comment_summary_list"] = $_REQUEST;
+    $current_user->prefs["comment_summary_list"] = $_REQUEST;
 } else {
-  $_REQUEST = $current_user->prefs["comment_summary_list"];
+    $_REQUEST = $current_user->prefs["comment_summary_list"];
 }
 
 $TPL["main_alloc_title"] = "Task Comment Summary";
 include_template("templates/summaryM.tpl");
-
-?>

--- a/comment/updateCommentTemplate.php
+++ b/comment/updateCommentTemplate.php
@@ -3,38 +3,34 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 if ($_GET["commentTemplateID"] && $_GET["commentTemplateID"] != "undefined" && $_GET["entity"] && $_GET["entityID"]) {
-  $commentTemplate = new commentTemplate();
-  $commentTemplate->set_id($_GET["commentTemplateID"]);
-  $commentTemplate->select();
-  $val = $commentTemplate->get_populated_template($_GET["entity"], $_GET["entityID"]);
-  echo page::textarea("comment",$val,array("height"=>"medium","width"=>"100%"));
+    $commentTemplate = new commentTemplate();
+    $commentTemplate->set_id($_GET["commentTemplateID"]);
+    $commentTemplate->select();
+    $val = $commentTemplate->get_populated_template($_GET["entity"], $_GET["entityID"]);
+    echo page::textarea("comment", $val, array("height"=>"medium","width"=>"100%"));
 } else {
-  echo page::textarea("comment",$val,array("height"=>"medium","width"=>"100%"));
+    echo page::textarea("comment", $val, array("height"=>"medium","width"=>"100%"));
 }
 
 echo "<script>$('textarea:not(.processed)').TextAreaResizer();</script>";
-
-
-
-?>

--- a/comment/updateRecipients.php
+++ b/comment/updateRecipients.php
@@ -3,33 +3,30 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
-interestedParty::make_interested_parties('comment',$_POST['commentID'],$_POST['comment_recipients']);
+interestedParty::make_interested_parties('comment', $_POST['commentID'], $_POST['comment_recipients']);
 
-if (interestedParty::is_external('comment',$_POST['commentID'])) {
-  echo 'external';
+if (interestedParty::is_external('comment', $_POST['commentID'])) {
+    echo 'external';
 } else {
-  echo 'internal';
+    echo 'internal';
 }
-
-
-?>

--- a/config/config.php
+++ b/config/config.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,169 +23,163 @@
 require_once("../alloc.php");
 
 if (!have_entity_perm("config", PERM_UPDATE, $current_user, true)) {
-  alloc_error("Permission denied.",true);
+    alloc_error("Permission denied.", true);
 }
 
 if ($_POST["test_email_gateway"]) {
-  $info["host"] = config::get_config_item("allocEmailHost");
-  $info["port"] = config::get_config_item("allocEmailPort");
-  $info["username"] = config::get_config_item("allocEmailUsername");
-  $info["password"] = config::get_config_item("allocEmailPassword");
-  $info["protocol"] = config::get_config_item("allocEmailProtocol");
+    $info["host"] = config::get_config_item("allocEmailHost");
+    $info["port"] = config::get_config_item("allocEmailPort");
+    $info["username"] = config::get_config_item("allocEmailUsername");
+    $info["password"] = config::get_config_item("allocEmailPassword");
+    $info["protocol"] = config::get_config_item("allocEmailProtocol");
 
-  if (!$info["host"]) {
-    alloc_error("Email mailbox host not defined, assuming email receive function is inactive.");
-  } else {
-    $mail = new email_receive($info,$lockfile);
-    $mail->open_mailbox(config::get_config_item("allocEmailFolder"));
-    $mail->check_mail();
-    $TPL["message_good"][] = "Connection succeeded!";
-  }
-
+    if (!$info["host"]) {
+        alloc_error("Email mailbox host not defined, assuming email receive function is inactive.");
+    } else {
+        $mail = new email_receive($info, $lockfile);
+        $mail->open_mailbox(config::get_config_item("allocEmailFolder"));
+        $mail->check_mail();
+        $TPL["message_good"][] = "Connection succeeded!";
+    }
 }
 
 
 $db = new db_alloc();
 $db->query("SELECT name,value,type FROM config");
 while ($db->next_record()) {
-  $fields_to_save[] = $db->f("name");
-  $types[$db->f("name")] = $db->f("type");
+    $fields_to_save[] = $db->f("name");
+    $types[$db->f("name")] = $db->f("type");
 
-  if ($db->f("type") == "text") {
-    $TPL[$db->f("name")] = page::htmlentities($db->f("value"));
-
-  } else if ($db->f("type") == "array") {
-    $TPL[$db->f("name")] = unserialize($db->f("value"));
-  }
+    if ($db->f("type") == "text") {
+        $TPL[$db->f("name")] = page::htmlentities($db->f("value"));
+    } else if ($db->f("type") == "array") {
+        $TPL[$db->f("name")] = unserialize($db->f("value"));
+    }
 }
 
 
 #echo "<pre>".print_r($_POST,1)."</pre>";
 
 if ($_POST["update_currencyless_transactions"] && $_POST["currency"]) {
-  $db = new db_alloc();
-  $q = prepare("UPDATE transaction SET currencyTypeID = '%s' WHERE currencyTypeID IS NULL",$_POST["currency"]);
-  $db->query($q);
-  $q = prepare("UPDATE transactionRepeat SET currencyTypeID = '%s' WHERE currencyTypeID IS NULL",$_POST["currency"]);
-  $db->query($q);
-  $q = prepare("UPDATE product SET sellPriceCurrencyTypeID = '%s' WHERE sellPriceCurrencyTypeID IS NULL",$_POST["currency"]);
-  $db->query($q);
-  $q = prepare("UPDATE productCost SET currencyTypeID = '%s' WHERE currencyTypeID IS NULL",$_POST["currency"]);
-  $db->query($q);
-  $q = prepare("UPDATE productSaleItem SET sellPriceCurrencyTypeID = '%s' WHERE sellPriceCurrencyTypeID IS NULL",$_POST["currency"]);
-  $db->query($q);
-  $q = prepare("UPDATE project SET currencyTypeID = '%s' WHERE currencyTypeID IS NULL",$_POST["currency"]);
-  $db->query($q);
-  $q = prepare("UPDATE timeSheet SET currencyTypeID = '%s' WHERE currencyTypeID IS NULL",$_POST["currency"]);
-  $db->query($q);
-  $q = prepare("UPDATE invoice SET invoice.currencyTypeID = '%s' WHERE invoice.currencyTypeID IS NULL",$_POST["currency"]);
-  $db->query($q);
+    $db = new db_alloc();
+    $q = prepare("UPDATE transaction SET currencyTypeID = '%s' WHERE currencyTypeID IS NULL", $_POST["currency"]);
+    $db->query($q);
+    $q = prepare("UPDATE transactionRepeat SET currencyTypeID = '%s' WHERE currencyTypeID IS NULL", $_POST["currency"]);
+    $db->query($q);
+    $q = prepare("UPDATE product SET sellPriceCurrencyTypeID = '%s' WHERE sellPriceCurrencyTypeID IS NULL", $_POST["currency"]);
+    $db->query($q);
+    $q = prepare("UPDATE productCost SET currencyTypeID = '%s' WHERE currencyTypeID IS NULL", $_POST["currency"]);
+    $db->query($q);
+    $q = prepare("UPDATE productSaleItem SET sellPriceCurrencyTypeID = '%s' WHERE sellPriceCurrencyTypeID IS NULL", $_POST["currency"]);
+    $db->query($q);
+    $q = prepare("UPDATE project SET currencyTypeID = '%s' WHERE currencyTypeID IS NULL", $_POST["currency"]);
+    $db->query($q);
+    $q = prepare("UPDATE timeSheet SET currencyTypeID = '%s' WHERE currencyTypeID IS NULL", $_POST["currency"]);
+    $db->query($q);
+    $q = prepare("UPDATE invoice SET invoice.currencyTypeID = '%s' WHERE invoice.currencyTypeID IS NULL", $_POST["currency"]);
+    $db->query($q);
 
   // Update currencyType table too
-  $q = prepare("UPDATE currencyType SET currencyTypeSeq = 1, currencyTypeActive = true WHERE currencyTypeID = '%s'",$_POST["currency"]);
-  $db->query($q);
-  $_POST["save"] = true;
+    $q = prepare("UPDATE currencyType SET currencyTypeSeq = 1, currencyTypeActive = true WHERE currencyTypeID = '%s'", $_POST["currency"]);
+    $db->query($q);
+    $_POST["save"] = true;
 }
 
 if ($_POST["fetch_exchange_rates"]) {
-  $rtn = exchangeRate::download();
-  $rtn and $TPL["message_good"] = $rtn;
+    $rtn = exchangeRate::download();
+    $rtn and $TPL["message_good"] = $rtn;
 }
 
 
 
 
 if ($_POST["save"]) {
-
-  if ($_POST["hoursInDay"]) {
-    $db = new db_alloc();
-    $day = $_POST["hoursInDay"]*60*60;
-    $q = prepare("UPDATE timeUnit SET timeUnitSeconds = '%d' WHERE timeUnitName = 'day'",$day);
-    $db->query($q);
-    $q = prepare("UPDATE timeUnit SET timeUnitSeconds = '%d' WHERE timeUnitName = 'week'",($day*5));
-    $db->query($q);
-    $q = prepare("UPDATE timeUnit SET timeUnitSeconds = '%d' WHERE timeUnitName = 'month'",(($day*5)*4));
-    $db->query($q);
-  }
+    if ($_POST["hoursInDay"]) {
+        $db = new db_alloc();
+        $day = $_POST["hoursInDay"]*60*60;
+        $q = prepare("UPDATE timeUnit SET timeUnitSeconds = '%d' WHERE timeUnitName = 'day'", $day);
+        $db->query($q);
+        $q = prepare("UPDATE timeUnit SET timeUnitSeconds = '%d' WHERE timeUnitName = 'week'", ($day*5));
+        $db->query($q);
+        $q = prepare("UPDATE timeUnit SET timeUnitSeconds = '%d' WHERE timeUnitName = 'month'", (($day*5)*4));
+        $db->query($q);
+    }
 
   // remove bracketed [Alex Lance <]alla@cyber.com.au[>] bits, leaving just alla@cyber.com.au
-  if ($_POST["AllocFromEmailAddress"]) {
-    $_POST["AllocFromEmailAddress"] = preg_replace("/^.*</","",$_POST["AllocFromEmailAddress"]);
-    $_POST["AllocFromEmailAddress"] = str_replace(">","",$_POST["AllocFromEmailAddress"]);
-  }
+    if ($_POST["AllocFromEmailAddress"]) {
+        $_POST["AllocFromEmailAddress"] = preg_replace("/^.*</", "", $_POST["AllocFromEmailAddress"]);
+        $_POST["AllocFromEmailAddress"] = str_replace(">", "", $_POST["AllocFromEmailAddress"]);
+    }
 
   // Save the companyLogo and a smaller version too.
-  if ($_FILES["companyLogo"] && !$_FILES["companyLogo"]["error"]) {
-    $img = image_create_from_file($_FILES["companyLogo"]["tmp_name"]);
-    if ($img) {
-      imagejpeg($img, ALLOC_LOGO, 100);
-      $x = imagesx($img);
-      $y = imagesy($img);
-      $save = imagecreatetruecolor($x/($y/40), $y/($y/40));
-      imagecopyresized($save, $img, 0, 0, 0, 0, imagesx($save), imagesy($save), $x, $y);
-      imagejpeg($save, ALLOC_LOGO_SMALL, 100);
-    }
-  }
-
-  foreach ($_POST as $name => $value) {
-
-    if (in_array($name,$fields_to_save)) {
-
-      $id = config::get_config_item_id($name);
-      $c = new config();
-      $c->set_id($id);
-      $c->select();
-
-      if ($types[$name] == "text") {
-        //current special case for the only money field
-        if ($name == "defaultTimeSheetRate") {
-          $value = page::money(0, $_POST[$name], "%mi");
-          $c->set_value("value",$value);
-        } else {
-          $c->set_value("value",$_POST[$name]);
+    if ($_FILES["companyLogo"] && !$_FILES["companyLogo"]["error"]) {
+        $img = image_create_from_file($_FILES["companyLogo"]["tmp_name"]);
+        if ($img) {
+            imagejpeg($img, ALLOC_LOGO, 100);
+            $x = imagesx($img);
+            $y = imagesy($img);
+            $save = imagecreatetruecolor($x/($y/40), $y/($y/40));
+            imagecopyresized($save, $img, 0, 0, 0, 0, imagesx($save), imagesy($save), $x, $y);
+            imagejpeg($save, ALLOC_LOGO_SMALL, 100);
         }
-        $TPL[$name] = page::htmlentities($value);
-      } else if ($types[$name] == "array") {
-        $c->set_value("value",serialize($_POST[$name]));
-        $TPL[$name] = $_POST[$name];
-      }
-      $c->save();
-      $TPL["message_good"] = "Saved configuration.";
     }
-  }
 
-  // Handle the only checkbox specially. If more checkboxes are added this 
+    foreach ($_POST as $name => $value) {
+        if (in_array($name, $fields_to_save)) {
+            $id = config::get_config_item_id($name);
+            $c = new config();
+            $c->set_id($id);
+            $c->select();
+
+            if ($types[$name] == "text") {
+                //current special case for the only money field
+                if ($name == "defaultTimeSheetRate") {
+                    $value = page::money(0, $_POST[$name], "%mi");
+                    $c->set_value("value", $value);
+                } else {
+                    $c->set_value("value", $_POST[$name]);
+                }
+                $TPL[$name] = page::htmlentities($value);
+            } else if ($types[$name] == "array") {
+                $c->set_value("value", serialize($_POST[$name]));
+                $TPL[$name] = $_POST[$name];
+            }
+            $c->save();
+            $TPL["message_good"] = "Saved configuration.";
+        }
+    }
+
+  // Handle the only checkbox specially. If more checkboxes are added this
   // should be rewritten.
   #echo var_dump($_POST);
-  if ($_POST['sbs_link'] == "rss" && !$_POST['rssShowProject']) {
-    $c = new config();
-    $c->set_id(config::get_config_item_id('rssShowProject'));
-    $c->select();
-    $c->set_value("value", '0');
-    $c->save();
-  }
+    if ($_POST['sbs_link'] == "rss" && !$_POST['rssShowProject']) {
+        $c = new config();
+        $c->set_id(config::get_config_item_id('rssShowProject'));
+        $c->select();
+        $c->set_value("value", '0');
+        $c->save();
+    }
 
-  $TPL["message"] or $TPL["message_good"] = "Saved configuration.";
-
+    $TPL["message"] or $TPL["message_good"] = "Saved configuration.";
 } else if ($_POST["delete_logo"]) {
-  foreach (array(ALLOC_LOGO,ALLOC_LOGO_SMALL) as $logo) {
-    if (file_exists($logo)) {
-      if (unlink($logo)) {
-        $TPL["message_good"][] = "Deleted ".$logo;
-      }
+    foreach (array(ALLOC_LOGO,ALLOC_LOGO_SMALL) as $logo) {
+        if (file_exists($logo)) {
+            if (unlink($logo)) {
+                $TPL["message_good"][] = "Deleted ".$logo;
+            }
+        }
+        if (file_exists($logo)) {
+            alloc_error("Unable to delete ".$logo);
+        }
     }
-    if (file_exists($logo)) {
-      alloc_error("Unable to delete ".$logo);
-    }
-  }
 }
 
 
-get_cached_table("config",true); // flush cache
+get_cached_table("config", true); // flush cache
 
 if (has("finance")) {
-  $tf = new tf();
-  $options = $tf->get_assoc_array("tfID","tfName");
+    $tf = new tf();
+    $options = $tf->get_assoc_array("tfID", "tfName");
 }
 $TPL["mainTfOptions"] = page::select_options($options, config::get_config_item("mainTfID"));
 $TPL["outTfOptions"] = page::select_options($options, config::get_config_item("outTfID"));
@@ -209,7 +203,7 @@ $selected_tabops = config::get_config_item("allocTabs") or $selected_tabops = ar
 $TPL["allocTabsOptions"] = page::select_options($tabops, $selected_tabops);
 
 $m = new meta("currencyType");
-$currencyOptions = $m->get_assoc_array("currencyTypeID","currencyTypeName");
+$currencyOptions = $m->get_assoc_array("currencyTypeID", "currencyTypeName");
 $TPL["currencyOptions"] = page::select_options($currencyOptions, config::get_config_item("currency"));
 
 $db = new db_alloc();
@@ -219,7 +213,7 @@ $display = array("", "username", ", ", "emailAddress");
 $person = new person();
 $people =& get_cached_table("person");
 foreach ($people as $p) {
-  $peeps[$p["personID"]] = $p["name"];
+    $peeps[$p["personID"]] = $p["name"];
 }
 
 // get the default time sheet manager/admin options
@@ -227,35 +221,34 @@ $TPL["defaultTimeSheetManagerListText"] = get_person_list(config::get_config_ite
 $TPL["defaultTimeSheetAdminListText"] = get_person_list(config::get_config_item("defaultTimeSheetAdminList"));
 
 $days =  array("Sun"=>"Sun","Mon"=>"Mon","Tue"=>"Tue","Wed"=>"Wed","Thu"=>"Thu","Fri"=>"Fri","Sat"=>"Sat");
-$TPL["calendarFirstDayOptions"] = page::select_options($days,config::get_config_item("calendarFirstDay"));
+$TPL["calendarFirstDayOptions"] = page::select_options($days, config::get_config_item("calendarFirstDay"));
 
-$TPL["timeSheetPrintOptions"] = page::select_options($TPL["timeSheetPrintOptions"],$TPL["timeSheetPrint"]);
+$TPL["timeSheetPrintOptions"] = page::select_options($TPL["timeSheetPrintOptions"], $TPL["timeSheetPrint"]);
 
 $commentTemplate = new commentTemplate();
-$ops = $commentTemplate->get_assoc_array("commentTemplateID","commentTemplateName");
+$ops = $commentTemplate->get_assoc_array("commentTemplateID", "commentTemplateName");
 
 $TPL["rssStatusFilterOptions"] = page::select_options(task::get_task_statii_array(true), config::get_config_item("rssStatusFilter"));
 
 if (has("timeUnit")) {
-  $timeUnit = new timeUnit();
-  $rate_type_array = $timeUnit->get_assoc_array("timeUnitID","timeUnitLabelB");
+    $timeUnit = new timeUnit();
+    $rate_type_array = $timeUnit->get_assoc_array("timeUnitID", "timeUnitLabelB");
 }
 $TPL["timesheetRate_options"] = page::select_options($rate_type_array, config::get_config_item("defaultTimeSheetUnit"));
 
 $TPL["main_alloc_title"] = "Setup - ".APPLICATION_NAME;
 include_template("templates/configM.tpl");
 
-function get_person_list($personID_array) {
-  global $peeps;
-  $people = array();
-  foreach($personID_array as $personID) {
-    $people[] = $peeps[$personID];
-  }
-  if(count($people) > 0) {
-    return implode(", ", $people);
-  } else {
-    return "<i>none</i>";
-  }
+function get_person_list($personID_array)
+{
+    global $peeps;
+    $people = array();
+    foreach ($personID_array as $personID) {
+        $people[] = $peeps[$personID];
+    }
+    if (count($people) > 0) {
+        return implode(", ", $people);
+    } else {
+        return "<i>none</i>";
+    }
 }
-
-?>

--- a/config/configEdit.php
+++ b/config/configEdit.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,7 +23,7 @@
 require_once("../alloc.php");
 
 if (!have_entity_perm("config", PERM_UPDATE, $current_user, true)) {
-  alloc_error("Permission denied.",true);
+    alloc_error("Permission denied.", true);
 }
 
 $configName = $_POST["configName"] or $configName = $_GET["configName"];
@@ -33,50 +33,42 @@ $configType = $_POST["configType"] or $configType = $_GET["configType"] or $conf
 $TPL["configType"] = $configType;
 
 if ($configName) {
-  $config = new config();
-  $id = config::get_config_item_id($configName);
-  $config->set_id($id);  
-  $config->select();  
+    $config = new config();
+    $id = config::get_config_item_id($configName);
+    $config->set_id($id);
+    $config->select();
 }
 
 if ($_POST["save"]) {
-
-  if($configType == "people") {
-    $arr = config::get_config_item($configName);
-    if(!in_array($_POST['value'], $arr)) {
-      $arr[] = $_POST["value"];
-      $config->set_value("value",serialize($arr));
-      $config->save();
+    if ($configType == "people") {
+        $arr = config::get_config_item($configName);
+        if (!in_array($_POST['value'], $arr)) {
+            $arr[] = $_POST["value"];
+            $config->set_value("value", serialize($arr));
+            $config->save();
+        }
+    } else {
+        $arr = config::get_config_item($configName);
+        $arr[$_POST["key"]] = $_POST["value"];
+        $config->set_value("value", serialize($arr));
+        $config->save();
     }
-  } else {
-    $arr = config::get_config_item($configName);
-    $arr[$_POST["key"]] = $_POST["value"];
-    $config->set_value("value",serialize($arr));
-    $config->save();
-  }
-
 } else if ($_POST["delete"]) {
-
-  $arr = config::get_config_item($configName);
-  if($configType == "people") {
-    unset($arr[array_search($_POST["value"], $arr)]);
-  } else {
-    unset($arr[$_POST["key"]]);
-  }
-  $config->set_value("value",serialize($arr));
-  $config->save();
+    $arr = config::get_config_item($configName);
+    if ($configType == "people") {
+        unset($arr[array_search($_POST["value"], $arr)]);
+    } else {
+        unset($arr[$_POST["key"]]);
+    }
+    $config->set_value("value", serialize($arr));
+    $config->save();
 }
 
 
 if (file_exists("templates/configEdit_".$configName.".tpl")) {
-  include_template("templates/configEdit_".$configName.".tpl");
-} elseif (file_exists("templates/configEdit_".$configType.".tpl")) {
-  include_template("templates/configEdit_".$configType.".tpl");
+    include_template("templates/configEdit_".$configName.".tpl");
+} else if (file_exists("templates/configEdit_".$configType.".tpl")) {
+    include_template("templates/configEdit_".$configType.".tpl");
 } else {
-  include_template("templates/configEdit.tpl");
+    include_template("templates/configEdit.tpl");
 }
-
-
-
-
-?>

--- a/config/lib/config.inc.php
+++ b/config/lib/config.inc.php
@@ -3,68 +3,67 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class config extends db_entity {
-  public $data_table = "config";
-  public $key_field = "configID";
-  public $data_fields = array("name"
+class config extends db_entity
+{
+    public $data_table = "config";
+    public $key_field = "configID";
+    public $data_fields = array("name"
                              ,"value"
                              ,"type"
                              );
 
-  public static function get_config_item($name='',$anew=false) {
-    $table =& get_cached_table("config",$anew);
-    if ($table[$name]["type"] == "array") {
-      $val = unserialize($table[$name]["value"]) or $val = array();
-      return $val;
-
-    } else if ($table[$name]["type"] == "text") {
-      $val = $table[$name]["value"];
-      return $val;
+    public static function get_config_item($name = '', $anew = false)
+    {
+        $table =& get_cached_table("config", $anew);
+        if ($table[$name]["type"] == "array") {
+            $val = unserialize($table[$name]["value"]) or $val = array();
+            return $val;
+        } else if ($table[$name]["type"] == "text") {
+            $val = $table[$name]["value"];
+            return $val;
+        }
     }
-  }
 
-  public static function get_config_item_id($name='') {
-    $db = new db_alloc();
-    $db->query(prepare("SELECT configID FROM config WHERE name = '%s'",$name));
-    $db->next_record();
-    return $db->f('configID');
-  }
-
-  public static function get_config_logo($anew=false) {
-    global $TPL;
-    $table =& get_cached_table("config",$anew);
-    $val = '';
-    if(file_exists(ALLOC_LOGO)) {
-      $val = '<img src="'.$TPL["url_alloc_logo"].'type=small" alt="'.$table['companyName']['value'].'" />';
-    } else {
-      $val = $table['companyName']['value'];
+    public static function get_config_item_id($name = '')
+    {
+        $db = new db_alloc();
+        $db->query(prepare("SELECT configID FROM config WHERE name = '%s'", $name));
+        $db->next_record();
+        return $db->f('configID');
     }
-    return $val;
-  }
 
-  public static function for_cyber() {
-    return config::get_config_item("companyHandle") == "cybersource";
-  }
+    public static function get_config_logo($anew = false)
+    {
+        global $TPL;
+        $table =& get_cached_table("config", $anew);
+        $val = '';
+        if (file_exists(ALLOC_LOGO)) {
+            $val = '<img src="'.$TPL["url_alloc_logo"].'type=small" alt="'.$table['companyName']['value'].'" />';
+        } else {
+            $val = $table['companyName']['value'];
+        }
+        return $val;
+    }
 
+    public static function for_cyber()
+    {
+        return config::get_config_item("companyHandle") == "cybersource";
+    }
 }
-
-
-
-?>

--- a/config/lib/init.php
+++ b/config/lib/init.php
@@ -3,26 +3,26 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class config_module extends module {
-  var $module = "config";
-  var $db_entities = array("config");
+class config_module extends module
+{
+    var $module = "config";
+    var $db_entities = array("config");
 }
-?>

--- a/config/metaEdit.php
+++ b/config/metaEdit.php
@@ -23,7 +23,7 @@
 require_once("../alloc.php");
 
 if (!have_entity_perm("config", PERM_UPDATE, $current_user, true)) {
-  alloc_error("Permission denied.",true);
+    alloc_error("Permission denied.", true);
 }
 
 $table = $_POST["configName"] or $table = $_GET["configName"];
@@ -31,18 +31,16 @@ $TPL["table"] = $table;
 
 
 if ($_POST["save"]) {
+    foreach ((array)$_POST[$table."ID"] as $k => $tableID) {
+      // Delete
+        if (in_array($tableID, (array)$_POST["delete"])) {
+            $t = new meta($table);
+            $t->set_id($tableID);
+            $t->delete();
 
-  foreach ((array)$_POST[$table."ID"] as $k => $tableID) {
-    // Delete
-    if (in_array($tableID, (array)$_POST["delete"])) {
-      $t = new meta($table);
-      $t->set_id($tableID);
-      $t->delete();
-
-    // Save
-    } else {
-
-      $a = array($table."ID"     => $tableID
+        // Save
+        } else {
+            $a = array($table."ID"     => $tableID
                 ,$table."Seq"    => $_POST[$table."Seq"][$k]
                 ,$table."Label"  => $_POST[$table."Label"][$k]
                 ,$table."Name"   => $_POST[$table."Name"][$k]
@@ -52,31 +50,25 @@ if ($_POST["save"]) {
                 ,$table."Active" => in_array($tableID, $_POST[$table."Active"])
                 );
 
-      $orig_tableID = $_POST[$table."IDOrig"][$k];
-      $t = new meta($table);
-      $t->read_array($a);
-      $errs = $t->validate();
-      if (!$errs) {
-        if ($orig_tableID && $orig_tableID != $tableID) {
-          $a[$table."Active"] = in_array($orig_tableID, $_POST[$table."Active"]);
-          $t->read_array($a);
-          $t->set_id($orig_tableID);
-          $k = new db_field($table."ID"); // If the primary key has changed, then it needs special handling.
-          $k->set_value($tableID);        // The primary keys in the referential integrity tables are not 
-          $t->data_fields[] = $k;         // usually just auto-incrementing IDs like every other table in alloc
-          $t->update();                   // So we have to trick db_entity into letting us update a primary key.
-        } else {
-          $t->save();
+            $orig_tableID = $_POST[$table."IDOrig"][$k];
+            $t = new meta($table);
+            $t->read_array($a);
+            $errs = $t->validate();
+            if (!$errs) {
+                if ($orig_tableID && $orig_tableID != $tableID) {
+                    $a[$table."Active"] = in_array($orig_tableID, $_POST[$table."Active"]);
+                    $t->read_array($a);
+                    $t->set_id($orig_tableID);
+                    $k = new db_field($table."ID"); // If the primary key has changed, then it needs special handling.
+                    $k->set_value($tableID);        // The primary keys in the referential integrity tables are not
+                    $t->data_fields[] = $k;         // usually just auto-incrementing IDs like every other table in alloc
+                    $t->update();                   // So we have to trick db_entity into letting us update a primary key.
+                } else {
+                    $t->save();
+                }
+            }
         }
-      }
     }
-  }
-
 }
 
 include_template("templates/metaEdit.tpl");
-
-
-
-
-?>

--- a/email/downloadComments.php
+++ b/email/downloadComments.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,11 +23,9 @@
 require_once("../alloc.php");
 
 if ($_REQUEST["entity"] && $_REQUEST["entityID"]) {
-  $s = new services();
-  $emails = $s->get_task_emails($_REQUEST["entityID"],$_REQUEST["entity"]);
-  $_REQUEST["entity"] == "task" and $emails .= "\n\n".$s->get_timeSheetItem_comments($_REQUEST["entityID"]);
-  header('Content-Type: text/plain; charset=utf-8');
-  echo ltrim($emails);
+    $s = new services();
+    $emails = $s->get_task_emails($_REQUEST["entityID"], $_REQUEST["entity"]);
+    $_REQUEST["entity"] == "task" and $emails .= "\n\n".$s->get_timeSheetItem_comments($_REQUEST["entityID"]);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo ltrim($emails);
 }
-
-?>

--- a/email/downloadEmail.php
+++ b/email/downloadEmail.php
@@ -3,29 +3,30 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function dump_email($uid,$mail) {
-  if ($uid) {
-    exit();
-  }
+function dump_email($uid, $mail)
+{
+    if ($uid) {
+        exit();
+    }
 }
 
 
@@ -39,57 +40,57 @@ $info["password"] = config::get_config_item("allocEmailPassword");
 $info["protocol"] = config::get_config_item("allocEmailProtocol");
 
 if (!$info["host"]) {
-  alloc_error("Email mailbox host not defined, assuming email fetch function is inactive.",true);
+    alloc_error("Email mailbox host not defined, assuming email fetch function is inactive.", true);
 }
 
 if ($_REQUEST["commentID"]) {
-  $c = new comment();
-  $c->set_id($_REQUEST["commentID"]);
-  $c->select();
+    $c = new comment();
+    $c->set_id($_REQUEST["commentID"]);
+    $c->select();
 
-  $entity = $c->get_value("commentMaster");
-  $entityID = $c->get_value("commentMasterID");
+    $entity = $c->get_value("commentMaster");
+    $entityID = $c->get_value("commentMasterID");
 
-  $mail = new email_receive($info);
-  $mail->open_mailbox(config::get_config_item("allocEmailFolder")."/".$entity.$entityID);
+    $mail = new email_receive($info);
+    $mail->open_mailbox(config::get_config_item("allocEmailFolder")."/".$entity.$entityID);
 
-  if ($_REQUEST["uid"]) {
-    header('Content-Type: text/plain; charset=utf-8');
-    list($h,$b) = $mail->get_raw_email_by_msg_uid($_REQUEST["uid"]);
-    $mail->close();
-    echo $h.$b;
-    exit();
-  }
+    if ($_REQUEST["uid"]) {
+        header('Content-Type: text/plain; charset=utf-8');
+        list($h,$b) = $mail->get_raw_email_by_msg_uid($_REQUEST["uid"]);
+        $mail->close();
+        echo $h.$b;
+        exit();
+    }
 
   //$uids = $mail->get_all_email_msg_uids();
 
-  $t = new token();
-  $t->select_token_by_entity_and_action($c->get_value("commentType"),$c->get_value("commentLinkID"),"add_comment_from_email");
-  $hash = $t->get_value("tokenHash");
+    $t = new token();
+    $t->select_token_by_entity_and_action($c->get_value("commentType"), $c->get_value("commentLinkID"), "add_comment_from_email");
+    $hash = $t->get_value("tokenHash");
 
   // First try a messageID search
-  if ($c->get_value("commentEmailMessageID")) {
-    $str = sprintf('TEXT "%s"',$c->get_value("commentEmailMessageID"));
-    $uids = $mail->get_emails_UIDs_search($str);
-    if (count($uids) == 1) {
-      alloc_redirect($TPL["url_alloc_downloadEmail"]."commentID=".$_REQUEST["commentID"]."&uid=".$uids[0]);
-    } else if (count($uids) > 1) {
-      $all_uids += $uids;
+    if ($c->get_value("commentEmailMessageID")) {
+        $str = sprintf('TEXT "%s"', $c->get_value("commentEmailMessageID"));
+        $uids = $mail->get_emails_UIDs_search($str);
+        if (count($uids) == 1) {
+            alloc_redirect($TPL["url_alloc_downloadEmail"]."commentID=".$_REQUEST["commentID"]."&uid=".$uids[0]);
+        } else if (count($uids) > 1) {
+            $all_uids += $uids;
+        }
     }
-  }
 
   // Next try a hash lookup
-  if ($hash) {
-    $str = sprintf('TEXT "%s"',$hash);
+    if ($hash) {
+        $str = sprintf('TEXT "%s"', $hash);
+        $uids = $mail->get_emails_UIDs_search($str);
+        $uids and $all_uids += $uids;
+    }
+
+
+    $str = sprintf('FROM "%s" ', $c->get_value("commentCreatedUserText"));
+    $str.= sprintf(' ON "%s"', format_date("d-M-Y", $c->get_value("commentCreatedTime")));
     $uids = $mail->get_emails_UIDs_search($str);
     $uids and $all_uids += $uids;
-  }
-
-
-  $str = sprintf('FROM "%s" ',$c->get_value("commentCreatedUserText"));
-  $str.= sprintf(' ON "%s"',format_date("d-M-Y",$c->get_value("commentCreatedTime")));
-  $uids = $mail->get_emails_UIDs_search($str);
-  $uids and $all_uids += $uids;
 
 
   // Couldn't get a body text search to work! Refuses to match long needles.
@@ -106,7 +107,5 @@ if ($_REQUEST["commentID"]) {
   //$uids = $mail->get_emails_UIDs_search($str);
   //echo "<br><br>Using BODY:".print_r($uids,1);
 
-  $mail->close();
+    $mail->close();
 }
-
-?>

--- a/email/fetchBody.php
+++ b/email/fetchBody.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -29,18 +29,16 @@ $info["password"] = config::get_config_item("allocEmailPassword");
 $info["protocol"] = config::get_config_item("allocEmailProtocol");
 
 if (!$info["host"]) {
-  alloc_error("Email mailbox host not defined, assuming email function is inactive.",true);
+    alloc_error("Email mailbox host not defined, assuming email function is inactive.", true);
 }
 
 $email_receive = new email_receive($info);
-$email_receive->open_mailbox(config::get_config_item("allocEmailFolder"),OP_HALFOPEN | OP_READONLY);
+$email_receive->open_mailbox(config::get_config_item("allocEmailFolder"), OP_HALFOPEN | OP_READONLY);
 $email_receive->set_msg($_REQUEST["id"]);
 $new_nums = $email_receive->get_new_email_msg_uids();
-in_array($_REQUEST["id"],(array)$new_nums) and $new = true;
+in_array($_REQUEST["id"], (array)$new_nums) and $new = true;
 $mail_text = $email_receive->fetch_mail_text();
 $new and $email_receive->set_unread(); // might have to "unread" the email, if it was new, i.e. set it back to new
 $email_receive->close();
 
 echo nl2br(trim(page::htmlentities($mail_text)));
-
-?>

--- a/email/inbox.php
+++ b/email/inbox.php
@@ -3,55 +3,51 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
-singleton("errors_thrown",true);
+singleton("errors_thrown", true);
 
-if (!have_entity_perm("inbox",PERM_READ,$current_user)) {
-  alloc_error("Permission denied.",true);
+if (!have_entity_perm("inbox", PERM_READ, $current_user)) {
+    alloc_error("Permission denied.", true);
 }
 
 $info = inbox::get_mail_info();
 
 if (!$info["host"]) {
-  alloc_error("Email mailbox host not defined, assuming email function is inactive.",true);
+    alloc_error("Email mailbox host not defined, assuming email function is inactive.", true);
 }
 
-if ($_REQUEST["id"] && $_REQUEST["hash"] && !inbox::verify_hash($_REQUEST["id"],$_REQUEST["hash"])) {
-  alloc_error("The IMAP ID for that email is no longer valid. Refresh the list and try again.");
-
+if ($_REQUEST["id"] && $_REQUEST["hash"] && !inbox::verify_hash($_REQUEST["id"], $_REQUEST["hash"])) {
+    alloc_error("The IMAP ID for that email is no longer valid. Refresh the list and try again.");
 } else if ($_REQUEST["id"] && $_REQUEST["hash"]) {
+    $_REQUEST["archive"]    && inbox::archive_email($_REQUEST);  // archive the email by moving it to another folder
+    $_REQUEST["download"]   && inbox::download_email($_REQUEST); // download it to a mbox file
+    $_REQUEST["process"]    && inbox::process_email($_REQUEST);  // attach it to a task etc
+    $_REQUEST["readmail"]   && inbox::read_email($_REQUEST);     // mark the email as read
+    $_REQUEST["unreadmail"] && inbox::unread_email($_REQUEST);   // mark the email as unread
+    $_REQUEST["newtask"]    && inbox::process_email_to_task($_REQUEST); // use this email to create a new task
+    $_REQUEST["taskID"]     && inbox::attach_email_to_existing_task($_REQUEST); // attach email as new comment thread onto existing task
 
-  $_REQUEST["archive"]    && inbox::archive_email($_REQUEST);  // archive the email by moving it to another folder
-  $_REQUEST["download"]   && inbox::download_email($_REQUEST); // download it to a mbox file
-  $_REQUEST["process"]    && inbox::process_email($_REQUEST);  // attach it to a task etc
-  $_REQUEST["readmail"]   && inbox::read_email($_REQUEST);     // mark the email as read
-  $_REQUEST["unreadmail"] && inbox::unread_email($_REQUEST);   // mark the email as unread
-  $_REQUEST["newtask"]    && inbox::process_email_to_task($_REQUEST); // use this email to create a new task
-  $_REQUEST["taskID"]     && inbox::attach_email_to_existing_task($_REQUEST); // attach email as new comment thread onto existing task
-
-  alloc_redirect($TPL["url_alloc_inbox"]);
+    alloc_redirect($TPL["url_alloc_inbox"]);
 }
 
 
 $TPL["rows"] = inbox::get_list();
 
 include_template("templates/inboxM.tpl");
-
-?>

--- a/email/lib/command.inc.php
+++ b/email/lib/command.inc.php
@@ -3,516 +3,519 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class command {
+class command
+{
 
-  var $commands;
-  var $email_receive;
+    var $commands;
+    var $email_receive;
 
-  function get_help($type) {
-    $message = ucwords($type)." fields:";
-    $fields = command::get_fields($type);
-    foreach ((array)$fields as $k => $arr) {
-      $message.= "\n      ".$k.":\t".$arr[1];
+    function get_help($type)
+    {
+        $message = ucwords($type)." fields:";
+        $fields = command::get_fields($type);
+        foreach ((array)$fields as $k => $arr) {
+            $message.= "\n      ".$k.":\t".$arr[1];
+        }
+        return $message;
     }
-    return $message;
-  }
 
-  function get_fields($type="all") {
+    function get_fields($type = "all")
+    {
 
-    $comment = array(
-      "key"   => array("","The comment thread key.")
-     ,"ip"    => array("","Add to a comment's interested parties. Eg: jon,jane@j.com,Hal Comp <hc@hc.com> ... can also remove eg: -jon")
-     ,"quiet" => array("","Don't resend the email back out to anyone.")
-    );
+        $comment = array(
+        "key"   => array("","The comment thread key.")
+        ,"ip"    => array("","Add to a comment's interested parties. Eg: jon,jane@j.com,Hal Comp <hc@hc.com> ... can also remove eg: -jon")
+        ,"quiet" => array("","Don't resend the email back out to anyone.")
+        );
 
-    $item = array(
-      "tsid"      => array("timeSheetID",           "time sheet that this item belongs to")
-     ,"date"      => array("dateTimeSheetItem",     "time sheet item's date")
-     ,"duration"  => array("timeSheetItemDuration", "time sheet item's duration")
-     ,"unit"      => array("timeSheetItemDurationUnitID", "time sheet item's unit of duration eg: 1=hours 2=days 3=week 4=month 5=fixed")
-     ,"task"      => array("taskID",                "ID of the time sheet item's task")
-     ,"rate"      => array("rate",                  "\$rate of the time sheet item's")
-     ,"private"   => array("commentPrivate",        "privacy setting of the time sheet item's comment eg: 1=private 0=normal")
-     ,"comment"   => array("comment",               "time sheet item comment")
-     ,"multiplier"=> array("multiplier",            "time sheet item multiplier eg: 1=standard 1.5=time-and-a-half 2=double-time 3=triple-time 0=no-charge")
-     ,"delete"    => array("",                      "set this to 1 to delete the time sheet item")
-     ,"time"      => array("",                      "Add some time to a time sheet. Auto-creates time sheet if none exist.")
-    );
+        $item = array(
+        "tsid"      => array("timeSheetID",           "time sheet that this item belongs to")
+        ,"date"      => array("dateTimeSheetItem",     "time sheet item's date")
+        ,"duration"  => array("timeSheetItemDuration", "time sheet item's duration")
+        ,"unit"      => array("timeSheetItemDurationUnitID", "time sheet item's unit of duration eg: 1=hours 2=days 3=week 4=month 5=fixed")
+        ,"task"      => array("taskID",                "ID of the time sheet item's task")
+        ,"rate"      => array("rate",                  "\$rate of the time sheet item's")
+        ,"private"   => array("commentPrivate",        "privacy setting of the time sheet item's comment eg: 1=private 0=normal")
+        ,"comment"   => array("comment",               "time sheet item comment")
+        ,"multiplier"=> array("multiplier",            "time sheet item multiplier eg: 1=standard 1.5=time-and-a-half 2=double-time 3=triple-time 0=no-charge")
+        ,"delete"    => array("",                      "set this to 1 to delete the time sheet item")
+        ,"time"      => array("",                      "Add some time to a time sheet. Auto-creates time sheet if none exist.")
+        );
 
-    $task = array(
-      "status"    => array("taskStatus",      "inprogress, notstarted, info, client, manager, invalid, duplicate, incomplete, complete; or: open, pending, closed")
-     ,"name"      => array("taskName",        "task's title")
-     ,"assign"    => array("personID",        "username of the person that the task is assigned to")
-     ,"manage"    => array("managerID",       "username of the person that the task is managed by")
-     ,"desc"      => array("taskDescription", "task's long description")
-     ,"priority"  => array("priority",        "1, 2, 3, 4 or 5; or one of Wishlist, Minor, Normal, Important or Critical")
-     ,"limit"     => array("timeLimit",       "limit in hours for effort spend on this task")
-     ,"best"      => array("timeBest",        "shortest estimate of how many hours of effort this task will take")
-     ,"likely"    => array("timeExpected",    "most likely amount of hours of effort this task will take")
-     ,"worst"     => array("timeWorst",       "longest estimate of how many hours of effort this task will take")
-     ,"estimator" => array("estimatorID",     "the person who created the estimates on this task")
-     ,"targetstart" => array("dateTargetStart","estimated date for work to start on this task")
-     ,"targetcompletion" => array("dateTargetCompletion","estimated date for when this task should be finished")
-     ,"project"   => array("projectID",       "task's project ID")
-     ,"type"      => array("taskTypeID",      "Task, Fault, Message, Milestone or Parent")
-     ,"dupe"      => array("duplicateTaskID", "If the task status is duplicate, then this should be set to the task ID of the related dupe")
-     ,"pend"      => array("",                "The task ID(s), commar separated, that block this task")
-     ,"reopen"    => array("",                "Reopen the task on this date. To be used with --status=pending.")
-     ,"task"      => array("",                "A task ID, or the word 'new' to create a new task.")
-     ,"dip"       => array("",                "Add some default interested parties.")
-     ,"tags"      => array("",                "Add some tags, comma separated tags")
-    );
+        $task = array(
+        "status"    => array("taskStatus",      "inprogress, notstarted, info, client, manager, invalid, duplicate, incomplete, complete; or: open, pending, closed")
+        ,"name"      => array("taskName",        "task's title")
+        ,"assign"    => array("personID",        "username of the person that the task is assigned to")
+        ,"manage"    => array("managerID",       "username of the person that the task is managed by")
+        ,"desc"      => array("taskDescription", "task's long description")
+        ,"priority"  => array("priority",        "1, 2, 3, 4 or 5; or one of Wishlist, Minor, Normal, Important or Critical")
+        ,"limit"     => array("timeLimit",       "limit in hours for effort spend on this task")
+        ,"best"      => array("timeBest",        "shortest estimate of how many hours of effort this task will take")
+        ,"likely"    => array("timeExpected",    "most likely amount of hours of effort this task will take")
+        ,"worst"     => array("timeWorst",       "longest estimate of how many hours of effort this task will take")
+        ,"estimator" => array("estimatorID",     "the person who created the estimates on this task")
+        ,"targetstart" => array("dateTargetStart","estimated date for work to start on this task")
+        ,"targetcompletion" => array("dateTargetCompletion","estimated date for when this task should be finished")
+        ,"project"   => array("projectID",       "task's project ID")
+        ,"type"      => array("taskTypeID",      "Task, Fault, Message, Milestone or Parent")
+        ,"dupe"      => array("duplicateTaskID", "If the task status is duplicate, then this should be set to the task ID of the related dupe")
+        ,"pend"      => array("",                "The task ID(s), commar separated, that block this task")
+        ,"reopen"    => array("",                "Reopen the task on this date. To be used with --status=pending.")
+        ,"task"      => array("",                "A task ID, or the word 'new' to create a new task.")
+        ,"dip"       => array("",                "Add some default interested parties.")
+        ,"tags"      => array("",                "Add some tags, comma separated tags")
+        );
 
-    $reminder = array(
-      "date"            => array("reminderTime",             "")
-     ,"subject"         => array("reminderSubject",          "")
-     ,"body"            => array("reminderContent",          "")
-     ,"frequency"       => array("reminderRecuringValue",    "")
-     ,"frequency_units" => array("reminderRecuringInterval", "")
-     ,"active"          => array("reminderActive",           "")
-     ,"notice"          => array("reminderAdvNoticeValue",   "")
-     ,"notice_units"    => array("reminderAdvNoticeInterval","")
-    );
+        $reminder = array(
+        "date"            => array("reminderTime",             "")
+        ,"subject"         => array("reminderSubject",          "")
+        ,"body"            => array("reminderContent",          "")
+        ,"frequency"       => array("reminderRecuringValue",    "")
+        ,"frequency_units" => array("reminderRecuringInterval", "")
+        ,"active"          => array("reminderActive",           "")
+        ,"notice"          => array("reminderAdvNoticeValue",   "")
+        ,"notice_units"    => array("reminderAdvNoticeInterval","")
+        );
 
-    $types = array("all"=>array_merge($comment,$item,$task,$reminder)
+        $types = array("all"=>array_merge($comment, $item, $task, $reminder)
                   ,"comment"=>$comment
                   ,"item"=>$item
                   ,"task"=>$task
                   ,"reminder"=>$reminder
                   );
-    return $types[$type];
-  }
-
-  function run_commands($commands=array(), $email_receive=false) {
-
-    if ($commands["command"] == "edit_timeSheetItem") {
-      list($s,$m) = $this->edit_timeSheetItem($commands);
-
-    } else if ($commands["command"] == "edit_task") {
-      list($s,$m) = $this->edit_task($commands,$email_receive);
-
-    } else if ($commands["command"] == "add_comment") {
-      list($s,$m) = $this->add_comment($commands);
-
-    } else if ($commands["command"] == "edit_reminder") {
-      list($s,$m) = $this->edit_reminder($commands);
+        return $types[$type];
     }
 
-    if ($commands["key"]) {
-      list($s,$m) = $this->add_comment_via_email($commands,$email_receive);
-    }
+    function run_commands($commands = array(), $email_receive = false)
+    {
 
-    if ($commands["time"]) {
-      list($s,$m) = $this->add_time($commands,$email_receive);
-    }
-
-    if ($s && $m) {
-      $status = $s;
-      $message = $m;
-    }
-
-    // Status will be yay, msg, err or die, i.e. mirrored with the alloc-cli messaging system
-    return array("status"=>$status,"message"=>$message);
-  }
-
-  function edit_task($commands,$email_receive) {
-    $task_fields = $this->get_fields("task");
-    // Task commands
-    if ($commands["task"]) {
-      unset($changes);
-
-      $taskPriorities = config::get_config_item("taskPriorities") or $taskPriorities = array();
-      foreach ($taskPriorities as $k => $v) {
-        $priorities[strtolower($v["label"])] = $k;
-      }
-
-      $people_by_username = person::get_people_by_username();
-
-      // Else edit/create the task ...
-      $task = new task();
-      if ($commands["task"] && strtolower($commands["task"]) != "new") {
-        $task->set_id($commands["task"]);
-        if(!$task->select()) {
-          alloc_error("Unable to select task with ID: ".$commands["task"]);
+        if ($commands["command"] == "edit_timeSheetItem") {
+            list($s,$m) = $this->edit_timeSheetItem($commands);
+        } else if ($commands["command"] == "edit_task") {
+            list($s,$m) = $this->edit_task($commands, $email_receive);
+        } else if ($commands["command"] == "add_comment") {
+            list($s,$m) = $this->add_comment($commands);
+        } else if ($commands["command"] == "edit_reminder") {
+            list($s,$m) = $this->edit_reminder($commands);
         }
-      }
 
-      foreach ($commands as $k => $v) {
-        // transform from username to personID
-        if ($k == "assign") {
-          $changes[$k] = "personID";
-          $v = $people_by_username[$v]["personID"];
-          $v or alloc_error("Unrecognized username.");
+        if ($commands["key"]) {
+            list($s,$m) = $this->add_comment_via_email($commands, $email_receive);
         }
+
+        if ($commands["time"]) {
+            list($s,$m) = $this->add_time($commands, $email_receive);
+        }
+
+        if ($s && $m) {
+            $status = $s;
+            $message = $m;
+        }
+
+      // Status will be yay, msg, err or die, i.e. mirrored with the alloc-cli messaging system
+        return array("status"=>$status,"message"=>$message);
+    }
+
+    function edit_task($commands, $email_receive)
+    {
+        $task_fields = $this->get_fields("task");
+      // Task commands
+        if ($commands["task"]) {
+            unset($changes);
+
+            $taskPriorities = config::get_config_item("taskPriorities") or $taskPriorities = array();
+            foreach ($taskPriorities as $k => $v) {
+                $priorities[strtolower($v["label"])] = $k;
+            }
+
+            $people_by_username = person::get_people_by_username();
+
+          // Else edit/create the task ...
+            $task = new task();
+            if ($commands["task"] && strtolower($commands["task"]) != "new") {
+                $task->set_id($commands["task"]);
+                if (!$task->select()) {
+                    alloc_error("Unable to select task with ID: ".$commands["task"]);
+                }
+            }
+
+            foreach ($commands as $k => $v) {
+                // transform from username to personID
+                if ($k == "assign") {
+                    $changes[$k] = "personID";
+                    $v = $people_by_username[$v]["personID"];
+                    $v or alloc_error("Unrecognized username.");
+                }
         
-        if ($k == "manage") {
-          $changes[$k] = "managerID";
-          $v = $people_by_username[$v]["personID"];
-          $v or alloc_error("Unrecognized username.");
-        }
+                if ($k == "manage") {
+                    $changes[$k] = "managerID";
+                    $v = $people_by_username[$v]["personID"];
+                    $v or alloc_error("Unrecognized username.");
+                }
 
-        if ($k == "estimator") {
-          $changes[$k] = "estimatorID";
-          $v = $people_by_username[$v]["personID"];
-          $v or alloc_error("Unrecognized username.");
-        }
+                if ($k == "estimator") {
+                    $changes[$k] = "estimatorID";
+                    $v = $people_by_username[$v]["personID"];
+                    $v or alloc_error("Unrecognized username.");
+                }
 
-        // transform from priority label to priority ID
-        if ($k == "priority" && !in_array($v,array(1,2,3,4,5))) {
-          $v = $priorities[strtolower($v)];
-        }
+                // transform from priority label to priority ID
+                if ($k == "priority" && !in_array($v, array(1,2,3,4,5))) {
+                    $v = $priorities[strtolower($v)];
+                }
 
-        // so that --type parent becomes --type Parent
-        // mysql's referential integrity is case-insensitive :(
-        if ($k == "type") {
-          $v = ucwords($v);
-        }
+                // so that --type parent becomes --type Parent
+                // mysql's referential integrity is case-insensitive :(
+                if ($k == "type") {
+                    $v = ucwords($v);
+                }
 
-        // Plug the value in
-        if ($task_fields[$k][0]) {
-          $changes[$k] = $task_fields[$k][0];
-          $task->set_value($task_fields[$k][0],sprintf("%s",$v));
-        }
-      }
+                // Plug the value in
+                if ($task_fields[$k][0]) {
+                    $changes[$k] = $task_fields[$k][0];
+                    $task->set_value($task_fields[$k][0], sprintf("%s", $v));
+                }
+            }
 
-      if (isset($commands["pend"])) {
-        $changes["pend"] = implode(",",(array)$task->get_pending_tasks());
-      }
+            if (isset($commands["pend"])) {
+                $changes["pend"] = implode(",", (array)$task->get_pending_tasks());
+            }
 
-      if (isset($commands["reopen"])) {
-        $reopen_rows = $task->get_reopen_reminders();
-        unset($rr_bits);
-        foreach ($reopen_rows as $rr) { $rr_bits[] = $rr["reminderTime"]; }
-        $changes["reopen"] = implode(",",(array)$rr_bits);
-      }
+            if (isset($commands["reopen"])) {
+                $reopen_rows = $task->get_reopen_reminders();
+                unset($rr_bits);
+                foreach ($reopen_rows as $rr) {
+                    $rr_bits[] = $rr["reminderTime"];
+                }
+                $changes["reopen"] = implode(",", (array)$rr_bits);
+            }
 
-      if (isset($commands["tags"])) {
-        $changes["tags"] = implode(",",$task->get_tags());
-      }
+            if (isset($commands["tags"])) {
+                $changes["tags"] = implode(",", $task->get_tags());
+            }
 
-      if (strtolower($commands["task"]) == "new") {
-        if (!$commands["desc"] && is_object($email_receive)) {
-          $task->set_value("taskDescription",$email_receive->get_converted_encoding());
-        }
-      }
+            if (strtolower($commands["task"]) == "new") {
+                if (!$commands["desc"] && is_object($email_receive)) {
+                    $task->set_value("taskDescription", $email_receive->get_converted_encoding());
+                }
+            }
 
-      $after_label = "After:  ";
-      if (strtolower($commands["task"]) != "new") {
-        $str = $this->condense_changes($changes,$task->row());
-        $str and $status[] = "msg";
-        $str and $message[] = "Before: ".$str;
-      } else {
-        $after_label = "Fields: ";
-      }
+            $after_label = "After:  ";
+            if (strtolower($commands["task"]) != "new") {
+                $str = $this->condense_changes($changes, $task->row());
+                $str and $status[] = "msg";
+                $str and $message[] = "Before: ".$str;
+            } else {
+                $after_label = "Fields: ";
+            }
 
-      // Save task
-      $err = $task->validate();
-      if (!$err && $task->save()) {
-        $task->select();
+          // Save task
+            $err = $task->validate();
+            if (!$err && $task->save()) {
+                $task->select();
 
-        if (isset($commands["pend"])) {
-          $task->add_pending_tasks($commands["pend"]);
-          $changes["pend"] = implode(",",(array)$task->get_pending_tasks());
-        }
-        if (isset($commands["reopen"])) {
-          $task->add_reopen_reminder($commands["reopen"]);
-          $reopen_rows = $task->get_reopen_reminders();
-          unset($rr_bits);
-          foreach ($reopen_rows as $rr) { $rr_bits[] = $rr["reminderTime"]; }
-          $changes["reopen"] = implode(",",(array)$rr_bits);
-        }
+                if (isset($commands["pend"])) {
+                    $task->add_pending_tasks($commands["pend"]);
+                    $changes["pend"] = implode(",", (array)$task->get_pending_tasks());
+                }
+                if (isset($commands["reopen"])) {
+                    $task->add_reopen_reminder($commands["reopen"]);
+                    $reopen_rows = $task->get_reopen_reminders();
+                    unset($rr_bits);
+                    foreach ($reopen_rows as $rr) {
+                        $rr_bits[] = $rr["reminderTime"];
+                    }
+                    $changes["reopen"] = implode(",", (array)$rr_bits);
+                }
 
-        if (isset($commands["tags"])) {
-          $task->add_tags(array($commands["tags"]));
-          $changes["tags"] = implode(",",$task->get_tags());
-        }
+                if (isset($commands["tags"])) {
+                    $task->add_tags(array($commands["tags"]));
+                    $changes["tags"] = implode(",", $task->get_tags());
+                }
 
-        $str = $this->condense_changes($changes,$task->row());
-        $str and $status[] = "msg";
-        $str and $message[] = $after_label.$str;
+                $str = $this->condense_changes($changes, $task->row());
+                $str and $status[] = "msg";
+                $str and $message[] = $after_label.$str;
 
-        if ($commands["dip"]) {
-          interestedParty::add_remove_ips($commands["dip"],"task",$task->get_id(),$task->get_value("projectID"));
-        }
+                if ($commands["dip"]) {
+                    interestedParty::add_remove_ips($commands["dip"], "task", $task->get_id(), $task->get_value("projectID"));
+                }
   
-        if (strtolower($commands["task"]) == "new") {
-          $status[] = "yay";
-          $message[] = "Task ".$task->get_id()." created.";
-        } else {
-          $status[] = "yay";
-          $message[] = "Task ".$task->get_id()." updated.";
+                if (strtolower($commands["task"]) == "new") {
+                    $status[] = "yay";
+                    $message[] = "Task ".$task->get_id()." created.";
+                } else {
+                    $status[] = "yay";
+                    $message[] = "Task ".$task->get_id()." updated.";
+                }
+
+              // Problems
+            } else {
+                alloc_error("Problem updating task: ".implode("\n", (array)$err));
+            }
         }
-
-      // Problems
-      } else {
-        alloc_error("Problem updating task: ".implode("\n",(array)$err));
-      }
-    }
-    return array($status,$message);
-  }
-
-  function edit_timeSheetItem($commands) {
-    $item_fields = $this->get_fields("item");
-
-    // Time Sheet Item commands
-    if ($commands["item"]) {
-
-      $timeSheetItem = new timeSheetItem();
-      if ($commands["item"] && strtolower($commands["item"] != "new")) {
-        $timeSheetItem->set_id($commands["item"]);
-        if(!$timeSheetItem->select()) {
-          alloc_error("Unable to select time sheet item with ID: ".$commands["item"]);
-        }
-      }
-      $timeSheet = $timeSheetItem->get_foreign_object("timeSheet");
-      $timeSheetItem->currency = $timeSheet->get_value("currencyTypeID");
-      $timeSheetItem->set_value("rate",$timeSheetItem->get_value("rate",DST_HTML_DISPLAY));
-
-      foreach ($commands as $k => $v) {
-
-        // Validate/coerce the fields
-        if ($k == "unit") {
-          $changes[$k] = "timeSheetItemDurationUnitID";
-          in_array($v,array(1,2,3,4,5)) or $err[] = "Invalid unit. Try a number from 1-5.";
-        } else if ($k == "task") {
-          $changes[$k] = "taskID";
-          $t = new task();
-          $t->set_id($v);
-          $t->select();
-          is_object($timeSheet) && $timeSheet->get_id() && $t->get_value("projectID") != $timeSheet->get_value("projectID") and $err[] = "Invalid task. Task belongs to different project.";
-        }
-
-        // Plug the value in
-        if ($item_fields[$k][0]) {
-          $changes[$k] = $item_fields[$k][0];
-          $timeSheetItem->set_value($item_fields[$k][0],sprintf("%s",$v));
-        }
-      }
-
-      $after_label2 = "After:  ";
-      if (strtolower($commands["item"]) != "new") {
-        $str = $this->condense_changes($changes,$timeSheetItem->row());
-        $str and $status[] = "msg";
-        $str and $message[] = "Before: ".$str;
-      } else {
-        $after_label2 = "Fields: ";
-      }
-
-      if ($commands["delete"]) {
-        $id = $timeSheetItem->get_id();
-        $timeSheetItem->delete();
-        $status[] = "yay";
-        $message[] = "Time sheet item ".$id." deleted.";
-
-      // Save timeSheetItem
-      } else if (!$err && $commands["item"] && $timeSheetItem->save()) {
-        $timeSheetItem->select();
-        $str = $this->condense_changes($changes,$timeSheetItem->row());
-        $str and $status[] = "msg";
-        $str and $message[] = $after_label2.$str;
-        $status[] = "yay";
-        if (strtolower($commands["item"]) == "new") {
-          $message[] = "Time sheet item ".$timeSheetItem->get_id()." created.";
-        } else {
-          $message[] = "Time sheet item ".$timeSheetItem->get_id()." updated.";
-        }
-
-      // Problems
-      } else if ($err && $commands["item"]) {
-        alloc_error("Problem updating time sheet item: ".implode("\n",(array)$err));
-      }
-    }
-    return array($status,$message);
-  }
-
-  function edit_reminder($commands) {
-    $id = $commands["reminder"];
-    $options = $commands;
-    $reminder = new reminder();
-    if ($id and $id != "new") {
-      $reminder->set_id($id);
-      $reminder->select();
-    } else if ($id == "new") {
-      // extra sanity checks, partially filled in reminder isn't much good
-      if (!$options['date'] || !$options['subject'] || !$options['recipients']) {
-        $status[] = "err";
-        $message[] = "Missing one of date, subject or recipients.";
         return array($status,$message);
-      }
-
-      if ($options['task']) {
-        $reminder->set_value('reminderType', 'task');
-        $reminder->set_value('reminderLinkID', $options['task']);
-      } else if ($options['project']) {
-        $reminder->set_value('reminderType', 'project');
-        $reminder->set_value('reminderLinkID', $options['project']);
-      } else if ($options['client']) {
-        $reminder->set_value('reminderLinkID', $options['client']);
-        $reminder->set_value('reminderType', 'client');
-      }
     }
 
-    // Tear apart the frequency bits
-    if ($options['frequency']) {
-      list($freq, $units) = sscanf($options['frequency'], "%d%c");
-      $freq_units = array('h' => 'Hour', 'd' => 'Day', 'w' => 'Week', 'm' => 'Month', 'y' => 'Year');
-      $options['frequency'] = $freq;
-      $options['frequency_units'] = $freq_units[strtolower($units)];
+    function edit_timeSheetItem($commands)
+    {
+        $item_fields = $this->get_fields("item");
+
+      // Time Sheet Item commands
+        if ($commands["item"]) {
+            $timeSheetItem = new timeSheetItem();
+            if ($commands["item"] && strtolower($commands["item"] != "new")) {
+                $timeSheetItem->set_id($commands["item"]);
+                if (!$timeSheetItem->select()) {
+                    alloc_error("Unable to select time sheet item with ID: ".$commands["item"]);
+                }
+            }
+            $timeSheet = $timeSheetItem->get_foreign_object("timeSheet");
+            $timeSheetItem->currency = $timeSheet->get_value("currencyTypeID");
+            $timeSheetItem->set_value("rate", $timeSheetItem->get_value("rate", DST_HTML_DISPLAY));
+
+            foreach ($commands as $k => $v) {
+                // Validate/coerce the fields
+                if ($k == "unit") {
+                    $changes[$k] = "timeSheetItemDurationUnitID";
+                    in_array($v, array(1,2,3,4,5)) or $err[] = "Invalid unit. Try a number from 1-5.";
+                } else if ($k == "task") {
+                    $changes[$k] = "taskID";
+                    $t = new task();
+                    $t->set_id($v);
+                    $t->select();
+                    is_object($timeSheet) && $timeSheet->get_id() && $t->get_value("projectID") != $timeSheet->get_value("projectID") and $err[] = "Invalid task. Task belongs to different project.";
+                }
+
+                // Plug the value in
+                if ($item_fields[$k][0]) {
+                    $changes[$k] = $item_fields[$k][0];
+                    $timeSheetItem->set_value($item_fields[$k][0], sprintf("%s", $v));
+                }
+            }
+
+            $after_label2 = "After:  ";
+            if (strtolower($commands["item"]) != "new") {
+                $str = $this->condense_changes($changes, $timeSheetItem->row());
+                $str and $status[] = "msg";
+                $str and $message[] = "Before: ".$str;
+            } else {
+                $after_label2 = "Fields: ";
+            }
+
+            if ($commands["delete"]) {
+                $id = $timeSheetItem->get_id();
+                $timeSheetItem->delete();
+                $status[] = "yay";
+                $message[] = "Time sheet item ".$id." deleted.";
+
+              // Save timeSheetItem
+            } else if (!$err && $commands["item"] && $timeSheetItem->save()) {
+                $timeSheetItem->select();
+                $str = $this->condense_changes($changes, $timeSheetItem->row());
+                $str and $status[] = "msg";
+                $str and $message[] = $after_label2.$str;
+                $status[] = "yay";
+                if (strtolower($commands["item"]) == "new") {
+                    $message[] = "Time sheet item ".$timeSheetItem->get_id()." created.";
+                } else {
+                    $message[] = "Time sheet item ".$timeSheetItem->get_id()." updated.";
+                }
+
+              // Problems
+            } else if ($err && $commands["item"]) {
+                alloc_error("Problem updating time sheet item: ".implode("\n", (array)$err));
+            }
+        }
+        return array($status,$message);
     }
 
-    if ($options['notice']) {
-      list($freq, $units) = sscanf($options['notice'], "%d%c");
-      $freq_units = array('h' => 'Hour', 'd' => 'Day', 'w' => 'Week', 'm' => 'Month', 'y' => 'Year');
-      $options['notice'] = $freq;
-      $options['notice_units'] = $freq_units[strtolower($units)];
+    function edit_reminder($commands)
+    {
+        $id = $commands["reminder"];
+        $options = $commands;
+        $reminder = new reminder();
+        if ($id and $id != "new") {
+            $reminder->set_id($id);
+            $reminder->select();
+        } else if ($id == "new") {
+          // extra sanity checks, partially filled in reminder isn't much good
+            if (!$options['date'] || !$options['subject'] || !$options['recipients']) {
+                $status[] = "err";
+                $message[] = "Missing one of date, subject or recipients.";
+                return array($status,$message);
+            }
 
-    }
-    $fields = $this->get_fields("reminder");
-    foreach ($fields as $s => $d) {
-      if ($options[$s]) {
-        $reminder->set_value($d[0], $options[$s]);
-      }
-    }
+            if ($options['task']) {
+                $reminder->set_value('reminderType', 'task');
+                $reminder->set_value('reminderLinkID', $options['task']);
+            } else if ($options['project']) {
+                $reminder->set_value('reminderType', 'project');
+                $reminder->set_value('reminderLinkID', $options['project']);
+            } else if ($options['client']) {
+                $reminder->set_value('reminderLinkID', $options['client']);
+                $reminder->set_value('reminderType', 'client');
+            }
+        }
 
-    if (!$reminder->get_value("reminderRecuringInterval")) {
-      $reminder->set_value("reminderRecuringInterval", "No");
-    }
+      // Tear apart the frequency bits
+        if ($options['frequency']) {
+            list($freq, $units) = sscanf($options['frequency'], "%d%c");
+            $freq_units = array('h' => 'Hour', 'd' => 'Day', 'w' => 'Week', 'm' => 'Month', 'y' => 'Year');
+            $options['frequency'] = $freq;
+            $options['frequency_units'] = $freq_units[strtolower($units)];
+        }
 
-    if (!$reminder->get_value("reminderAdvNoticeInterval")) {
-      $reminder->set_value("reminderAdvNoticeInterval", "No");
-    }
+        if ($options['notice']) {
+            list($freq, $units) = sscanf($options['notice'], "%d%c");
+            $freq_units = array('h' => 'Hour', 'd' => 'Day', 'w' => 'Week', 'm' => 'Month', 'y' => 'Year');
+            $options['notice'] = $freq;
+            $options['notice_units'] = $freq_units[strtolower($units)];
+        }
+        $fields = $this->get_fields("reminder");
+        foreach ($fields as $s => $d) {
+            if ($options[$s]) {
+                $reminder->set_value($d[0], $options[$s]);
+            }
+        }
 
-    $reminder->save();
+        if (!$reminder->get_value("reminderRecuringInterval")) {
+            $reminder->set_value("reminderRecuringInterval", "No");
+        }
 
-    // Deal with recipients
-    if ($options['recipients']) {
-      list($_x, $recipients) = $reminder->get_recipient_options();
-      if ($options['recipients']) {
-        $recipients = array_unique(array_merge($recipients, $options['recipients']));
-      }
-      if ($options['recipients_remove']) {
-        $recipients = array_diff($recipients, $options['recipients_remove']);
-      }
-      $reminder->update_recipients($recipients);
-    }
+        if (!$reminder->get_value("reminderAdvNoticeInterval")) {
+            $reminder->set_value("reminderAdvNoticeInterval", "No");
+        }
+
+        $reminder->save();
+
+      // Deal with recipients
+        if ($options['recipients']) {
+            list($_x, $recipients) = $reminder->get_recipient_options();
+            if ($options['recipients']) {
+                $recipients = array_unique(array_merge($recipients, $options['recipients']));
+            }
+            if ($options['recipients_remove']) {
+                $recipients = array_diff($recipients, $options['recipients_remove']);
+            }
+            $reminder->update_recipients($recipients);
+        }
     
-    if (is_object($reminder) && $reminder->get_id()) {
-      $status[] = "yay";
-      $message[] = "Reminder ".$reminder->get_id()." saved.";
-    } else {
-      $status[] = "err";
-      $message[] = "Reminder not saved.";
-    }
-    return array($status,$message);
-  }
-
-  function add_time($commands,$email_receive) {
-    $current_user = &singleton("current_user");
-    if ($commands["time"]) {
-
-      // CLI passes time along as a string, email passes time along as an array
-      if (!is_array($commands["time"])) {
-        $t = $commands["time"];
-        unset($commands["time"]);
-        $commands["time"][] = $t;
-      }
-
-      foreach ((array)$commands["time"] as $time) {
-        $t = timeSheetItem::parse_time_string($time);
-
-        if (is_numeric($t["duration"]) && $current_user->get_id()) {
-          $timeSheet = new timeSheet();
-          is_object($email_receive) and $t["msg_uid"] = $email_receive->msg_uid;
-          $tsi_row = $timeSheet->add_timeSheetItem($t);
-          $status[] = $tsi_row["status"];
-          $message[] = $tsi_row["message"];
+        if (is_object($reminder) && $reminder->get_id()) {
+            $status[] = "yay";
+            $message[] = "Reminder ".$reminder->get_id()." saved.";
+        } else {
+            $status[] = "err";
+            $message[] = "Reminder not saved.";
         }
-      }
+        return array($status,$message);
     }
-    return array($status,$message);
-  }
 
-  function add_comment_via_email($commands,$email_receive) {
-    // If there's Key in the email, then add a comment with the contents of the email.
-    $token = new token();
-    if ($commands["key"] && $token->set_hash($commands["key"])) {
+    function add_time($commands, $email_receive)
+    {
+        $current_user = &singleton("current_user");
+        if ($commands["time"]) {
+          // CLI passes time along as a string, email passes time along as an array
+            if (!is_array($commands["time"])) {
+                $t = $commands["time"];
+                unset($commands["time"]);
+                $commands["time"][] = $t;
+            }
 
-      $db = new db_alloc();
-      $comment = $token->get_value("tokenEntity");
-      $commentID = $token->get_value("tokenEntityID");
+            foreach ((array)$commands["time"] as $time) {
+                $t = timeSheetItem::parse_time_string($time);
 
-      list($entity,$method) = $token->execute();
-      if (is_object($entity) && $method == "add_comment_from_email") {
-
-        $c = comment::add_comment_from_email($email_receive,$entity);
-
-        if (is_object($c) && $c->get_id()) {
-          $quiet = interestedParty::adjust_by_email_subject($email_receive,$entity);
-
-          if ($commands["ip"]) {
-            $rtn = interestedParty::add_remove_ips($commands["ip"],$entity->classname,$entity->get_id(),$entity->get_project_id());
-          }
-
-          if (!$quiet) {
-            comment::send_comment($c->get_id(),array("interested"),$email_receive);
-          }
+                if (is_numeric($t["duration"]) && $current_user->get_id()) {
+                    $timeSheet = new timeSheet();
+                    is_object($email_receive) and $t["msg_uid"] = $email_receive->msg_uid;
+                    $tsi_row = $timeSheet->add_timeSheetItem($t);
+                    $status[] = $tsi_row["status"];
+                    $message[] = $tsi_row["message"];
+                }
+            }
         }
-      }
-    // Bad or missing key, then error
-    } else if ($email_receive) {
-      alloc_error("Bad or missing key. Unable to process email.");
+        return array($status,$message);
     }
-    return array($status,$message);
-  }
+
+    function add_comment_via_email($commands, $email_receive)
+    {
+      // If there's Key in the email, then add a comment with the contents of the email.
+        $token = new token();
+        if ($commands["key"] && $token->set_hash($commands["key"])) {
+            $db = new db_alloc();
+            $comment = $token->get_value("tokenEntity");
+            $commentID = $token->get_value("tokenEntityID");
+
+            list($entity,$method) = $token->execute();
+            if (is_object($entity) && $method == "add_comment_from_email") {
+                $c = comment::add_comment_from_email($email_receive, $entity);
+
+                if (is_object($c) && $c->get_id()) {
+                    $quiet = interestedParty::adjust_by_email_subject($email_receive, $entity);
+
+                    if ($commands["ip"]) {
+                        $rtn = interestedParty::add_remove_ips($commands["ip"], $entity->classname, $entity->get_id(), $entity->get_project_id());
+                    }
+
+                    if (!$quiet) {
+                        comment::send_comment($c->get_id(), array("interested"), $email_receive);
+                    }
+                }
+            }
+        // Bad or missing key, then error
+        } else if ($email_receive) {
+            alloc_error("Bad or missing key. Unable to process email.");
+        }
+        return array($status,$message);
+    }
  
-  function add_comment($commands) {
-    $commentID = comment::add_comment($commands["entity"], $commands["entityID"], $commands["comment_text"]);
+    function add_comment($commands)
+    {
+        $commentID = comment::add_comment($commands["entity"], $commands["entityID"], $commands["comment_text"]);
 
-    // add interested parties
-    foreach((array)$commands["ip"] as $k => $info) {
-      $info["entity"] = "comment";
-      $info["entityID"] = $commentID;
-      interestedParty::add_interested_party($info);
+      // add interested parties
+        foreach ((array)$commands["ip"] as $k => $info) {
+            $info["entity"] = "comment";
+            $info["entityID"] = $commentID;
+            interestedParty::add_interested_party($info);
+        }
+
+        $emailRecipients = array();
+        $emailRecipients[] = "interested";
+        if (defined("ALLOC_DEFAULT_FROM_ADDRESS") && ALLOC_DEFAULT_FROM_ADDRESS) {
+            list($from_address,$from_name) = parse_email_address(ALLOC_DEFAULT_FROM_ADDRESS);
+            $emailRecipients[] = $from_address;
+        }
+
+      // Re-email the comment out
+        comment::send_comment($commentID, $emailRecipients);
+        return array($status,$message);
     }
 
-    $emailRecipients = array();
-    $emailRecipients[] = "interested";
-    if (defined("ALLOC_DEFAULT_FROM_ADDRESS") && ALLOC_DEFAULT_FROM_ADDRESS) {
-      list($from_address,$from_name) = parse_email_address(ALLOC_DEFAULT_FROM_ADDRESS);
-      $emailRecipients[] = $from_address;
+    function condense_changes($changes, $fields)
+    {
+        foreach ((array)$changes as $label => $field) {
+            $v = $fields[$field] or $v = $field;
+            $str.= $sep.$label.": ".$v;
+            $sep = ", ";
+        }
+        return $str;
     }
-
-    // Re-email the comment out
-    comment::send_comment($commentID,$emailRecipients);
-    return array($status,$message);
-  }
-
-  function condense_changes($changes, $fields) {
-    foreach ((array)$changes as $label => $field) {
-      $v = $fields[$field] or $v = $field;
-      $str.= $sep.$label.": ".$v;
-      $sep = ", ";
-    }
-    return $str;
-  }
-
 }
-
-?>

--- a/email/lib/email_receive.inc.php
+++ b/email/lib/email_receive.inc.php
@@ -3,753 +3,790 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class email_receive {
+class email_receive
+{
 
-  var $host;
-  var $port;
-  var $username;
-  var $password;
-  var $protocol;
-  var $lockfile;
-  var $mbox;
-  var $connection;
-  var $mail_headers;
-  var $mail_structure;
-  var $mail_text;
-  var $mail_parts;
-  var $mail_info;
-  var $dir;
-  var $mime_types = array("text", "multipart", "message", "application", "audio", "image", "video", "other");
+    var $host;
+    var $port;
+    var $username;
+    var $password;
+    var $protocol;
+    var $lockfile;
+    var $mbox;
+    var $connection;
+    var $mail_headers;
+    var $mail_structure;
+    var $mail_text;
+    var $mail_parts;
+    var $mail_info;
+    var $dir;
+    var $mime_types = array("text", "multipart", "message", "application", "audio", "image", "video", "other");
   
-  function __construct($info,$lockfile=false) {
-    $this->host     = $info["host"];
-    $this->port     = $info["port"];
-    $this->username = $info["username"];
-    $this->password = $info["password"];
-    $this->protocol = $info["protocol"] or $this->protocol = "imap";
-    $this->lockfile = $lockfile;
+    function __construct($info, $lockfile = false)
+    {
+        $this->host     = $info["host"];
+        $this->port     = $info["port"];
+        $this->username = $info["username"];
+        $this->password = $info["password"];
+        $this->protocol = $info["protocol"] or $this->protocol = "imap";
+        $this->lockfile = $lockfile;
 
-    // Nuke lock files that are more that 30 min old 
-    if ($this->lockfile && file_exists($this->lockfile) && (time() - filemtime($this->lockfile)) > 1800) {
-      $this->unlock();
-    } 
-
-    if ($this->lockfile && file_exists($this->lockfile)) {
-      alloc_error("Mailbox is locked. Remove ".$this->lockfile." to unlock.");
-    } else if ($this->lockfile) {
-      $this->lock();
-    }
-  }
-  
-  function open_mailbox($folder="",$ops=OP_HALFOPEN, $fatal=true) {
-    if ($this->connection && is_resource($this->connection)) {
-      imap_close($this->connection); 
-    }
-    $this->connect_string = '{'.$this->host.':'.$this->port.'/'.$this->protocol.config::get_config_item("allocEmailExtra").'}';
-    $this->connection = imap_open($this->connect_string, $this->username, $this->password, $ops);
-    if (!$this->connection && $fatal) {
-      alloc_error("Unable to access mail folder(1).");
-    }
-    $list = imap_list($this->connection, $this->connect_string, "*");
-    if (!is_array($list) || !count($list)) { // || !in_array($connect_string.$folder,$list)) {
-      $this->unlock();
-      imap_close($this->connection); 
-      if ($fatal) {
-        alloc_error("Unable to access mail folder(2).");
-      }
-    } else {
-      $rtn = imap_reopen($this->connection, $this->connect_string.$folder);
-
-      $errs = print_r(imap_errors(),1);
-      if (!$rtn || preg_match("/Invalid mailbox name/i",$errs) || preg_match("/Mailbox does not exist/i",$errs)) {
-        $rtn = imap_reopen($this->connection, $this->connect_string.str_replace("/",".",$folder));
-      }
-
-      if (!$rtn) {
-        imap_close($this->connection); 
-        if ($fatal) {
-          alloc_error("Unable to access mail folder(3).");
+      // Nuke lock files that are more that 30 min old
+        if ($this->lockfile && file_exists($this->lockfile) && (time() - filemtime($this->lockfile)) > 1800) {
+            $this->unlock();
         }
-      }
-    }
-    if (!$rtn && $fatal) {
-      alloc_error("<pre>IMAP errors: ".print_r(imap_errors(),1).print_r(imap_alerts(),1)."</pre>");
-    }
-    return $rtn;
-  }
 
-  function get_num_emails() {
-    if (!$this->mail_info) {
-      $this->check_mail();
-    }
-    if (is_object($this->mail_info)) {
-      return $this->mail_info->messages;
-    }
-  }
-
-  function get_num_new_emails() {
-    if (!$this->mail_info) {
-      $this->check_mail();
-    }
-    if (is_object($this->mail_info)) {
-      return $this->mail_info->unseen;
-    }
-  }
-
-  function check_mail() {
-    if ($this->connection) {
-      $this->mail_info = imap_status($this->connection, $this->connect_string, SA_ALL);
-    } else { 
-      unset($this->mail_info);
-    }
-  }
-
-  function create_mailbox($name) {
-    if (!imap_status($this->connection,$this->connect_string.$name,SA_ALL)) {
-      $rtn = imap_createmailbox($this->connection, imap_utf7_encode($this->connect_string.$name));
-    }
-    if (!$rtn) {
-      $name = str_replace("/",".",$name);
-      if (!imap_status($this->connection,$this->connect_string.$name,SA_ALL)) {
-        $rtn = imap_createmailbox($this->connection, imap_utf7_encode($this->connect_string.$name));
-      }
-    }
-    return $rtn;
-  }
-
-  function move_mail($uid,$mailbox) {
-    $moved = imap_mail_move($this->connection, $uid, $mailbox, CP_UID);
-    $moved or $moved = imap_mail_move($this->connection, $uid, str_replace("/",".",$mailbox), CP_UID);
-    return $moved;
-  }
-
-  function get_new_email_msg_uids() {
-    return imap_search($this->connection,"UNSEEN",SE_UID);
-  }
-
-  function set_unread() {
-    return imap_clearflag_full($this->connection,$this->msg_uid,'\\Seen',ST_UID);
-  }
-
-  function get_all_email_msg_uids() {
-    return imap_search($this->connection,"ALL",SE_UID);
-  }
-
-  function get_emails_UIDs_search($str) {
-    return imap_search($this->connection,$str, SE_UID);
-  }
-
-  function set_msg($x) {
-    $this->msg_uid = $x;
-    $this->mail_headers = '';
-    $this->mail_structure = '';
-    $this->mail_text = '';
-    $this->mail_parts = '';
-    $this->mail_info = '';
-    $this->dir = '';
-    $this->mimebits = '';
-  }
-
-  function set_msg_text($text) {
-    $this->set_msg(null);
-    $this->msg_text = $text;
-  }
-
-  function get_msg_header($uid=0) {
-    $uid or $uid = $this->msg_uid;
-    if ($uid) {
-      $this->mail_headers = $this->parse_headers(imap_fetchheader($this->connection, $uid, FT_UID));
-    } else if ($this->msg_text) {
-      $bits = preg_split("/\r?\n\r?\n/", $this->msg_text);
-      $this->mail_headers = $this->parse_headers($bits[0]);
-    }
-    return $this->mail_headers;
-  }
-
-  function parse_headers($headers="") {
-    $lines = preg_split("/\r?\n/", $headers);
-    foreach ($lines as $line) {
-      // start new header
-      if (preg_match('/^[A-Za-z]/', $line)) {
-        preg_match('/([^:]+): ?(.*)$/', $line, $matches);
-        $newHeader = strtolower($matches[1]);
-        $rtn[$newHeader] = trim($matches[2]);
-        $currentHeader = $newHeader;
-
-      // continue header
-      } else if ($line && $currentHeader) {
-        $rtn[$currentHeader] .= " ".trim($line);
-      }
-    }
-    return (array)$rtn;
-  }
-
-  function download_email_part($part) {
-    $this->load_structure();
-    $this->load_parts($this->mail_structure);
-    foreach ((array)$this->mail_parts as $v) {
-      $s = $v["part_object"]; // structure
-      if ($part == $v["part_number"]) {
-        $raw_data = imap_fetchbody($this->connection, $this->msg_uid, $part, FT_UID | FT_PEEK);
-        $thing = $this->decode_part($s->encoding,$raw_data);
-        $filename = $this->get_parameter_attribute_value($s->parameters,"name");
-        $filename or $filename = $this->get_parameter_attribute_value($s->parameters,"filename");
-        $filename or $filename = $this->get_parameter_attribute_value($s->dparameters,"name");
-        $filename or $filename = $this->get_parameter_attribute_value($s->dparameters,"filename");
-        return array($filename,$thing);
-      }
-    }
-    return array(false,false);
-  }
-
-  function load_structure() {
-    if ($this->msg_uid && !$this->mail_structure) {
-      $this->mail_structure = imap_fetchstructure($this->connection,$this->msg_uid,FT_UID);
-    } else if ($this->msg_text) {
-      $m = new Mail_mimeDecode($this->msg_text);
-      $params['include_bodies'] = true;
-      $params['decode_bodies']  = true;
-      $params['decode_headers'] = true;
-      $this->mail_structure = $m->decode($params);
-    }
-  }
-
-  function get_raw_email_by_msg_uid($msg_uid) {
-    // $result = imap_fetch_overview($this->connection,$msg_uid,FT_UID);
-    // only view emails that *have* been seen before otherwise 
-    // we might view an email before it has been downloaded by
-    // receiveEmail.php
-    //if (is_array($result) && $result[0]->seen) { 
-
-    // Now we don't care if it's been seen before, since we're not polling IMAP anymore
-    return $this->get_raw_header_and_body($msg_uid);
-  }
-
-  function get_raw_header_and_body($msg_uid=false) {
-    $msg_uid or $msg_uid = $this->msg_uid;
-    static $cache;
-
-    if ($msg_uid) {
-      if ($cache[$msg_uid]) {
-        return $cache[$msg_uid];
-      }
-      $header = imap_fetchheader($this->connection,$msg_uid, FT_UID);
-      $body = imap_body($this->connection,$msg_uid,FT_UID);
-      $cache[$msg_uid] = array($header,$body);
-      return $cache[$msg_uid];
-    } else if ($this->msg_text) {
-      return Mail_mimeDecode::_splitBodyHeader($this->msg_text);
-    }
-  }
-
-  function fetch_mail_text() {
-    $this->load_structure();
-    $this->load_parts($this->mail_structure);
-    foreach ($this->mail_parts as $v) {
-      $s = $v["part_object"]; // structure
-      $raw_data = imap_fetchbody($this->connection, $this->msg_uid, $v["part_number"],FT_UID | FT_PEEK);
-      $thing = $this->decode_part($s->encoding,$raw_data);
-      if (!$mail_text && strtolower($this->mime_types[$s->type]."/".$s->subtype) == "text/plain") {
-        $mail_text = $thing;
-      }
-      if (strtolower($this->mime_types[$s->type]."/".$s->subtype) == "text/html") {
-        $mail_html = $thing;
-      }
+        if ($this->lockfile && file_exists($this->lockfile)) {
+            alloc_error("Mailbox is locked. Remove ".$this->lockfile." to unlock.");
+        } else if ($this->lockfile) {
+            $this->lock();
+        }
     }
   
-    if ($mail_text) {
-      return $mail_text;
-    } else if ($mail_html) {
-      return $mail_html;
-    }
-  }
-
-  function save_email() {
-
-    if ($this->msg_text) {
-      return $this->save_email_from_text();
-    }
-
-    $this->load_structure();
-    $this->load_parts($this->mail_structure);
-
-    foreach ($this->mail_parts as $v) {
-      $s = $v["part_object"]; // structure
-      $raw_data = imap_fetchbody($this->connection, $this->msg_uid, $v["part_number"],FT_UID | FT_PEEK);
-      $thing = $this->decode_part($s->encoding,$raw_data);
-
-      if (!$this->mail_text && strtolower($this->mime_types[$s->type]."/".$s->subtype) == "text/plain") {
-        $this->mail_text = $thing;
-      } else {
-        $filename = $this->get_parameter_attribute_value($s->parameters,"name");
-        $filename or $filename = $this->get_parameter_attribute_value($s->parameters,"filename");
-        $filename or $filename = $this->get_parameter_attribute_value($s->dparameters,"name");
-        $filename or $filename = $this->get_parameter_attribute_value($s->dparameters,"filename");
-
-        if ($filename) {
-          $bits = array();
-          $bits["part"] = $v["part_number"];
-          $bits["name"] = $filename;
-          $bits["size"] = strlen($thing);
-          $bits["blob"] = $thing;
-          $this->mimebits[] = $bits;
+    function open_mailbox($folder = "", $ops = OP_HALFOPEN, $fatal = true)
+    {
+        if ($this->connection && is_resource($this->connection)) {
+            imap_close($this->connection);
         }
-      }
-    } 
-
-    // If there's no text/plain part, then search out a text/html one
-    if (!$this->mail_text) {
-      foreach ($this->mail_parts as $v) {
-        $s = $v["part_object"]; // structure
-        $raw_data = imap_fetchbody($this->connection, $this->msg_uid, $v["part_number"],FT_UID | FT_PEEK);
-        $thing = $this->decode_part($s->encoding,$raw_data);
-        if (strtolower($this->mime_types[$s->type]."/".$s->subtype) == "text/html") {
-          $this->mail_text = $thing;
+        $this->connect_string = '{'.$this->host.':'.$this->port.'/'.$this->protocol.config::get_config_item("allocEmailExtra").'}';
+        $this->connection = imap_open($this->connect_string, $this->username, $this->password, $ops);
+        if (!$this->connection && $fatal) {
+            alloc_error("Unable to access mail folder(1).");
         }
-      }
-    }
-  }
-
-  function parse_mime($structure) {
-    foreach ((array)$structure->parts as $part) {
-      if ($part->disposition == 'attachment') {
-        $i++;
-        $attachments[$i]['body'] = $part->body;
-        unset($name);
-        $name = $part->ctype_parameters['name'];
-        $name or $name = $part->ctype_parameters['filename'];
-        if (property_exists($part,"d_parameters") && is_array($part->d_parameters)) {
-          $name or $name = $part->d_parameters["name"];
-          $name or $name = $part->d_parameters["filename"];
-        }
-
-        $attachments[$i]['name'] = $name;
-      } else {
-        if(count($part->parts)>0) {
-          foreach($part->parts as $sp) {
-            if(strpos($sp->headers['content-type'],'text/plain')!==false) {
-              $plain = $sp->body;
+        $list = imap_list($this->connection, $this->connect_string, "*");
+        if (!is_array($list) || !count($list)) { // || !in_array($connect_string.$folder,$list)) {
+            $this->unlock();
+            imap_close($this->connection);
+            if ($fatal) {
+                alloc_error("Unable to access mail folder(2).");
             }
-            if(strpos($sp->headers['content-type'],'text/html')!==false) {
-              $html = $sp->body;
-            }
-          }
         } else {
-          if(strpos($part->headers['content-type'],'text/plain')!==false) {
-            $plain = $part->body;
-          }
-          if(strpos($part->headers['content-type'],'text/html')!==false) {
-            $html = $part->body;
-          }
-        }
-      }
-    }
-    if(trim($plain)=='') {
-      $plain = $structure->body;
-    }
-    return array($plain, $attachments);
-  }
+            $rtn = imap_reopen($this->connection, $this->connect_string.$folder);
 
-  function save_email_from_text() {
-    $this->load_structure();
-    list($this->mail_text,$attachments) = $this->parse_mime($this->mail_structure);
-
-    foreach ((array)$attachments as $k => $v) {
-      if ($v["name"]) {
-        $bits = array();
-        $bits["part"] = $k+1; // nope: $v["part_number"];
-        $bits["name"] = $v["name"];
-        $bits["size"] = strlen($v["body"]);
-        $bits["blob"] = $v["body"];
-        $this->mimebits[] = $bits;
-      }
-    }
-  }
-
-  function mark_seen() {
-    if ($this->msg_uid) {
-      imap_setflag_full($this->connection, $this->msg_uid, "\\SEEN", FT_UID); // this doesn't work!
-      $body = imap_body($this->connection, $this->msg_uid,FT_UID); // this seems to force it to be marked seen
-    }
-  }
-
-  function mark_unseen() {
-    imap_clearflag_full($this->connection, $this->msg_uid, "\\SEEN", ST_UID);
-  }
-
-  function forward($address,$subject,$text='') {
-    list($header,$body) = $this->get_raw_header_and_body();
-    $header and $header_obj = $this->parse_headers($header);
-    $orig_subject = $header_obj["subject"];
-    $orig_subject and $s = " [".trim($orig_subject)."]";
-
-    $dir = ATTACHMENTS_DIR.'tmp'.DIRECTORY_SEPARATOR;
-
-    $filename = md5($header.$body);
-    $fh = fopen($dir.$filename,"wb");
-    fputs($fh, $header.$body);
-    fclose($fh);
-
-    $email = new email_send();
-    $email->set_from(config::get_config_item("AllocFromEmailAddress"));
-    $email->set_subject($subject.$s);
-    $email->set_body($text);
-    $email->set_to_address($address);
-    $email->set_message_type("orphan");
-    $email->add_attachment($dir.$filename);
-    $email->send(false);
-
-    unlink($dir.$filename);
-  }
-
-  function lock() {
-    if (is_dir(dirname($this->lockfile)) && is_writeable(dirname($this->lockfile))) {
-      $fh = fopen($this->lockfile,"w");
-      fputs($fh,date("r"));
-      fclose($fh);
-    }
-  }
-
-  function unlock() {
-    if (file_exists($this->lockfile)) {
-      unlink($this->lockfile);  
-    }
-  }
-
-  function close() {
-    $this->unlock();
-    if ($this->connection) {
-      #imap_close($this->connection);
-      imap_close($this->connection,CL_EXPUNGE); // expunge messages marked for deletion
-    }
-  }
-
-  function archive($mailbox=null) {
-    $keys = $this->get_hashes();
-    $token = new token();
-    if ($keys && is_array($keys) && $token->set_hash($keys[0])) {
-      if ($token->get_value("tokenEntity") == "comment") {
-        $db = new db_alloc();
-        $row = $db->qr("SELECT commentMaster,commentMasterID 
-                          FROM comment
-                         WHERE commentID = %d"
-                      ,$token->get_value("tokenEntityID"));
-        $m = $row["commentMaster"];
-        $mID = $row["commentMasterID"];
-        $mailbox = "INBOX/".$m.$mID;
-      } else {
-        $m = $token->get_value("tokenEntity");
-        $mID = $token->get_value("tokenEntityID");
-        $mailbox = "INBOX/".$m.$mID;
-      }
-    }
-    $mailbox or $mailbox = "INBOX";
-
-    // Some IMAP servers like dot-separated mail folders, some like slash-separated
-    if ($mailbox) { 
-      $this->create_mailbox($mailbox);
-
-      if ($this->msg_uid) {
-        $this->move_mail($this->msg_uid,$mailbox);
-
-      } else if ($this->msg_text) {
-        $this->append($mailbox,$this->msg_text);
-      }
-    }
-  }
-
-  function append($mailbox,$text) {
-    $appended = imap_append($this->connection,$this->connect_string.$mailbox,$text);
-    $appended or $appended = imap_append($this->connection,$this->connect_string.str_replace("/",".",$mailbox),$text);
-    return $appended;
-  }
-
-  function delete($x=0) {
-    #return;
-    $x or $x = $this->msg_uid;
-    if ($this->connection) {
-      imap_delete($this->connection, $x, FT_UID);
-    }
-  }
-
-  function expunge() {
-    imap_expunge($this->connection);
-  }
-
-  function get_hashes($headers=false) {
-    $headers or $headers = $this->mail_headers;
-    $keys = array();
-
-    if (preg_match("/\{Key:[A-Za-z0-9]{8}/i",$headers["subject"],$m)) {
-      $key = $m[0];
-      $key = str_replace("{Key:","",$key);
-      $key and $keys[] = $key;
-    }
-
-    $str = $headers["in-reply-to"]." ".$headers["references"]." ".$headers["message-id"];
-
-    preg_match_all("/\.alloc\.key\.([A-Za-z0-9]{8})@/",$str,$m);
-
-    if (is_array($m[1])) {
-      $temp = array_flip($m[1]);// unique pls
-      foreach ($temp as $k => $v) {
-        $keys[] = $k;
-      }
-    }
-
-    return array_unique((array)$keys);
-  }
-
-  function get_commands($commands=array()) {
-    list($header,$body) = $this->get_raw_header_and_body();
-    $header and $header_obj = $this->parse_headers($header);
-    $subject = $header_obj["subject"];
-    
-    $e = new email_send();
-    $e->set_headers($header);
-  
-
-    $str = $header_obj["in-reply-to"]." ".$header_obj["references"];
-    preg_match_all("/\.alloc\.key\.([A-Za-z0-9]{8})@/",$str,$m);
-    if (is_array($m[1])) {
-      $temp = array_flip($m[1]);// unique pls
-      foreach ($temp as $k => $v) {
-        $rtn["key"][] = $k;
-      }
-    }
-
-    // We now have: $header,$body,$subject
-    if ($commands) {
-      /* Disabled ...
-      // Look for commands in the email's header
-      foreach ($commands as $k=>$v) {
-        $h = trim($e->get_header("x-alloc-".$k));
-        $h and $rtn[strtolower($k)][] = $h;
-      }
-
-      // Look for commands in the email's body
-      $lines = explode("\n",$this->mail_text);
-
-      #echo "Lines: ".print_r($lines,1);
-      #echo "<br>Com:".print_r($commands,1);
-
-      // Loop through the email backwards, we're looking for the final paragraph of commands
-      for($i=count($lines);$i>0;$i--){
-        #echo "<br>line: [".$i."]:".$lines[$i]." go:".sprintf("%d",$go)." starting_line: ".$starting_line;
-        $lines[$i] and $go = true;
-        $go && !$lines[$i] and $starting_line = $i;
-      }
-
-      // Loop forwards and accumulate the commands
-      for($i=$starting_line-1;$i<=count($lines);$i++) {
-        foreach ($commands as $k=>$v) {
-          preg_match("/^".$k.":\s*(.*)$/i",$lines[$i],$matches);
-          if ($matches[1]) {
-            $rtn[strtolower($k)][] = trim($matches[1]);
-          }
-        }
-      }
-      */ 
-      // Look for commands in the email's subject line
-      preg_match("/{(Key:[^}]*)}/i",$subject,$matches);
-      $subject = $matches[1];
-      $bits = explode("^",$subject);
-      foreach ($bits as $bit) {
-        if ($bit) {
-          // ^something: value
-          $chunks = explode(":",$bit);
-          $key = trim(array_shift($chunks));
-          $val = trim(implode(":",$chunks)); 
-          if ($commands[strtolower($key)] && $val) {
-            $rtn[strtolower($key)][] = trim($val);
-          }
-        }
-      }
-    }
-  
-    // we can have multiple time: entries in an email
-    // all other commands are only used once per email
-    foreach ((array)$rtn as $k => $v) {
-      if ($k == "time") {
-        $r[$k] = $v;
-      } else {
-        $r[$k] = end($v);
-      }
-    }
-
-    return (array)$r; 
-  }
-  
-  function decode_part($encoding, $thing) {
-    if ($encoding == 0) { 
-      // 7bit
-    } else if ($encoding == 1) { 
-      // 8bit
-    } else if ($encoding == 2) { 
-      // 8bit
-    } else if ($encoding == 3) { 
-      $thing = imap_base64($thing);  // Decodes base64
-    } else if ($encoding == 4) { 
-      $thing = imap_qprint($thing);  // quoted-printable to 8bit
-    } else if ($encoding == 5) { 
-      // ietf-token
-    }
-    return $thing;
-  }
-
-  function load_parts($struct) {
-    if (!$this->mail_parts) {
-      if (sizeof($struct->parts) > 0) {
-        foreach ($struct->parts as $count => $part) {
-          $this->add_part_to_array($part, ($count+1));
-        }
-      // Email does not have a seperate mime attachment for text
-      } else {
-        $this->mail_parts[] = array('part_number'=>'1', 'part_object'=>$struct);
-      }
-    }
-    return $this->mail_parts;
-  }
-
-  function add_part_to_array($struct, $partno) {
-    $this->mail_parts[] = array('part_number'=>$partno, 'part_object'=>$struct);
-
-    // Check to see if the part is an attached email message, as in the RFC-822 type
-    if ($struct->type == 2) {
-      if (sizeof($struct->parts) > 0) {
-        foreach ($struct->parts as $count => $part) {
-
-          // Iterate here again to compensate for the broken way that imap_fetchbody() handles attachments
-          if (sizeof($part->parts) > 0) {
-            foreach ($part->parts as $count2 => $part2) {
-              $this->add_part_to_array($part2, $partno.".".($count2+1));
+            $errs = print_r(imap_errors(), 1);
+            if (!$rtn || preg_match("/Invalid mailbox name/i", $errs) || preg_match("/Mailbox does not exist/i", $errs)) {
+                $rtn = imap_reopen($this->connection, $this->connect_string.str_replace("/", ".", $folder));
             }
 
-          // Attached email does not have a seperate mime attachment for text
-          } else {
-            $this->mail_parts[] = array('part_number'=>$partno.'.'.($count+1), 'part_object'=>$struct);
+            if (!$rtn) {
+                imap_close($this->connection);
+                if ($fatal) {
+                    alloc_error("Unable to access mail folder(3).");
+                }
+            }
+        }
+        if (!$rtn && $fatal) {
+            alloc_error("<pre>IMAP errors: ".print_r(imap_errors(), 1).print_r(imap_alerts(), 1)."</pre>");
+        }
+        return $rtn;
+    }
+
+    function get_num_emails()
+    {
+        if (!$this->mail_info) {
+            $this->check_mail();
+        }
+        if (is_object($this->mail_info)) {
+            return $this->mail_info->messages;
+        }
+    }
+
+    function get_num_new_emails()
+    {
+        if (!$this->mail_info) {
+            $this->check_mail();
+        }
+        if (is_object($this->mail_info)) {
+            return $this->mail_info->unseen;
+        }
+    }
+
+    function check_mail()
+    {
+        if ($this->connection) {
+            $this->mail_info = imap_status($this->connection, $this->connect_string, SA_ALL);
+        } else {
+            unset($this->mail_info);
+        }
+    }
+
+    function create_mailbox($name)
+    {
+        if (!imap_status($this->connection, $this->connect_string.$name, SA_ALL)) {
+            $rtn = imap_createmailbox($this->connection, imap_utf7_encode($this->connect_string.$name));
+        }
+        if (!$rtn) {
+            $name = str_replace("/", ".", $name);
+            if (!imap_status($this->connection, $this->connect_string.$name, SA_ALL)) {
+                $rtn = imap_createmailbox($this->connection, imap_utf7_encode($this->connect_string.$name));
+            }
+        }
+        return $rtn;
+    }
+
+    function move_mail($uid, $mailbox)
+    {
+        $moved = imap_mail_move($this->connection, $uid, $mailbox, CP_UID);
+        $moved or $moved = imap_mail_move($this->connection, $uid, str_replace("/", ".", $mailbox), CP_UID);
+        return $moved;
+    }
+
+    function get_new_email_msg_uids()
+    {
+        return imap_search($this->connection, "UNSEEN", SE_UID);
+    }
+
+    function set_unread()
+    {
+        return imap_clearflag_full($this->connection, $this->msg_uid, '\\Seen', ST_UID);
+    }
+
+    function get_all_email_msg_uids()
+    {
+        return imap_search($this->connection, "ALL", SE_UID);
+    }
+
+    function get_emails_UIDs_search($str)
+    {
+        return imap_search($this->connection, $str, SE_UID);
+    }
+
+    function set_msg($x)
+    {
+        $this->msg_uid = $x;
+        $this->mail_headers = '';
+        $this->mail_structure = '';
+        $this->mail_text = '';
+        $this->mail_parts = '';
+        $this->mail_info = '';
+        $this->dir = '';
+        $this->mimebits = '';
+    }
+
+    function set_msg_text($text)
+    {
+        $this->set_msg(null);
+        $this->msg_text = $text;
+    }
+
+    function get_msg_header($uid = 0)
+    {
+        $uid or $uid = $this->msg_uid;
+        if ($uid) {
+            $this->mail_headers = $this->parse_headers(imap_fetchheader($this->connection, $uid, FT_UID));
+        } else if ($this->msg_text) {
+            $bits = preg_split("/\r?\n\r?\n/", $this->msg_text);
+            $this->mail_headers = $this->parse_headers($bits[0]);
+        }
+        return $this->mail_headers;
+    }
+
+    function parse_headers($headers = "")
+    {
+        $lines = preg_split("/\r?\n/", $headers);
+        foreach ($lines as $line) {
+          // start new header
+            if (preg_match('/^[A-Za-z]/', $line)) {
+                preg_match('/([^:]+): ?(.*)$/', $line, $matches);
+                $newHeader = strtolower($matches[1]);
+                $rtn[$newHeader] = trim($matches[2]);
+                $currentHeader = $newHeader;
+
+              // continue header
+            } else if ($line && $currentHeader) {
+                $rtn[$currentHeader] .= " ".trim($line);
+            }
+        }
+        return (array)$rtn;
+    }
+
+    function download_email_part($part)
+    {
+        $this->load_structure();
+        $this->load_parts($this->mail_structure);
+        foreach ((array)$this->mail_parts as $v) {
+            $s = $v["part_object"]; // structure
+            if ($part == $v["part_number"]) {
+                $raw_data = imap_fetchbody($this->connection, $this->msg_uid, $part, FT_UID | FT_PEEK);
+                $thing = $this->decode_part($s->encoding, $raw_data);
+                $filename = $this->get_parameter_attribute_value($s->parameters, "name");
+                $filename or $filename = $this->get_parameter_attribute_value($s->parameters, "filename");
+                $filename or $filename = $this->get_parameter_attribute_value($s->dparameters, "name");
+                $filename or $filename = $this->get_parameter_attribute_value($s->dparameters, "filename");
+                return array($filename,$thing);
+            }
+        }
+        return array(false,false);
+    }
+
+    function load_structure()
+    {
+        if ($this->msg_uid && !$this->mail_structure) {
+            $this->mail_structure = imap_fetchstructure($this->connection, $this->msg_uid, FT_UID);
+        } else if ($this->msg_text) {
+            $m = new Mail_mimeDecode($this->msg_text);
+            $params['include_bodies'] = true;
+            $params['decode_bodies']  = true;
+            $params['decode_headers'] = true;
+            $this->mail_structure = $m->decode($params);
+        }
+    }
+
+    function get_raw_email_by_msg_uid($msg_uid)
+    {
+      // $result = imap_fetch_overview($this->connection,$msg_uid,FT_UID);
+      // only view emails that *have* been seen before otherwise
+      // we might view an email before it has been downloaded by
+      // receiveEmail.php
+      //if (is_array($result) && $result[0]->seen) {
+
+      // Now we don't care if it's been seen before, since we're not polling IMAP anymore
+        return $this->get_raw_header_and_body($msg_uid);
+    }
+
+    function get_raw_header_and_body($msg_uid = false)
+    {
+        $msg_uid or $msg_uid = $this->msg_uid;
+        static $cache;
+
+        if ($msg_uid) {
+            if ($cache[$msg_uid]) {
+                return $cache[$msg_uid];
+            }
+            $header = imap_fetchheader($this->connection, $msg_uid, FT_UID);
+            $body = imap_body($this->connection, $msg_uid, FT_UID);
+            $cache[$msg_uid] = array($header,$body);
+            return $cache[$msg_uid];
+        } else if ($this->msg_text) {
+            return Mail_mimeDecode::_splitBodyHeader($this->msg_text);
+        }
+    }
+
+    function fetch_mail_text()
+    {
+        $this->load_structure();
+        $this->load_parts($this->mail_structure);
+        foreach ($this->mail_parts as $v) {
+            $s = $v["part_object"]; // structure
+            $raw_data = imap_fetchbody($this->connection, $this->msg_uid, $v["part_number"], FT_UID | FT_PEEK);
+            $thing = $this->decode_part($s->encoding, $raw_data);
+            if (!$mail_text && strtolower($this->mime_types[$s->type]."/".$s->subtype) == "text/plain") {
+                $mail_text = $thing;
+            }
+            if (strtolower($this->mime_types[$s->type]."/".$s->subtype) == "text/html") {
+                $mail_html = $thing;
+            }
+        }
+  
+        if ($mail_text) {
+            return $mail_text;
+        } else if ($mail_html) {
+            return $mail_html;
+        }
+    }
+
+    function save_email()
+    {
+
+        if ($this->msg_text) {
+            return $this->save_email_from_text();
+        }
+
+        $this->load_structure();
+        $this->load_parts($this->mail_structure);
+
+        foreach ($this->mail_parts as $v) {
+            $s = $v["part_object"]; // structure
+            $raw_data = imap_fetchbody($this->connection, $this->msg_uid, $v["part_number"], FT_UID | FT_PEEK);
+            $thing = $this->decode_part($s->encoding, $raw_data);
+
+            if (!$this->mail_text && strtolower($this->mime_types[$s->type]."/".$s->subtype) == "text/plain") {
+                $this->mail_text = $thing;
+            } else {
+                $filename = $this->get_parameter_attribute_value($s->parameters, "name");
+                $filename or $filename = $this->get_parameter_attribute_value($s->parameters, "filename");
+                $filename or $filename = $this->get_parameter_attribute_value($s->dparameters, "name");
+                $filename or $filename = $this->get_parameter_attribute_value($s->dparameters, "filename");
+
+                if ($filename) {
+                    $bits = array();
+                    $bits["part"] = $v["part_number"];
+                    $bits["name"] = $filename;
+                    $bits["size"] = strlen($thing);
+                    $bits["blob"] = $thing;
+                    $this->mimebits[] = $bits;
+                }
+            }
+        }
+
+      // If there's no text/plain part, then search out a text/html one
+        if (!$this->mail_text) {
+            foreach ($this->mail_parts as $v) {
+                $s = $v["part_object"]; // structure
+                $raw_data = imap_fetchbody($this->connection, $this->msg_uid, $v["part_number"], FT_UID | FT_PEEK);
+                $thing = $this->decode_part($s->encoding, $raw_data);
+                if (strtolower($this->mime_types[$s->type]."/".$s->subtype) == "text/html") {
+                    $this->mail_text = $thing;
+                }
+            }
+        }
+    }
+
+    function parse_mime($structure)
+    {
+        foreach ((array)$structure->parts as $part) {
+            if ($part->disposition == 'attachment') {
+                $i++;
+                $attachments[$i]['body'] = $part->body;
+                unset($name);
+                $name = $part->ctype_parameters['name'];
+                $name or $name = $part->ctype_parameters['filename'];
+                if (property_exists($part, "d_parameters") && is_array($part->d_parameters)) {
+                    $name or $name = $part->d_parameters["name"];
+                    $name or $name = $part->d_parameters["filename"];
+                }
+
+                $attachments[$i]['name'] = $name;
+            } else {
+                if (count($part->parts)>0) {
+                    foreach ($part->parts as $sp) {
+                        if (strpos($sp->headers['content-type'], 'text/plain')!==false) {
+                            $plain = $sp->body;
+                        }
+                        if (strpos($sp->headers['content-type'], 'text/html')!==false) {
+                            $html = $sp->body;
+                        }
+                    }
+                } else {
+                    if (strpos($part->headers['content-type'], 'text/plain')!==false) {
+                        $plain = $part->body;
+                    }
+                    if (strpos($part->headers['content-type'], 'text/html')!==false) {
+                        $html = $part->body;
+                    }
+                }
+            }
+        }
+        if (trim($plain)=='') {
+            $plain = $structure->body;
+        }
+        return array($plain, $attachments);
+    }
+
+    function save_email_from_text()
+    {
+        $this->load_structure();
+        list($this->mail_text,$attachments) = $this->parse_mime($this->mail_structure);
+
+        foreach ((array)$attachments as $k => $v) {
+            if ($v["name"]) {
+                $bits = array();
+                $bits["part"] = $k+1; // nope: $v["part_number"];
+                $bits["name"] = $v["name"];
+                $bits["size"] = strlen($v["body"]);
+                $bits["blob"] = $v["body"];
+                $this->mimebits[] = $bits;
+            }
+        }
+    }
+
+    function mark_seen()
+    {
+        if ($this->msg_uid) {
+            imap_setflag_full($this->connection, $this->msg_uid, "\\SEEN", FT_UID); // this doesn't work!
+            $body = imap_body($this->connection, $this->msg_uid, FT_UID); // this seems to force it to be marked seen
+        }
+    }
+
+    function mark_unseen()
+    {
+        imap_clearflag_full($this->connection, $this->msg_uid, "\\SEEN", ST_UID);
+    }
+
+    function forward($address, $subject, $text = '')
+    {
+        list($header,$body) = $this->get_raw_header_and_body();
+        $header and $header_obj = $this->parse_headers($header);
+        $orig_subject = $header_obj["subject"];
+        $orig_subject and $s = " [".trim($orig_subject)."]";
+
+        $dir = ATTACHMENTS_DIR.'tmp'.DIRECTORY_SEPARATOR;
+
+        $filename = md5($header.$body);
+        $fh = fopen($dir.$filename, "wb");
+        fputs($fh, $header.$body);
+        fclose($fh);
+
+        $email = new email_send();
+        $email->set_from(config::get_config_item("AllocFromEmailAddress"));
+        $email->set_subject($subject.$s);
+        $email->set_body($text);
+        $email->set_to_address($address);
+        $email->set_message_type("orphan");
+        $email->add_attachment($dir.$filename);
+        $email->send(false);
+
+        unlink($dir.$filename);
+    }
+
+    function lock()
+    {
+        if (is_dir(dirname($this->lockfile)) && is_writeable(dirname($this->lockfile))) {
+            $fh = fopen($this->lockfile, "w");
+            fputs($fh, date("r"));
+            fclose($fh);
+        }
+    }
+
+    function unlock()
+    {
+        if (file_exists($this->lockfile)) {
+            unlink($this->lockfile);
+        }
+    }
+
+    function close()
+    {
+        $this->unlock();
+        if ($this->connection) {
+          #imap_close($this->connection);
+            imap_close($this->connection, CL_EXPUNGE); // expunge messages marked for deletion
+        }
+    }
+
+    function archive($mailbox = null)
+    {
+        $keys = $this->get_hashes();
+        $token = new token();
+        if ($keys && is_array($keys) && $token->set_hash($keys[0])) {
+            if ($token->get_value("tokenEntity") == "comment") {
+                $db = new db_alloc();
+                $row = $db->qr(
+                    "SELECT commentMaster,commentMasterID 
+                          FROM comment
+                         WHERE commentID = %d",
+                    $token->get_value("tokenEntityID")
+                );
+                $m = $row["commentMaster"];
+                $mID = $row["commentMasterID"];
+                $mailbox = "INBOX/".$m.$mID;
+            } else {
+                $m = $token->get_value("tokenEntity");
+                $mID = $token->get_value("tokenEntityID");
+                $mailbox = "INBOX/".$m.$mID;
+            }
+        }
+        $mailbox or $mailbox = "INBOX";
+
+      // Some IMAP servers like dot-separated mail folders, some like slash-separated
+        if ($mailbox) {
+            $this->create_mailbox($mailbox);
+
+            if ($this->msg_uid) {
+                $this->move_mail($this->msg_uid, $mailbox);
+            } else if ($this->msg_text) {
+                $this->append($mailbox, $this->msg_text);
+            }
+        }
+    }
+
+    function append($mailbox, $text)
+    {
+        $appended = imap_append($this->connection, $this->connect_string.$mailbox, $text);
+        $appended or $appended = imap_append($this->connection, $this->connect_string.str_replace("/", ".", $mailbox), $text);
+        return $appended;
+    }
+
+    function delete($x = 0)
+    {
+      #return;
+        $x or $x = $this->msg_uid;
+        if ($this->connection) {
+            imap_delete($this->connection, $x, FT_UID);
+        }
+    }
+
+    function expunge()
+    {
+        imap_expunge($this->connection);
+    }
+
+    function get_hashes($headers = false)
+    {
+        $headers or $headers = $this->mail_headers;
+        $keys = array();
+
+        if (preg_match("/\{Key:[A-Za-z0-9]{8}/i", $headers["subject"], $m)) {
+            $key = $m[0];
+            $key = str_replace("{Key:", "", $key);
+            $key and $keys[] = $key;
+        }
+
+        $str = $headers["in-reply-to"]." ".$headers["references"]." ".$headers["message-id"];
+
+        preg_match_all("/\.alloc\.key\.([A-Za-z0-9]{8})@/", $str, $m);
+
+        if (is_array($m[1])) {
+            $temp = array_flip($m[1]);// unique pls
+            foreach ($temp as $k => $v) {
+                $keys[] = $k;
+            }
+        }
+
+        return array_unique((array)$keys);
+    }
+
+    function get_commands($commands = array())
+    {
+        list($header,$body) = $this->get_raw_header_and_body();
+        $header and $header_obj = $this->parse_headers($header);
+        $subject = $header_obj["subject"];
+    
+        $e = new email_send();
+        $e->set_headers($header);
+  
+
+        $str = $header_obj["in-reply-to"]." ".$header_obj["references"];
+        preg_match_all("/\.alloc\.key\.([A-Za-z0-9]{8})@/", $str, $m);
+        if (is_array($m[1])) {
+            $temp = array_flip($m[1]);// unique pls
+            foreach ($temp as $k => $v) {
+                $rtn["key"][] = $k;
+            }
+        }
+
+      // We now have: $header,$body,$subject
+        if ($commands) {
+          /* Disabled ...
+          // Look for commands in the email's header
+          foreach ($commands as $k=>$v) {
+            $h = trim($e->get_header("x-alloc-".$k));
+            $h and $rtn[strtolower($k)][] = $h;
           }
+
+          // Look for commands in the email's body
+          $lines = explode("\n",$this->mail_text);
+
+          #echo "Lines: ".print_r($lines,1);
+          #echo "<br>Com:".print_r($commands,1);
+
+          // Loop through the email backwards, we're looking for the final paragraph of commands
+          for($i=count($lines);$i>0;$i--){
+            #echo "<br>line: [".$i."]:".$lines[$i]." go:".sprintf("%d",$go)." starting_line: ".$starting_line;
+            $lines[$i] and $go = true;
+            $go && !$lines[$i] and $starting_line = $i;
+          }
+
+          // Loop forwards and accumulate the commands
+          for($i=$starting_line-1;$i<=count($lines);$i++) {
+            foreach ($commands as $k=>$v) {
+            preg_match("/^".$k.":\s*(.*)$/i",$lines[$i],$matches);
+            if ($matches[1]) {
+            $rtn[strtolower($k)][] = trim($matches[1]);
+            }
+            }
+          }
+          */
+          // Look for commands in the email's subject line
+            preg_match("/{(Key:[^}]*)}/i", $subject, $matches);
+            $subject = $matches[1];
+            $bits = explode("^", $subject);
+            foreach ($bits as $bit) {
+                if ($bit) {
+                  // ^something: value
+                    $chunks = explode(":", $bit);
+                    $key = trim(array_shift($chunks));
+                    $val = trim(implode(":", $chunks));
+                    if ($commands[strtolower($key)] && $val) {
+                        $rtn[strtolower($key)][] = trim($val);
+                    }
+                }
+            }
+        }
+  
+      // we can have multiple time: entries in an email
+      // all other commands are only used once per email
+        foreach ((array)$rtn as $k => $v) {
+            if ($k == "time") {
+                $r[$k] = $v;
+            } else {
+                $r[$k] = end($v);
+            }
         }
 
-      // Not sure if this is possible
-      } else {
-        $this->mail_parts[] = array('part_number'=>$prefix.'.1', 'part_object'=>$struct);
-      }
-    // If there are more sub-parts, expand them out.
-    } else {
-      if (sizeof($struct->parts) > 0) {
-        foreach ($struct->parts as $count => $p) {
-          $this->add_part_to_array($p, $partno.".".($count+1));
+        return (array)$r;
+    }
+  
+    function decode_part($encoding, $thing)
+    {
+        if ($encoding == 0) {
+          // 7bit
+        } else if ($encoding == 1) {
+          // 8bit
+        } else if ($encoding == 2) {
+          // 8bit
+        } else if ($encoding == 3) {
+            $thing = imap_base64($thing);  // Decodes base64
+        } else if ($encoding == 4) {
+            $thing = imap_qprint($thing);  // quoted-printable to 8bit
+        } else if ($encoding == 5) {
+          // ietf-token
         }
-      }
-    }
-  }
-
-  function get_charset() {
-    if (!$this->mail_structure) {
-      $this->load_structure();
+        return $thing;
     }
 
-    if (property_exists($this->mail_structure,"parameters")) {
-      return $this->get_parameter_attribute_value($this->mail_structure->parameters,"charset");
-
-    } else if (property_exists($this->mail_structure,"ctype_parameters") && is_array($this->mail_structure->ctype_parameters)) {
-      return $this->mail_structure->ctype_parameters["charset"];
+    function load_parts($struct)
+    {
+        if (!$this->mail_parts) {
+            if (sizeof($struct->parts) > 0) {
+                foreach ($struct->parts as $count => $part) {
+                    $this->add_part_to_array($part, ($count+1));
+                }
+              // Email does not have a seperate mime attachment for text
+            } else {
+                $this->mail_parts[] = array('part_number'=>'1', 'part_object'=>$struct);
+            }
+        }
+        return $this->mail_parts;
     }
-  }
 
-  function get_parameter_attribute_value($parameters,$needle) {
-    foreach ((array)$parameters as $v) {
-      if (strtolower($v->attribute) == $needle) {
-        $rtn = $v->value;
-      }
+    function add_part_to_array($struct, $partno)
+    {
+        $this->mail_parts[] = array('part_number'=>$partno, 'part_object'=>$struct);
+
+      // Check to see if the part is an attached email message, as in the RFC-822 type
+        if ($struct->type == 2) {
+            if (sizeof($struct->parts) > 0) {
+                foreach ($struct->parts as $count => $part) {
+                  // Iterate here again to compensate for the broken way that imap_fetchbody() handles attachments
+                    if (sizeof($part->parts) > 0) {
+                        foreach ($part->parts as $count2 => $part2) {
+                            $this->add_part_to_array($part2, $partno.".".($count2+1));
+                        }
+
+                        // Attached email does not have a seperate mime attachment for text
+                    } else {
+                        $this->mail_parts[] = array('part_number'=>$partno.'.'.($count+1), 'part_object'=>$struct);
+                    }
+                }
+
+              // Not sure if this is possible
+            } else {
+                $this->mail_parts[] = array('part_number'=>$prefix.'.1', 'part_object'=>$struct);
+            }
+        // If there are more sub-parts, expand them out.
+        } else {
+            if (sizeof($struct->parts) > 0) {
+                foreach ($struct->parts as $count => $p) {
+                    $this->add_part_to_array($p, $partno.".".($count+1));
+                }
+            }
+        }
     }
-    return $rtn;
-  }
 
-  function get_converted_encoding() {
-    // Update comment with the text body and the creator
-    $body = trim($this->mail_text);
+    function get_charset()
+    {
+        if (!$this->mail_structure) {
+            $this->load_structure();
+        }
 
-    // if the email has a different encoding, change it to the DB connection encoding so mysql doesn't choke
-    $enc = $this->get_charset();
-    if ($enc) {
-      $db = new db_alloc();
-      $db->connect();
-      $body = mb_convert_encoding($body, $db->get_encoding(), $enc);
+        if (property_exists($this->mail_structure, "parameters")) {
+            return $this->get_parameter_attribute_value($this->mail_structure->parameters, "charset");
+        } else if (property_exists($this->mail_structure, "ctype_parameters") && is_array($this->mail_structure->ctype_parameters)) {
+            return $this->mail_structure->ctype_parameters["charset"];
+        }
     }
-    return $body;
-  }
 
-  function get_printable_from_address() {
-    list($from_address,$from_name) = parse_email_address($this->mail_headers["from"]);
-    if ($from_address && $from_name) {
-      $f = $from_name." <".$from_address.">";
-    } else if ($from_name) {
-      $f = $from_name;
-    } else if ($from_address) {
-      $f = $from_address;
+    function get_parameter_attribute_value($parameters, $needle)
+    {
+        foreach ((array)$parameters as $v) {
+            if (strtolower($v->attribute) == $needle) {
+                $rtn = $v->value;
+            }
+        }
+        return $rtn;
     }
-    return $f;
-  }
+
+    function get_converted_encoding()
+    {
+      // Update comment with the text body and the creator
+        $body = trim($this->mail_text);
+
+      // if the email has a different encoding, change it to the DB connection encoding so mysql doesn't choke
+        $enc = $this->get_charset();
+        if ($enc) {
+            $db = new db_alloc();
+            $db->connect();
+            $body = mb_convert_encoding($body, $db->get_encoding(), $enc);
+        }
+        return $body;
+    }
+
+    function get_printable_from_address()
+    {
+        list($from_address,$from_name) = parse_email_address($this->mail_headers["from"]);
+        if ($from_address && $from_name) {
+            $f = $from_name." <".$from_address.">";
+        } else if ($from_name) {
+            $f = $from_name;
+        } else if ($from_address) {
+            $f = $from_address;
+        }
+        return $f;
+    }
 }
 
 
 // Tests
 if (basename($_SERVER["PHP_SELF"]) == "email_receive.inc.php") {
-  define("NO_AUTH",1);
-  require_once("alloc.php");
+    define("NO_AUTH", 1);
+    require_once("alloc.php");
   //require_once("emailsettings.php");
 
-  $num = 30;
+    $num = 30;
 
-  $e = new email_receive($info);
-  $e->open_mailbox("INBOX");
+    $e = new email_receive($info);
+    $e->open_mailbox("INBOX");
 
-  echo "\nNum emails: ".$e->get_num_emails();
-  echo "\nNew emails: ".$e->get_num_new_emails();
-  echo "\ncheck_mail(): ".str_replace("\n"," ",print_r($e->mail_info,1));
-  echo "\nget_new_email_msg_uids(): ".str_replace("\n"," ",print_r($e->get_new_email_msg_uids(),1));
-  echo "\nget_all_email_msg_uids(): ".str_replace("\n"," ",print_r($e->get_all_email_msg_uids(),1));
+    echo "\nNum emails: ".$e->get_num_emails();
+    echo "\nNew emails: ".$e->get_num_new_emails();
+    echo "\ncheck_mail(): ".str_replace("\n", " ", print_r($e->mail_info, 1));
+    echo "\nget_new_email_msg_uids(): ".str_replace("\n", " ", print_r($e->get_new_email_msg_uids(), 1));
+    echo "\nget_all_email_msg_uids(): ".str_replace("\n", " ", print_r($e->get_all_email_msg_uids(), 1));
   //exit();
-  echo "\nget_emails_UIDs_search(): ".str_replace("\n"," ",print_r($e->get_emails_UIDs_search("SUBJECT alloc"),1));
+    echo "\nget_emails_UIDs_search(): ".str_replace("\n", " ", print_r($e->get_emails_UIDs_search("SUBJECT alloc"), 1));
   //echo "\nget_msg_header(): ".str_replace("\n"," ",print_r($e->get_msg_header($num),1));
 
-  echo "\n";
-  $e->set_msg($num);
-  $e->load_structure();
-  echo "\nload_structure(): ".str_replace(" "," ",print_r($e->mail_structure,1));
-  echo "\nget_charset(): ".$e->get_charset();
+    echo "\n";
+    $e->set_msg($num);
+    $e->load_structure();
+    echo "\nload_structure(): ".str_replace(" ", " ", print_r($e->mail_structure, 1));
+    echo "\nget_charset(): ".$e->get_charset();
   //exit();
 
-  list($h,$b) = $e->get_raw_email_by_msg_uid($num);
+    list($h,$b) = $e->get_raw_email_by_msg_uid($num);
   //echo "\nget_raw_email_by_msg_uid(): "."HEADER: ".$h."\nBODY: ".$b;
 
-  echo "\nsave_email(): ".$e->save_email();
+    echo "\nsave_email(): ".$e->save_email();
   //echo "\nload_parts(): ".print_r($e->mail_parts,1);
-  echo "\nmail_text (plaintext version): ".$e->mail_text;
-  echo "\nget_commands(): ".print_r($e->get_commands(task::get_exposed_fields()),1);
-  echo "\n";
+    echo "\nmail_text (plaintext version): ".$e->mail_text;
+    echo "\nget_commands(): ".print_r($e->get_commands(task::get_exposed_fields()), 1);
+    echo "\n";
 }
-
-
-
-
-?>

--- a/email/lib/email_send.inc.php
+++ b/email/lib/email_send.inc.php
@@ -3,261 +3,282 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 // Class to handle all emails that alloc sends
-// 
+//
 // Will log emails sent, and will not attempt to send email when the server is a dev boxes
-// 
-class email_send {
+//
+class email_send
+{
   
   // If URL has any of these strings in it then the email won't be sent.
   #var $no_email_urls = array("alloc_dev");
-  var $no_email_urls = array();
+    var $no_email_urls = array();
 
   // If alloc is running on any of these boxes then no emails will be sent!
-  var $no_email_hosts = array();
+    var $no_email_hosts = array();
 
   // Set to true to skip host and url checking
-  var $ignore_no_email_hosts = false; 
-  var $ignore_no_email_urls = false; 
+    var $ignore_no_email_hosts = false;
+    var $ignore_no_email_urls = false;
 
   // Actual email variables
-  var $to_address = "";
-  var $headers = ""; 
-  var $default_headers = ""; 
-  var $subject = "";
-  var $body = ""; 
-  var $body_without_attachments = ""; 
+    var $to_address = "";
+    var $headers = "";
+    var $default_headers = "";
+    var $subject = "";
+    var $body = "";
+    var $body_without_attachments = "";
 
-  function __construct($to_address="",$subject="",$body="",$message_type="") {
-    $this->default_headers = "X-Mailer: ".APPLICATION_NAME." ".get_alloc_version();
-    $to_address   and $this->set_to_address($to_address);
-    $subject      and $this->set_subject($subject);
-    $body         and $this->set_body($body);
-    $message_type and $this->set_message_type($message_type);
-  }
-  function set_to_address($to=false) {
-    $to or $to = $this->to_address;
-    #$to or $to = ALLOC_DEFAULT_TO_ADDRESS; // no
-    $this->to_address = $to;
-    $this->del_header("to");
-  }
-  function set_body($body=false,$body_without_attachments="") {
-    $body or $body = $this->body;
-    $this->body = $body;
-    $this->body_without_attachments = $body_without_attachments;
-  }
-  function set_message_type($message_type=false) {
-    $message_type or $message_type = $this->message_type;
-    $this->message_type = $message_type;
-  }
-  function set_from($from=false) {
-    $from or $from = $this->from;
-    $from or $from = APPLICATION_NAME." ".ALLOC_DEFAULT_FROM_ADDRESS;
-    $this->add_header("From",$from);
-    $this->from = $from;
-  }
-  function set_content_type($type=false) {
-    $type or $type = "text/plain; charset=utf-8; format=flowed";
-    $this->add_header("Content-Type",$type);
-  }
-  function set_subject($subject=false) {
-    $subject or $subject = $this->subject;
-    $this->subject = $subject;
-    $this->del_header("subject");
-  }
-  function set_reply_to($email=false) {
-    $email or $email = ALLOC_DEFAULT_FROM_ADDRESS;
-    $this->add_header("Reply-To",$email);
-  }
-  function set_date($date=false) {
-    // Date: Tue, 07 Jun 2011 15:37:32 +1000
-    $date or $date = date("D, d M Y H:i:s O");
-    $this->add_header("Date", $date);
-  }
-  function set_message_id($hash=false) {
-    $hash and $hash = ".alloc.key.".$hash;
-    list($usec, $sec) = explode(" ", microtime());
-    $time = $sec.$usec;
-    $time = base_convert($time,10,36);
-    $rand = md5(microtime().getmypid().md5(microtime()));
-    $rand = base_convert($rand,16,36);
-    $bits = explode("@",ALLOC_DEFAULT_FROM_ADDRESS);
-    $host = str_replace(">","",$bits[1]);
-    $h = "<".$time.".".$rand.$hash."@".$host.">";
-    $this->add_header("Message-ID", $h);
-    return $h;
-  }
-  function send($use_default_headers=true) {
-
-    if ($use_default_headers) {
-      $this->set_to_address();
-      $this->set_body();
-      $this->set_message_type();
-      $this->set_from();
-      $this->set_content_type();
-      $this->set_subject();
-      $this->set_reply_to();
-      $this->set_date();
-      $this->set_message_id();
+    function __construct($to_address = "", $subject = "", $body = "", $message_type = "")
+    {
+        $this->default_headers = "X-Mailer: ".APPLICATION_NAME." ".get_alloc_version();
+        $to_address   and $this->set_to_address($to_address);
+        $subject      and $this->set_subject($subject);
+        $body         and $this->set_body($body);
+        $message_type and $this->set_message_type($message_type);
     }
+    function set_to_address($to = false)
+    {
+        $to or $to = $this->to_address;
+      #$to or $to = ALLOC_DEFAULT_TO_ADDRESS; // no
+        $this->to_address = $to;
+        $this->del_header("to");
+    }
+    function set_body($body = false, $body_without_attachments = "")
+    {
+        $body or $body = $this->body;
+        $this->body = $body;
+        $this->body_without_attachments = $body_without_attachments;
+    }
+    function set_message_type($message_type = false)
+    {
+        $message_type or $message_type = $this->message_type;
+        $this->message_type = $message_type;
+    }
+    function set_from($from = false)
+    {
+        $from or $from = $this->from;
+        $from or $from = APPLICATION_NAME." ".ALLOC_DEFAULT_FROM_ADDRESS;
+        $this->add_header("From", $from);
+        $this->from = $from;
+    }
+    function set_content_type($type = false)
+    {
+        $type or $type = "text/plain; charset=utf-8; format=flowed";
+        $this->add_header("Content-Type", $type);
+    }
+    function set_subject($subject = false)
+    {
+        $subject or $subject = $this->subject;
+        $this->subject = $subject;
+        $this->del_header("subject");
+    }
+    function set_reply_to($email = false)
+    {
+        $email or $email = ALLOC_DEFAULT_FROM_ADDRESS;
+        $this->add_header("Reply-To", $email);
+    }
+    function set_date($date = false)
+    {
+      // Date: Tue, 07 Jun 2011 15:37:32 +1000
+        $date or $date = date("D, d M Y H:i:s O");
+        $this->add_header("Date", $date);
+    }
+    function set_message_id($hash = false)
+    {
+        $hash and $hash = ".alloc.key.".$hash;
+        list($usec, $sec) = explode(" ", microtime());
+        $time = $sec.$usec;
+        $time = base_convert($time, 10, 36);
+        $rand = md5(microtime().getmypid().md5(microtime()));
+        $rand = base_convert($rand, 16, 36);
+        $bits = explode("@", ALLOC_DEFAULT_FROM_ADDRESS);
+        $host = str_replace(">", "", $bits[1]);
+        $h = "<".$time.".".$rand.$hash."@".$host.">";
+        $this->add_header("Message-ID", $h);
+        return $h;
+    }
+    function send($use_default_headers = true)
+    {
 
-    if ($this->is_valid_url()) {
+        if ($use_default_headers) {
+            $this->set_to_address();
+            $this->set_body();
+            $this->set_message_type();
+            $this->set_from();
+            $this->set_content_type();
+            $this->set_subject();
+            $this->set_reply_to();
+            $this->set_date();
+            $this->set_message_id();
+        }
+
+        if ($this->is_valid_url()) {
+          // if we've added attachments to the email, end the mime boundary
+            if ($this->done_top_mime_header) {
+                $this->body.= $this->get_bottom_mime_header();
+            }
+
+            $this->to_address or $this->to_address = null;
+            $this->headers = trim($this->headers)."\n".trim($this->default_headers);
+            $this->headers = str_replace("\r\n", "\n", $this->headers);
+            $this->headers = str_replace("\n", PHP_EOL, $this->headers); // according to php.net/mail
+
+          # echo "<pre><br>HEADERS:\n".page::htmlentities($this->headers)."</pre>";
+          # echo "<pre><br>TO:\n".page::htmlentities($this->to_address)."</pre>";
+          # echo "<pre><br>SUBJECT:\n".page::htmlentities($this->subject)."</pre>";
+          # echo "<pre><br>BODY:\n".page::htmlentities($this->body)."</pre>";
     
-      // if we've added attachments to the email, end the mime boundary
-      if ($this->done_top_mime_header) { 
-        $this->body.= $this->get_bottom_mime_header();
-      }
+            if (defined("ALLOC_DEFAULT_RETURN_PATH_ADDRESS") && ALLOC_DEFAULT_RETURN_PATH_ADDRESS) {
+                $return_path = "-f".ALLOC_DEFAULT_RETURN_PATH_ADDRESS;
+            }
 
-      $this->to_address or $this->to_address = null;
-      $this->headers = trim($this->headers)."\n".trim($this->default_headers);
-      $this->headers = str_replace("\r\n","\n",$this->headers);
-      $this->headers = str_replace("\n",PHP_EOL,$this->headers); // according to php.net/mail
-
-      # echo "<pre><br>HEADERS:\n".page::htmlentities($this->headers)."</pre>";
-      # echo "<pre><br>TO:\n".page::htmlentities($this->to_address)."</pre>";
-      # echo "<pre><br>SUBJECT:\n".page::htmlentities($this->subject)."</pre>";
-      # echo "<pre><br>BODY:\n".page::htmlentities($this->body)."</pre>";
-    
-      if (defined("ALLOC_DEFAULT_RETURN_PATH_ADDRESS") && ALLOC_DEFAULT_RETURN_PATH_ADDRESS) {
-        $return_path = "-f".ALLOC_DEFAULT_RETURN_PATH_ADDRESS;
-      } 
-
-      $result = mail($this->to_address, $this->subject, $this->body, $this->headers, $return_path);
-      if ($result) {
-        $this->log();
-        return true;
-      } 
+            $result = mail($this->to_address, $this->subject, $this->body, $this->headers, $return_path);
+            if ($result) {
+                $this->log();
+                return true;
+            }
+        }
+        return false;
     }
-    return false;
-  }
-  function set_headers($headers="") {
-    $headers or $headers = $this->headers;
-    $headers = preg_replace("/\r?\n\s+/"," ",$headers);
-    $this->headers = $headers;
-  }
-  function get_headers() {
-    return $this->headers;
-  }
-  function add_header($header,$value="",$replace=1) {
-    if ($replace) {
-      $this->del_header($header);
+    function set_headers($headers = "")
+    {
+        $headers or $headers = $this->headers;
+        $headers = preg_replace("/\r?\n\s+/", " ", $headers);
+        $this->headers = $headers;
     }
-    $this->headers = trim($this->headers)."\n".$header.": ".$value;
-  }
-  function del_header($header) {
-    $this->headers = preg_replace("/\r?\n".$header.":\s*.*/i","",$this->headers);
-  }
-  function get_header($header) {
-    preg_match("/\r?\n".$header.":(.*)/i",$this->headers,$matches);
-    return $matches[1];
-  }
-  function header_exists($header) {
-    return preg_match("/\r?\n".$header.":(.*)/i",$this->headers);
-  }
-  function is_valid_url() {
+    function get_headers()
+    {
+        return $this->headers;
+    }
+    function add_header($header, $value = "", $replace = 1)
+    {
+        if ($replace) {
+            $this->del_header($header);
+        }
+        $this->headers = trim($this->headers)."\n".$header.": ".$value;
+    }
+    function del_header($header)
+    {
+        $this->headers = preg_replace("/\r?\n".$header.":\s*.*/i", "", $this->headers);
+    }
+    function get_header($header)
+    {
+        preg_match("/\r?\n".$header.":(.*)/i", $this->headers, $matches);
+        return $matches[1];
+    }
+    function header_exists($header)
+    {
+        return preg_match("/\r?\n".$header.":(.*)/i", $this->headers);
+    }
+    function is_valid_url()
+    {
 
-    // Validate against particular hosts
-    in_array($_SERVER["SERVER_NAME"], $this->no_email_hosts) and $dont_send = true;
-    $this->ignore_no_email_hosts and $dont_send = false;
+      // Validate against particular hosts
+        in_array($_SERVER["SERVER_NAME"], $this->no_email_hosts) and $dont_send = true;
+        $this->ignore_no_email_hosts and $dont_send = false;
 
-    // Validate against particular bits in the url
-    foreach ($this->no_email_urls as $url) {
-      preg_match("/".$url."/",$_SERVER["SCRIPT_FILENAME"]) and $dont_send = true;
-    }
-    $this->ignore_no_email_urls and $dont_send = false;
+      // Validate against particular bits in the url
+        foreach ($this->no_email_urls as $url) {
+            preg_match("/".$url."/", $_SERVER["SCRIPT_FILENAME"]) and $dont_send = true;
+        }
+        $this->ignore_no_email_urls and $dont_send = false;
 
-    // Invert return
-    return !$dont_send;
-  }
-  function log() {
-    $current_user = &singleton("current_user");
-    $sentEmailLog = new sentEmailLog();
-    $to = $this->to_address or $to = $this->get_header("Cc") or $to = $this->get_header("Bcc");
-    $sentEmailLog->set_value("sentEmailTo",$to);
-    $sentEmailLog->set_value("sentEmailSubject",$this->subject);
-    $sentEmailLog->set_value("sentEmailBody",substr($this->body_without_attachments,0,65000)); // length of a TEXT column
-    $sentEmailLog->set_value("sentEmailHeader",$this->headers);
-    $sentEmailLog->set_value("sentEmailType",$this->message_type);
-    $sentEmailLog->save();
-  }
-  function get_mime_boundary() {
-    // This function will generate a new mime boundary
-    if (!$this->mime_boundary) {
-      $rand = md5(time().microtime()); 
-      $this->mime_boundary = "alloc".mktime().$rand;
+      // Invert return
+        return !$dont_send;
     }
-    return $this->mime_boundary;
-  }
-  function get_top_mime_header() {
-    if (!$this->done_top_mime_header) {
-      $mime_boundary = $this->get_mime_boundary();
-      $header = "--".$mime_boundary;
-      $header.= "\nContent-Type: text/plain; charset=utf-8; format=flowed";
-      $header.= "\nContent-Disposition: inline";
-      $header.= "\n";
-      $header.= "\n";
-      $this->done_top_mime_header = true;
-      return $header;
+    function log()
+    {
+        $current_user = &singleton("current_user");
+        $sentEmailLog = new sentEmailLog();
+        $to = $this->to_address or $to = $this->get_header("Cc") or $to = $this->get_header("Bcc");
+        $sentEmailLog->set_value("sentEmailTo", $to);
+        $sentEmailLog->set_value("sentEmailSubject", $this->subject);
+        $sentEmailLog->set_value("sentEmailBody", substr($this->body_without_attachments, 0, 65000)); // length of a TEXT column
+        $sentEmailLog->set_value("sentEmailHeader", $this->headers);
+        $sentEmailLog->set_value("sentEmailType", $this->message_type);
+        $sentEmailLog->save();
     }
-  }
-  function get_bottom_mime_header() {
-    return "\n\n--".$this->get_mime_boundary()."--";
-  }
-  function add_attachment($file) {
-    if (file_exists($file) && is_readable($file) && filesize($file)) {
-      $mime_boundary = $this->get_mime_boundary();
-      $this->add_header("MIME-Version","1.0");
-      $this->add_header("Content-Type","multipart/mixed; boundary=\"".$mime_boundary."\"");
-      $this->add_header("Content-Disposition","inline");
+    function get_mime_boundary()
+    {
+      // This function will generate a new mime boundary
+        if (!$this->mime_boundary) {
+            $rand = md5(time().microtime());
+            $this->mime_boundary = "alloc".mktime().$rand;
+        }
+        return $this->mime_boundary;
+    }
+    function get_top_mime_header()
+    {
+        if (!$this->done_top_mime_header) {
+            $mime_boundary = $this->get_mime_boundary();
+            $header = "--".$mime_boundary;
+            $header.= "\nContent-Type: text/plain; charset=utf-8; format=flowed";
+            $header.= "\nContent-Disposition: inline";
+            $header.= "\n";
+            $header.= "\n";
+            $this->done_top_mime_header = true;
+            return $header;
+        }
+    }
+    function get_bottom_mime_header()
+    {
+        return "\n\n--".$this->get_mime_boundary()."--";
+    }
+    function add_attachment($file)
+    {
+        if (file_exists($file) && is_readable($file) && filesize($file)) {
+            $mime_boundary = $this->get_mime_boundary();
+            $this->add_header("MIME-Version", "1.0");
+            $this->add_header("Content-Type", "multipart/mixed; boundary=\"".$mime_boundary."\"");
+            $this->add_header("Content-Disposition", "inline");
   
-      // Read the file to be attached ('rb' = read binary) 
-      $fh = fopen($file,'rb'); 
-      $data = fread($fh,filesize($file)); 
-      fclose($fh);
+          // Read the file to be attached ('rb' = read binary)
+            $fh = fopen($file, 'rb');
+            $data = fread($fh, filesize($file));
+            fclose($fh);
 
-      $mimetype = get_mimetype($file);
+            $mimetype = get_mimetype($file);
   
-      // Base64 encode the file data 
-      $data = chunk_split(base64_encode($data));
-      $name = basename($file);
+          // Base64 encode the file data
+            $data = chunk_split(base64_encode($data));
+            $name = basename($file);
 
-      $this->body = $this->get_top_mime_header().$this->body;
-      $this->body.= "\n\n--".$mime_boundary;
-      $this->body.= "\nContent-Type: ".$mimetype."; name=\"".$name."\"";
-      $this->body.= "\nContent-Disposition: attachment; filename=\"".$name."\"";
-      $this->body.= "\nContent-Transfer-Encoding: base64";
-      $this->body.= "\n\n".$data;
+            $this->body = $this->get_top_mime_header().$this->body;
+            $this->body.= "\n\n--".$mime_boundary;
+            $this->body.= "\nContent-Type: ".$mimetype."; name=\"".$name."\"";
+            $this->body.= "\nContent-Disposition: attachment; filename=\"".$name."\"";
+            $this->body.= "\nContent-Transfer-Encoding: base64";
+            $this->body.= "\n\n".$data;
+        }
     }
-  }
-  function get_header_mime_boundary() {
-    // This function will parse the header for a mime boundary
-    $content_type = $this->get_header("Content-Type");
-    // If the email is a multipart, ie has attachments 
-    if (preg_match("/multipart/i",$content_type) && preg_match("/boundary/i",$content_type)) {
-      // Suck out the mime boundary
-      preg_match("/boundary=\"?([^\"]*)\"?/i",$content_type,$matches);
-      $mime_boundary = $matches[1];
-      return $mime_boundary;
+    function get_header_mime_boundary()
+    {
+      // This function will parse the header for a mime boundary
+        $content_type = $this->get_header("Content-Type");
+      // If the email is a multipart, ie has attachments
+        if (preg_match("/multipart/i", $content_type) && preg_match("/boundary/i", $content_type)) {
+          // Suck out the mime boundary
+            preg_match("/boundary=\"?([^\"]*)\"?/i", $content_type, $matches);
+            $mime_boundary = $matches[1];
+            return $mime_boundary;
+        }
     }
-  }
 }
-
-
-?>

--- a/email/lib/inbox.inc.php
+++ b/email/lib/inbox.inc.php
@@ -3,340 +3,351 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class inbox extends db_entity {
+class inbox extends db_entity
+{
 
-  function change_current_user($from) {
-    list($from_address,$from_name) = parse_email_address($from);
-    $person = new person();
-    $personID = $person->find_by_email($from_address);
-    $personID or $personID = $person->find_by_name($from_name);
+    function change_current_user($from)
+    {
+        list($from_address,$from_name) = parse_email_address($from);
+        $person = new person();
+        $personID = $person->find_by_email($from_address);
+        $personID or $personID = $person->find_by_name($from_name);
 
-    // If we've determined a personID from the $from_address
-    if ($personID) {
-      $current_user = new person();
-      $current_user->load_current_user($personID);
-      singleton("current_user",$current_user);
-      return true;
+      // If we've determined a personID from the $from_address
+        if ($personID) {
+            $current_user = new person();
+            $current_user->load_current_user($personID);
+            singleton("current_user", $current_user);
+            return true;
+        }
+        return false;
     }
-    return false;
-  }
 
-  function verify_hash($id,$hash) {
-    $info = inbox::get_mail_info();
-    $email_receive = new email_receive($info);
-    $email_receive->open_mailbox($info["folder"],OP_HALFOPEN | OP_READONLY);
-    $email_receive->set_msg($id);
-    $email_receive->get_msg_header();
-    $rtn = ($hash == md5($email_receive->mail_headers["date"]
+    function verify_hash($id, $hash)
+    {
+        $info = inbox::get_mail_info();
+        $email_receive = new email_receive($info);
+        $email_receive->open_mailbox($info["folder"], OP_HALFOPEN | OP_READONLY);
+        $email_receive->set_msg($id);
+        $email_receive->get_msg_header();
+        $rtn = ($hash == md5($email_receive->mail_headers["date"]
                         .$email_receive->get_printable_from_address()
                         .$email_receive->mail_headers["subject"]));
-    $email_receive->close();
-    return $rtn;
-  }
-
-  function archive_email($req=array()) {
-    global $TPL;
-    $info = inbox::get_mail_info();
-    $email_receive = new email_receive($info);
-    $email_receive->open_mailbox($info["folder"]);
-    $mailbox = "INBOX/archive".date("Y");
-    $email_receive->create_mailbox($mailbox) and $TPL["message_good"][] = "Created mailbox: ".$mailbox;
-    $email_receive->move_mail($req["id"],$mailbox) and $TPL["message_good"][] = "Moved email ".$req["id"]." to ".$mailbox;
-    $email_receive->close();
-  }
-
-  function download_email($req=array()) {
-    global $TPL;
-    $info = inbox::get_mail_info();
-    $email_receive = new email_receive($info);
-    $email_receive->open_mailbox($info["folder"],OP_HALFOPEN | OP_READONLY);
-    $email_receive->set_msg($req["id"]);
-    $new_nums = $email_receive->get_new_email_msg_uids();
-    in_array($req["id"],(array)$new_nums) and $new = true;
-    list($h,$b) = $email_receive->get_raw_header_and_body();
-    $new and $email_receive->set_unread(); // might have to "unread" the email, if it was new, i.e. set it back to new
-    $email_receive->close();
-    header('Content-Type: text/plain');
-    header('Content-Disposition: attachment; filename="email'.$req["id"].'.txt"');
-    echo $h.$b;
-    exit();
-  }
-
-  function process_email($req=array()) {
-    global $TPL;
-    $info = inbox::get_mail_info();
-    $email_receive = new email_receive($info);
-    $email_receive->open_mailbox($info["folder"]);
-    $email_receive->set_msg($req["id"]);
-    $email_receive->get_msg_header();
-    inbox::process_one_email($email_receive);
-    $email_receive->expunge();
-    $email_receive->close();
-  }
-
-  function process_email_to_task($req=array()) {
-    global $TPL;
-    $info = inbox::get_mail_info();
-    $email_receive = new email_receive($info);
-    $email_receive->open_mailbox($info["folder"]);
-    $email_receive->set_msg($req["id"]);
-    $email_receive->get_msg_header();
-    inbox::convert_email_to_new_task($email_receive);
-    $email_receive->expunge();
-    $email_receive->close();
-  }
-
-  function process_one_email($email_receive) {
-    $current_user = &singleton("current_user");
-    $orig_current_user = &$current_user;
-
-    // wrap db queries in a transaction
-    $db = new db_alloc();
-    $db->start_transaction();
-
-    inbox::change_current_user($email_receive->mail_headers["from"]);
-    $current_user = &singleton("current_user");
-    $email_receive->save_email();
-
-    // Run any commands that have been embedded in the email
-    $command = new command();
-    $fields = $command->get_fields();
-    $commands = $email_receive->get_commands($fields);
-
-    try {
-      $command->run_commands($commands,$email_receive);
-    } catch (Exception $e) {
-      $current_user = &$orig_current_user;
-      singleton("current_user",$current_user);
-      $db->query("ROLLBACK");
-      $failed = true;
-      throw new Exception($e);
+        $email_receive->close();
+        return $rtn;
     }
 
-    // Commit the db, and move the email into its storage location eg: INBOX.task1234
-    if (!$failed && !$TPL["message"]) {
-      $db->commit();
-      $email_receive->archive();
+    function archive_email($req = array())
+    {
+        global $TPL;
+        $info = inbox::get_mail_info();
+        $email_receive = new email_receive($info);
+        $email_receive->open_mailbox($info["folder"]);
+        $mailbox = "INBOX/archive".date("Y");
+        $email_receive->create_mailbox($mailbox) and $TPL["message_good"][] = "Created mailbox: ".$mailbox;
+        $email_receive->move_mail($req["id"], $mailbox) and $TPL["message_good"][] = "Moved email ".$req["id"]." to ".$mailbox;
+        $email_receive->close();
     }
 
-    // Put current_user back to normal
-    $current_user = &$orig_current_user;
-    singleton("current_user",$current_user);
-  }
-
-  function convert_email_to_new_task($email_receive,$change_user=false) {
-    global $TPL;
-    $current_user = &singleton("current_user");
-    $orig_current_user = &$current_user;
-
-    if ($change_user) {
-      inbox::change_current_user($email_receive->mail_headers["from"]);
-      $current_user = &singleton("current_user");
-      if (is_object($current_user) && method_exists($current_user,"get_id") && $current_user->get_id()) {
-        $personID = $current_user->get_id();
-      }
+    function download_email($req = array())
+    {
+        global $TPL;
+        $info = inbox::get_mail_info();
+        $email_receive = new email_receive($info);
+        $email_receive->open_mailbox($info["folder"], OP_HALFOPEN | OP_READONLY);
+        $email_receive->set_msg($req["id"]);
+        $new_nums = $email_receive->get_new_email_msg_uids();
+        in_array($req["id"], (array)$new_nums) and $new = true;
+        list($h,$b) = $email_receive->get_raw_header_and_body();
+        $new and $email_receive->set_unread(); // might have to "unread" the email, if it was new, i.e. set it back to new
+        $email_receive->close();
+        header('Content-Type: text/plain');
+        header('Content-Disposition: attachment; filename="email'.$req["id"].'.txt"');
+        echo $h.$b;
+        exit();
     }
 
-    $email_receive->save_email();
-
-    // Subject line is name, email body is body
-    $task = new task();
-    $task->set_value("taskName",$email_receive->mail_headers["subject"]);
-    $task->set_value("taskDescription",$email_receive->mail_text);
-    $task->set_value("priority","3");
-    $task->set_value("taskTypeID","Task");
-    $task->save();
-
-    if (!$TPL["message"] && $task->get_id()) {
-      $dir = ATTACHMENTS_DIR.DIRECTORY_SEPARATOR."task".DIRECTORY_SEPARATOR.$task->get_id();
-      if (!is_dir($dir)) {
-        mkdir($dir);
-        foreach((array)$email_receive->mimebits as $file) {
-          $fh = fopen($dir.DIRECTORY_SEPARATOR.$file["name"],"wb");
-          fputs($fh, $file["blob"]);
-          fclose($fh);
-        }
-      }
-      rmdir_if_empty(ATTACHMENTS_DIR.DIRECTORY_SEPARATOR."task".DIRECTORY_SEPARATOR.$task->get_id());
-
-      $msg = "Created task ".$task->get_task_link(array("prefixTaskID"=>true))." and moved the email to the task's mail folder.";
-      $mailbox = "INBOX/task".$task->get_id();
-      $email_receive->create_mailbox($mailbox) and $msg.= "\nCreated mailbox: ".$mailbox;
-      $email_receive->archive($mailbox) and $msg.= "\nMoved email to ".$mailbox;
-      $msg and $TPL["message_good_no_esc"][] = $msg;
-
-      list($from_address,$from_name) = parse_email_address($email_receive->mail_headers["from"]);
-      $ip["emailAddress"] = $from_address;
-      $ip["name"] = $from_name;
-      $ip["personID"] = $personID;
-      $ip["entity"] = "task";
-      $ip["entityID"] = $task->get_id();
-      interestedParty::add_interested_party($ip);
-
-    }
-    // Put current_user back to normal
-    $current_user = &$orig_current_user;
-    singleton("current_user",$current_user);
-  }
-
-  function attach_email_to_existing_task($req=array()) {
-    global $TPL;
-    $info = inbox::get_mail_info();
-    $current_user = &singleton("current_user");
-    $orig_current_user = &$current_user;
-    $req["taskID"] = sprintf("%d",$req["taskID"]);
-
-    $task = new task();
-    $task->set_id($req["taskID"]);
-    if ($task->select()) {
-      $email_receive = new email_receive($info);
-      $email_receive->open_mailbox($info["folder"]);
-      $email_receive->set_msg($req["id"]);
-      $email_receive->get_msg_header();
-      $email_receive->save_email();
-
-      $c = comment::add_comment_from_email($email_receive,$task);
-      $commentID = $c->get_id();
-      $commentID and $TPL["message_good_no_esc"][] = "Created comment ".$commentID." on task ".$task->get_task_link(array("prefixTaskID"=>true));
-
-      // Possibly change the identity of current_user
-      list($from_address,$from_name) = parse_email_address($email_receive->mail_headers["from"]);
-      $person = new person();
-      $personID = $person->find_by_email($from_address);
-      $personID or $personID = $person->find_by_name($from_name);
-      if ($personID) {
-        $current_user = new person();
-        $current_user->load_current_user($personID);
-        singleton("current_user",$current_user);
-      } 
-
-      // swap back to normal user
-      $current_user = &$orig_current_user;
-      singleton("current_user",$current_user);
-
-      // manually add task manager and assignee to ip list
-      $extraips = array();
-      if ($task->get_value("personID")) {
-        $p = new person($task->get_value("personID"));
-        if ($p->get_value("emailAddress")) {
-          $extraips[$p->get_value("emailAddress")]["name"] = $p->get_name();
-          $extraips[$p->get_value("emailAddress")]["role"] = "assignee";
-          $extraips[$p->get_value("emailAddress")]["personID"] = $task->get_value("personID");
-          $extraips[$p->get_value("emailAddress")]["selected"] = 1;
-        }
-      }
-      if ($task->get_value("managerID")) {
-        $p = new person($task->get_value("managerID"));
-        if ($p->get_value("emailAddress")) {
-          $extraips[$p->get_value("emailAddress")]["name"] = $p->get_name();
-          $extraips[$p->get_value("emailAddress")]["role"] = "manager";
-          $extraips[$p->get_value("emailAddress")]["personID"] = $task->get_value("managerID");
-          $extraips[$p->get_value("emailAddress")]["selected"] = 1;
-        }
-      }
-
-      // add all the other interested parties
-      $ips = interestedParty::get_interested_parties("task",$req["taskID"],$extraips);
-      foreach((array)$ips as $k => $inf) {
-        $inf["entity"] = "comment";
-        $inf["entityID"] = $commentID;
-        $inf["email"] and $inf["emailAddress"] = $inf["email"];
-        if ($req["emailto"] == "internal" && !$inf["external"] && !$inf["clientContactID"]) {
-          $id = interestedParty::add_interested_party($inf);
-          $recipients[] = $inf["name"]." ".add_brackets($k);
-        } else if ($req["emailto"] == "default") {
-          $id = interestedParty::add_interested_party($inf);
-          $recipients[] = $inf["name"]." ".add_brackets($k);
-        }
-      }
-    
-      $recipients and $recipients = implode(", ",(array)$recipients);
-      $recipients and $TPL["message_good"][] = "Sent email to ".$recipients;
-
-      // Re-email the comment out
-      comment::send_comment($commentID,array("interested"),$email_receive);
-
-      // File email away in the task's mail folder
-      $mailbox = "INBOX/task".$task->get_id();
-      $email_receive->create_mailbox($mailbox) and $TPL["message_good"][] = "Created mailbox: ".$mailbox;
-      $email_receive->move_mail($req["id"],$mailbox) and $TPL["message_good"][] = "Moved email ".$req["id"]." to ".$mailbox;
-      $email_receive->close();
-    }
-  }
-
-  function unread_email($req=array()) {
-    global $TPL;
-    $info = inbox::get_mail_info();
-    $email_receive = new email_receive($info);
-    $email_receive->open_mailbox($info["folder"]);
-    $email_receive->set_msg($req["id"]);
-    $email_receive->set_unread();
-    $email_receive->close();
-  }
-
-  function read_email($req=array()) {
-    global $TPL;
-    $info = inbox::get_mail_info();
-    $email_receive = new email_receive($info);
-    $email_receive->open_mailbox($info["folder"]);
-    $email_receive->set_msg($req["id"]);
-    list($h,$b) = $email_receive->get_raw_header_and_body();
-    $email_receive->close();
-  }
-
-  function get_mail_info() {
-    $info["host"] = config::get_config_item("allocEmailHost");
-    $info["port"] = config::get_config_item("allocEmailPort");
-    $info["username"] = config::get_config_item("allocEmailUsername");
-    $info["password"] = config::get_config_item("allocEmailPassword");
-    $info["protocol"] = config::get_config_item("allocEmailProtocol");
-    $info["folder"] = config::get_config_item("allocEmailFolder");
-    return $info;
-  }
-
-  public static function get_list() {
-    // Get list of emails
-    $info = inbox::get_mail_info();
-    $email_receive = new email_receive($info);
-    $email_receive->open_mailbox($info["folder"],OP_HALFOPEN | OP_READONLY);
-    $email_receive->check_mail();
-    $new_nums = $email_receive->get_new_email_msg_uids();
-    $msg_nums = $email_receive->get_all_email_msg_uids();
-
-    if ($msg_nums) {
-      foreach ($msg_nums as $num) {
-        $row = array();
-        $email_receive->set_msg($num);
+    function process_email($req = array())
+    {
+        global $TPL;
+        $info = inbox::get_mail_info();
+        $email_receive = new email_receive($info);
+        $email_receive->open_mailbox($info["folder"]);
+        $email_receive->set_msg($req["id"]);
         $email_receive->get_msg_header();
-        $row["from"] = $email_receive->get_printable_from_address();
-        in_array($num,(array)$new_nums) and $row["new"] = true;
-
-        $row["id"] = $num;
-        $row["date"] = $email_receive->mail_headers["date"];
-        $row["subject"] = $email_receive->mail_headers["subject"];
-        $rows[] = $row;
-      }
+        inbox::process_one_email($email_receive);
+        $email_receive->expunge();
+        $email_receive->close();
     }
-    $email_receive->close();
-    return $rows;
-  }
 
+    function process_email_to_task($req = array())
+    {
+        global $TPL;
+        $info = inbox::get_mail_info();
+        $email_receive = new email_receive($info);
+        $email_receive->open_mailbox($info["folder"]);
+        $email_receive->set_msg($req["id"]);
+        $email_receive->get_msg_header();
+        inbox::convert_email_to_new_task($email_receive);
+        $email_receive->expunge();
+        $email_receive->close();
+    }
+
+    function process_one_email($email_receive)
+    {
+        $current_user = &singleton("current_user");
+        $orig_current_user = &$current_user;
+
+      // wrap db queries in a transaction
+        $db = new db_alloc();
+        $db->start_transaction();
+
+        inbox::change_current_user($email_receive->mail_headers["from"]);
+        $current_user = &singleton("current_user");
+        $email_receive->save_email();
+
+      // Run any commands that have been embedded in the email
+        $command = new command();
+        $fields = $command->get_fields();
+        $commands = $email_receive->get_commands($fields);
+
+        try {
+            $command->run_commands($commands, $email_receive);
+        } catch (Exception $e) {
+            $current_user = &$orig_current_user;
+            singleton("current_user", $current_user);
+            $db->query("ROLLBACK");
+            $failed = true;
+            throw new Exception($e);
+        }
+
+      // Commit the db, and move the email into its storage location eg: INBOX.task1234
+        if (!$failed && !$TPL["message"]) {
+            $db->commit();
+            $email_receive->archive();
+        }
+
+      // Put current_user back to normal
+        $current_user = &$orig_current_user;
+        singleton("current_user", $current_user);
+    }
+
+    function convert_email_to_new_task($email_receive, $change_user = false)
+    {
+        global $TPL;
+        $current_user = &singleton("current_user");
+        $orig_current_user = &$current_user;
+
+        if ($change_user) {
+            inbox::change_current_user($email_receive->mail_headers["from"]);
+            $current_user = &singleton("current_user");
+            if (is_object($current_user) && method_exists($current_user, "get_id") && $current_user->get_id()) {
+                $personID = $current_user->get_id();
+            }
+        }
+
+        $email_receive->save_email();
+
+      // Subject line is name, email body is body
+        $task = new task();
+        $task->set_value("taskName", $email_receive->mail_headers["subject"]);
+        $task->set_value("taskDescription", $email_receive->mail_text);
+        $task->set_value("priority", "3");
+        $task->set_value("taskTypeID", "Task");
+        $task->save();
+
+        if (!$TPL["message"] && $task->get_id()) {
+            $dir = ATTACHMENTS_DIR.DIRECTORY_SEPARATOR."task".DIRECTORY_SEPARATOR.$task->get_id();
+            if (!is_dir($dir)) {
+                mkdir($dir);
+                foreach ((array)$email_receive->mimebits as $file) {
+                    $fh = fopen($dir.DIRECTORY_SEPARATOR.$file["name"], "wb");
+                    fputs($fh, $file["blob"]);
+                    fclose($fh);
+                }
+            }
+            rmdir_if_empty(ATTACHMENTS_DIR.DIRECTORY_SEPARATOR."task".DIRECTORY_SEPARATOR.$task->get_id());
+
+            $msg = "Created task ".$task->get_task_link(array("prefixTaskID"=>true))." and moved the email to the task's mail folder.";
+            $mailbox = "INBOX/task".$task->get_id();
+            $email_receive->create_mailbox($mailbox) and $msg.= "\nCreated mailbox: ".$mailbox;
+            $email_receive->archive($mailbox) and $msg.= "\nMoved email to ".$mailbox;
+            $msg and $TPL["message_good_no_esc"][] = $msg;
+
+            list($from_address,$from_name) = parse_email_address($email_receive->mail_headers["from"]);
+            $ip["emailAddress"] = $from_address;
+            $ip["name"] = $from_name;
+            $ip["personID"] = $personID;
+            $ip["entity"] = "task";
+            $ip["entityID"] = $task->get_id();
+            interestedParty::add_interested_party($ip);
+        }
+      // Put current_user back to normal
+        $current_user = &$orig_current_user;
+        singleton("current_user", $current_user);
+    }
+
+    function attach_email_to_existing_task($req = array())
+    {
+        global $TPL;
+        $info = inbox::get_mail_info();
+        $current_user = &singleton("current_user");
+        $orig_current_user = &$current_user;
+        $req["taskID"] = sprintf("%d", $req["taskID"]);
+
+        $task = new task();
+        $task->set_id($req["taskID"]);
+        if ($task->select()) {
+            $email_receive = new email_receive($info);
+            $email_receive->open_mailbox($info["folder"]);
+            $email_receive->set_msg($req["id"]);
+            $email_receive->get_msg_header();
+            $email_receive->save_email();
+
+            $c = comment::add_comment_from_email($email_receive, $task);
+            $commentID = $c->get_id();
+            $commentID and $TPL["message_good_no_esc"][] = "Created comment ".$commentID." on task ".$task->get_task_link(array("prefixTaskID"=>true));
+
+          // Possibly change the identity of current_user
+            list($from_address,$from_name) = parse_email_address($email_receive->mail_headers["from"]);
+            $person = new person();
+            $personID = $person->find_by_email($from_address);
+            $personID or $personID = $person->find_by_name($from_name);
+            if ($personID) {
+                $current_user = new person();
+                $current_user->load_current_user($personID);
+                singleton("current_user", $current_user);
+            }
+
+          // swap back to normal user
+            $current_user = &$orig_current_user;
+            singleton("current_user", $current_user);
+
+          // manually add task manager and assignee to ip list
+            $extraips = array();
+            if ($task->get_value("personID")) {
+                $p = new person($task->get_value("personID"));
+                if ($p->get_value("emailAddress")) {
+                    $extraips[$p->get_value("emailAddress")]["name"] = $p->get_name();
+                    $extraips[$p->get_value("emailAddress")]["role"] = "assignee";
+                    $extraips[$p->get_value("emailAddress")]["personID"] = $task->get_value("personID");
+                    $extraips[$p->get_value("emailAddress")]["selected"] = 1;
+                }
+            }
+            if ($task->get_value("managerID")) {
+                $p = new person($task->get_value("managerID"));
+                if ($p->get_value("emailAddress")) {
+                    $extraips[$p->get_value("emailAddress")]["name"] = $p->get_name();
+                    $extraips[$p->get_value("emailAddress")]["role"] = "manager";
+                    $extraips[$p->get_value("emailAddress")]["personID"] = $task->get_value("managerID");
+                    $extraips[$p->get_value("emailAddress")]["selected"] = 1;
+                }
+            }
+
+          // add all the other interested parties
+            $ips = interestedParty::get_interested_parties("task", $req["taskID"], $extraips);
+            foreach ((array)$ips as $k => $inf) {
+                $inf["entity"] = "comment";
+                $inf["entityID"] = $commentID;
+                $inf["email"] and $inf["emailAddress"] = $inf["email"];
+                if ($req["emailto"] == "internal" && !$inf["external"] && !$inf["clientContactID"]) {
+                    $id = interestedParty::add_interested_party($inf);
+                    $recipients[] = $inf["name"]." ".add_brackets($k);
+                } else if ($req["emailto"] == "default") {
+                    $id = interestedParty::add_interested_party($inf);
+                    $recipients[] = $inf["name"]." ".add_brackets($k);
+                }
+            }
+    
+            $recipients and $recipients = implode(", ", (array)$recipients);
+            $recipients and $TPL["message_good"][] = "Sent email to ".$recipients;
+
+          // Re-email the comment out
+            comment::send_comment($commentID, array("interested"), $email_receive);
+
+          // File email away in the task's mail folder
+            $mailbox = "INBOX/task".$task->get_id();
+            $email_receive->create_mailbox($mailbox) and $TPL["message_good"][] = "Created mailbox: ".$mailbox;
+            $email_receive->move_mail($req["id"], $mailbox) and $TPL["message_good"][] = "Moved email ".$req["id"]." to ".$mailbox;
+            $email_receive->close();
+        }
+    }
+
+    function unread_email($req = array())
+    {
+        global $TPL;
+        $info = inbox::get_mail_info();
+        $email_receive = new email_receive($info);
+        $email_receive->open_mailbox($info["folder"]);
+        $email_receive->set_msg($req["id"]);
+        $email_receive->set_unread();
+        $email_receive->close();
+    }
+
+    function read_email($req = array())
+    {
+        global $TPL;
+        $info = inbox::get_mail_info();
+        $email_receive = new email_receive($info);
+        $email_receive->open_mailbox($info["folder"]);
+        $email_receive->set_msg($req["id"]);
+        list($h,$b) = $email_receive->get_raw_header_and_body();
+        $email_receive->close();
+    }
+
+    function get_mail_info()
+    {
+        $info["host"] = config::get_config_item("allocEmailHost");
+        $info["port"] = config::get_config_item("allocEmailPort");
+        $info["username"] = config::get_config_item("allocEmailUsername");
+        $info["password"] = config::get_config_item("allocEmailPassword");
+        $info["protocol"] = config::get_config_item("allocEmailProtocol");
+        $info["folder"] = config::get_config_item("allocEmailFolder");
+        return $info;
+    }
+
+    public static function get_list()
+    {
+      // Get list of emails
+        $info = inbox::get_mail_info();
+        $email_receive = new email_receive($info);
+        $email_receive->open_mailbox($info["folder"], OP_HALFOPEN | OP_READONLY);
+        $email_receive->check_mail();
+        $new_nums = $email_receive->get_new_email_msg_uids();
+        $msg_nums = $email_receive->get_all_email_msg_uids();
+
+        if ($msg_nums) {
+            foreach ($msg_nums as $num) {
+                $row = array();
+                $email_receive->set_msg($num);
+                $email_receive->get_msg_header();
+                $row["from"] = $email_receive->get_printable_from_address();
+                in_array($num, (array)$new_nums) and $row["new"] = true;
+
+                $row["id"] = $num;
+                $row["date"] = $email_receive->mail_headers["date"];
+                $row["subject"] = $email_receive->mail_headers["subject"];
+                $rows[] = $row;
+            }
+        }
+        $email_receive->close();
+        return $rows;
+    }
 }
-?>

--- a/email/lib/init.php
+++ b/email/lib/init.php
@@ -3,26 +3,26 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class email_module extends module {
-  var $module = "email";
-  var $db_entities = array("token");
+class email_module extends module
+{
+    var $module = "email";
+    var $db_entities = array("token");
 }
-?>

--- a/email/lib/sentEmailLog.inc.php
+++ b/email/lib/sentEmailLog.inc.php
@@ -3,29 +3,30 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class sentEmailLog extends db_entity {
-  public $classname = "sentEmailLog";
-  public $data_table = "sentEmailLog";
-  public $key_field = "sentEmailLogID";
-  public $data_fields = array("sentEmailTo"
+class sentEmailLog extends db_entity
+{
+    public $classname = "sentEmailLog";
+    public $data_table = "sentEmailLog";
+    public $key_field = "sentEmailLogID";
+    public $data_fields = array("sentEmailTo"
                              ,"sentEmailSubject"
                              ,"sentEmailBody"
                              ,"sentEmailHeader"
@@ -34,6 +35,3 @@ class sentEmailLog extends db_entity {
                              ,"sentEmailLogCreatedUser"
                              );
 }
-
-
-?>

--- a/email/lib/token.inc.php
+++ b/email/lib/token.inc.php
@@ -3,28 +3,29 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class token extends db_entity {
-  public $classname = "token";
-  public $data_table = "token";
-  public $key_field = "tokenID";
-  public $data_fields = array("tokenHash"
+class token extends db_entity
+{
+    public $classname = "token";
+    public $data_table = "token";
+    public $key_field = "tokenID";
+    public $data_fields = array("tokenHash"
                              ,"tokenEntity"
                              ,"tokenEntityID"
                              ,"tokenActionID"
@@ -37,126 +38,129 @@ class token extends db_entity {
                              );
 
 
-  function set_hash($hash,$validate=true) {
+    function set_hash($hash, $validate = true)
+    {
     
-    $validate and $extra = " AND tokenActive = 1";
-    $validate and $extra.= " AND (tokenUsed < tokenMaxUsed OR tokenMaxUsed IS NULL OR tokenMaxUsed = 0)";
-    $validate and $extra.= prepare(" AND (tokenExpirationDate > '%s' OR tokenExpirationDate IS NULL)",date("Y-m-d H:i:s"));
+        $validate and $extra = " AND tokenActive = 1";
+        $validate and $extra.= " AND (tokenUsed < tokenMaxUsed OR tokenMaxUsed IS NULL OR tokenMaxUsed = 0)";
+        $validate and $extra.= prepare(" AND (tokenExpirationDate > '%s' OR tokenExpirationDate IS NULL)", date("Y-m-d H:i:s"));
     
 
-    $q = prepare("SELECT * FROM token 
+        $q = prepare("SELECT * FROM token 
                    WHERE tokenHash = '%s'
                   $extra
-                 ",$hash);
-    #echo "<br><br>".$q;
-    $db = new db_alloc();
-    $db->query($q);
-    if ($db->next_record()) {
-      $this->set_id($db->f("tokenID"));
-      $this->select();
-      return true;
-    }
-  }
-
-  function execute() {
-    if ($this->get_id()) {
-      if ($this->get_value("tokenActionID")) {
-        $tokenAction = new tokenAction();
-        $tokenAction->set_id($this->get_value("tokenActionID"));    
-        $tokenAction->select();
-      }
-      if ($this->get_value("tokenEntity")) {
-        $class = $this->get_value("tokenEntity");
-        $entity = new $class;
-        if ($this->get_value("tokenEntityID")) {
-          $entity->set_id($this->get_value("tokenEntityID"));
-          $entity->select();
+                 ", $hash);
+      #echo "<br><br>".$q;
+        $db = new db_alloc();
+        $db->query($q);
+        if ($db->next_record()) {
+            $this->set_id($db->f("tokenID"));
+            $this->select();
+            return true;
         }
-        $method = $tokenAction->get_value("tokenActionMethod");
-        $this->increment_tokenUsed(); 
-        if ($entity->get_id()) {
-          return array($entity,$method);
+    }
+
+    function execute()
+    {
+        if ($this->get_id()) {
+            if ($this->get_value("tokenActionID")) {
+                $tokenAction = new tokenAction();
+                $tokenAction->set_id($this->get_value("tokenActionID"));
+                $tokenAction->select();
+            }
+            if ($this->get_value("tokenEntity")) {
+                $class = $this->get_value("tokenEntity");
+                $entity = new $class;
+                if ($this->get_value("tokenEntityID")) {
+                    $entity->set_id($this->get_value("tokenEntityID"));
+                    $entity->select();
+                }
+                $method = $tokenAction->get_value("tokenActionMethod");
+                $this->increment_tokenUsed();
+                if ($entity->get_id()) {
+                    return array($entity,$method);
+                }
+            }
         }
-      }
+        return array(false,false);
     }
-    return array(false,false);
-  }
 
-  function increment_tokenUsed() {
-    $q = prepare("UPDATE token SET tokenUsed = coalesce(tokenUsed,0) + 1 WHERE tokenID = %d",$this->get_id());
-    $db = new db_alloc();
-    $db->query($q);
-  }
-
-  function decrement_tokenUsed() {
-    $q = prepare("UPDATE token SET tokenUsed = coalesce(tokenUsed,0) - 1 WHERE tokenID = %d",$this->get_id());
-    $db = new db_alloc();
-    $db->query($q);
-  }
-
-  function get_hash_str() {
-    list($usec, $sec) = explode(' ', microtime());
-    $seed = $sec + ($usec * 100000);
-    mt_srand($seed);
-    $randval = mt_rand(1,99999999); // get a random 8 digit number
-    $randval = sprintf("%-08d",$randval);
-    $randval = base_convert($randval,10,36);
-    return $randval;
-  }
-
-  function generate_hash() {
-    // Make an eight character base 36 garbage fds3ys79 / also check that we haven't used this ID already
-    $randval = $this->get_hash_str();
-    while (strlen($randval) < 8 || $this->set_hash($randval,false)) {
-      $randval.= $this->get_hash_str();
-      $randval = substr($randval, -8);
+    function increment_tokenUsed()
+    {
+        $q = prepare("UPDATE token SET tokenUsed = coalesce(tokenUsed,0) + 1 WHERE tokenID = %d", $this->get_id());
+        $db = new db_alloc();
+        $db->query($q);
     }
-    return $randval;
-  }
 
-  function select_token_by_entity_and_action($entity,$entityID,$action) {
-    $q = prepare("SELECT token.*, tokenAction.*
+    function decrement_tokenUsed()
+    {
+        $q = prepare("UPDATE token SET tokenUsed = coalesce(tokenUsed,0) - 1 WHERE tokenID = %d", $this->get_id());
+        $db = new db_alloc();
+        $db->query($q);
+    }
+
+    function get_hash_str()
+    {
+        list($usec, $sec) = explode(' ', microtime());
+        $seed = $sec + ($usec * 100000);
+        mt_srand($seed);
+        $randval = mt_rand(1, 99999999); // get a random 8 digit number
+        $randval = sprintf("%-08d", $randval);
+        $randval = base_convert($randval, 10, 36);
+        return $randval;
+    }
+
+    function generate_hash()
+    {
+      // Make an eight character base 36 garbage fds3ys79 / also check that we haven't used this ID already
+        $randval = $this->get_hash_str();
+        while (strlen($randval) < 8 || $this->set_hash($randval, false)) {
+            $randval.= $this->get_hash_str();
+            $randval = substr($randval, -8);
+        }
+        return $randval;
+    }
+
+    function select_token_by_entity_and_action($entity, $entityID, $action)
+    {
+        $q = prepare("SELECT token.*, tokenAction.*
                     FROM token 
                LEFT JOIN tokenAction ON token.tokenActionID = tokenAction.tokenActionID 
                    WHERE tokenEntity = '%s' 
                      AND tokenEntityID = %d
                      AND tokenAction.tokenActionMethod = '%s'
-                ",$entity,$entityID,$action);
-    $db = new db_alloc();
-    $db->query($q);
-    if ($db->next_record()) {
-      $this->set_id($db->f("tokenID"));
-      $this->select();
-      return true;
+                ", $entity, $entityID, $action);
+        $db = new db_alloc();
+        $db->query($q);
+        if ($db->next_record()) {
+            $this->set_id($db->f("tokenID"));
+            $this->select();
+            return true;
+        }
     }
-  }
 
-  function get_list_filter($filter=array()) {
-    $filter["tokenEntity"]   and $sql[] = sprintf_implode("token.tokenEntity = '%s'", $filter["tokenEntity"]);
-    $filter["tokenEntityID"] and $sql[] = sprintf_implode("token.tokenEntityID = %d", $filter["tokenEntityID"]);
-    $filter["tokenHash"]     and $sql[] = sprintf_implode("token.tokenHash = '%s'", $filter["tokenHash"]);
-    return $sql;
-  }
+    function get_list_filter($filter = array())
+    {
+        $filter["tokenEntity"]   and $sql[] = sprintf_implode("token.tokenEntity = '%s'", $filter["tokenEntity"]);
+        $filter["tokenEntityID"] and $sql[] = sprintf_implode("token.tokenEntityID = %d", $filter["tokenEntityID"]);
+        $filter["tokenHash"]     and $sql[] = sprintf_implode("token.tokenHash = '%s'", $filter["tokenHash"]);
+        return $sql;
+    }
   
-  public static function get_list($_FORM) {
-    $filter = token::get_list_filter($_FORM);
+    public static function get_list($_FORM)
+    {
+        $filter = token::get_list_filter($_FORM);
     
-    if (is_array($filter) && count($filter)) {
-      $filter = " WHERE ".implode(" AND ",$filter);
+        if (is_array($filter) && count($filter)) {
+            $filter = " WHERE ".implode(" AND ", $filter);
+        }
+
+        $q = "SELECT * FROM token ".$filter;
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->next_record()) {
+            $rows[$row["tokenID"]] = $row;
+        }
+        return (array)$rows;
     }
-
-    $q = "SELECT * FROM token ".$filter; 
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->next_record()) {
-      $rows[$row["tokenID"]] = $row;
-    }
-    return (array)$rows;
-  }
-
-
 }
-
-
-
-?>

--- a/email/lib/tokenAction.inc.php
+++ b/email/lib/tokenAction.inc.php
@@ -3,33 +3,30 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class tokenAction extends db_entity {
-  public $classname = "tokenAction";
-  public $data_table = "tokenAction";
-  public $key_field = "tokenActionID";
-  public $data_fields = array("tokenAction"
+class tokenAction extends db_entity
+{
+    public $classname = "tokenAction";
+    public $data_table = "tokenAction";
+    public $key_field = "tokenActionID";
+    public $data_fields = array("tokenAction"
                              ,"tokenActionType"
                              ,"tokenActionMethod"
                              );
 }
-
-
-
-?>

--- a/email/pipeEmail.php
+++ b/email/pipeEmail.php
@@ -4,19 +4,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -29,7 +29,7 @@
  * which may only be readable by the webserver.
  *
  * Say alloc is listening on the email address alloc@cyber.com.au.
- * 
+ *
  * If new email is sent to that address, WITHOUT A KEY in the subject line or headers:
  *  - from staff: then create new task, archive email in INBOX/task1234 folder
  *  - from other: archive email in INBOX
@@ -38,13 +38,13 @@
  *
 */
 
-define("NO_AUTH",1);
+define("NO_AUTH", 1);
 //require_once(dirname(__FILE__)."/../alloc.php");
 require_once(dirname($_SERVER["SUDO_COMMAND"])."/../alloc.php");
-singleton("errors_fatal",true);
-singleton("errors_format","text");
-singleton("errors_logged",true);
-singleton("errors_thrown",true);
+singleton("errors_fatal", true);
+singleton("errors_format", "text");
+singleton("errors_logged", true);
+singleton("errors_thrown", true);
 unset($current_user);
 
 $db = new db_alloc();
@@ -52,19 +52,19 @@ $db = new db_alloc();
 $info = inbox::get_mail_info();
 
 if (!$info["host"]) {
-  alloc_error("Email mailbox host not defined, assuming email receive function is inactive.");
+    alloc_error("Email mailbox host not defined, assuming email receive function is inactive.");
 }
 
 // Read an email from stdin
-while (FALSE !== ($line = fgets(STDIN))) {
-  $email[] = $line;
+while (false !== ($line = fgets(STDIN))) {
+    $email[] = $line;
 }
 // Nuke any mbox header that sendmail/postfix may have prepended.
 if ($email[0] == "") {
-  array_shift($email);
+    array_shift($email);
 }
-if (preg_match("/^From /i",$email[0])) {
-  array_shift($email);
+if (preg_match("/^From /i", $email[0])) {
+    array_shift($email);
 }
 
 $email = implode("", (array)$email);
@@ -76,47 +76,46 @@ $email_receive->set_msg_text($email);
 $email_receive->get_msg_header();
 $keys = $email_receive->get_hashes();
 
-  try {
-
+try {
     // If no keys
     if (!$keys) {
       // If email sent from a known staff member
-      $from_staff = inbox::change_current_user($email_receive->mail_headers["from"]);
-      if ($from_staff) {
-        inbox::convert_email_to_new_task($email_receive,true);
-      } else {
-        //$email_receive->mark_seen(); in alouy we want the emails to still appear new (as opposed to alloc with receiveEmail.php)
-        $email_receive->archive();
-      }
+        $from_staff = inbox::change_current_user($email_receive->mail_headers["from"]);
+        if ($from_staff) {
+            inbox::convert_email_to_new_task($email_receive, true);
+        } else {
+          //$email_receive->mark_seen(); in alouy we want the emails to still appear new (as opposed to alloc with receiveEmail.php)
+            $email_receive->archive();
+        }
 
     // Else if we have a key, append to comment
     } else {
-
       // Skip over emails that are from alloc. These emails are kept only for
       // posterity and should not be parsed and downloaded and re-emailed etc.
-      if (same_email_address($email_receive->mail_headers["from"], ALLOC_DEFAULT_FROM_ADDRESS)) {
-        $email_receive->mark_seen();
-        $email_receive->archive();
-      } else {
-        inbox::process_one_email($email_receive);
-      }
+        if (same_email_address($email_receive->mail_headers["from"], ALLOC_DEFAULT_FROM_ADDRESS)) {
+            $email_receive->mark_seen();
+            $email_receive->archive();
+        } else {
+            inbox::process_one_email($email_receive);
+        }
     }
-
-  } catch (Exception $e) {
-
+} catch (Exception $e) {
     // There may have been a database error, so let the database know it can run this next bit
     db_alloc::$stop_doing_queries = false;
 
     // Try forwarding the errant email
     try {
-      $email_receive->forward(
-           config::get_config_item("allocEmailAdmin"),"Email command failed","\n".$e->getMessage()."\n\n".$e->getTraceAsString());
+        $email_receive->forward(
+            config::get_config_item("allocEmailAdmin"),
+            "Email command failed",
+            "\n".$e->getMessage()."\n\n".$e->getTraceAsString()
+        );
 
       // If that fails, try last-ditch email send
     } catch (Exception $e) {
-      mail(config::get_config_item("allocEmailAdmin"),"Email command failed(2)","\n".$e->getMessage()."\n\n".$e->getTraceAsString());
+        mail(config::get_config_item("allocEmailAdmin"), "Email command failed(2)", "\n".$e->getMessage()."\n\n".$e->getTraceAsString());
     }
-  }
+}
 
 // Commit the db, and move the email into its storage location eg: INBOX.task1234
 $db->commit();

--- a/email/receiveEmail.php
+++ b/email/receiveEmail.php
@@ -3,36 +3,36 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_AUTH",1);
+define("NO_AUTH", 1);
 require_once("../alloc.php");
-singleton("errors_fatal",false);
-singleton("errors_format","text");
-singleton("errors_logged",false);
-singleton("errors_thrown",true);
-singleton("errors_haltdb",true);
+singleton("errors_fatal", false);
+singleton("errors_format", "text");
+singleton("errors_logged", false);
+singleton("errors_thrown", true);
+singleton("errors_haltdb", true);
 
 $nl = "<br>\n";
 $info = inbox::get_mail_info();
 
 if (!$info["host"]) {
-  alloc_error("Email mailbox host not defined, assuming email receive function is inactive.",true);
+    alloc_error("Email mailbox host not defined, assuming email receive function is inactive.", true);
 }
 
 $email_receive = new email_receive($info);
@@ -41,61 +41,57 @@ $email_receive->check_mail();
 $num_new_emails = $email_receive->get_num_new_emails();
 
 if ($num_new_emails >0) {
-  $msg_nums = $email_receive->get_new_email_msg_uids(); 
-  print $nl.date("Y-m-d H:i:s")." Found ".count($msg_nums)." new/unseen emails.".$nl;
-  foreach ($msg_nums as $num) {
+    $msg_nums = $email_receive->get_new_email_msg_uids();
+    print $nl.date("Y-m-d H:i:s")." Found ".count($msg_nums)." new/unseen emails.".$nl;
+    foreach ($msg_nums as $num) {
+      // Errors from previous iterations shouldn't affect processing of the next email
+        db_alloc::$stop_doing_queries = false;
 
-    // Errors from previous iterations shouldn't affect processing of the next email
-    db_alloc::$stop_doing_queries = false;
+        $email_receive->set_msg($num);
+        $email_receive->get_msg_header();
+        $keys = $email_receive->get_hashes();
 
-    $email_receive->set_msg($num);
-    $email_receive->get_msg_header();
-    $keys = $email_receive->get_hashes();
+        try {
+          // If no keys
+            if (!$keys) {
+                // If email sent from a known staff member
+                $from_staff = inbox::change_current_user($email_receive->mail_headers["from"]);
+                if ($from_staff) {
+                    inbox::convert_email_to_new_task($email_receive, true);
+                } else {
+                    $email_receive->mark_seen(); // mark it seen so we don't poll for it again
+                    alloc_error("Could not create a task from this email. Email was not sent by a staff member. Email resides in INBOX.");
+                }
 
-    try {
+              // Else if we have a key, append to comment
+            } else {
+                // Skip over emails that are from alloc. These emails are kept only for
+                // posterity and should not be parsed and downloaded and re-emailed etc.
+                if (same_email_address($email_receive->mail_headers["from"], ALLOC_DEFAULT_FROM_ADDRESS)) {
+                    $email_receive->mark_seen();
+                    $email_receive->archive();
+                } else {
+                    inbox::process_one_email($email_receive);
+                }
+            }
+        } catch (Exception $e) {
+          // There may have been a database error, so let the database know it can run this next bit
+            db_alloc::$stop_doing_queries = false;
 
-      // If no keys
-      if (!$keys) {
-        // If email sent from a known staff member
-        $from_staff = inbox::change_current_user($email_receive->mail_headers["from"]);
-        if ($from_staff) {
-          inbox::convert_email_to_new_task($email_receive,true);
-        } else {
-          $email_receive->mark_seen(); // mark it seen so we don't poll for it again
-          alloc_error("Could not create a task from this email. Email was not sent by a staff member. Email resides in INBOX.");
+          // Try forwarding the errant email
+            try {
+                $email_receive->forward(
+                    config::get_config_item("allocEmailAdmin"),
+                    "Email command failed",
+                    "\n".$e->getMessage()."\n\n".$e->getTraceAsString()
+                );
+
+              // If that fails, try last-ditch email send
+            } catch (Exception $e) {
+                mail(config::get_config_item("allocEmailAdmin"), "Email command failed(2)", "\n".$e->getMessage()."\n\n".$e->getTraceAsString());
+            }
         }
-
-      // Else if we have a key, append to comment
-      } else {
-
-        // Skip over emails that are from alloc. These emails are kept only for
-        // posterity and should not be parsed and downloaded and re-emailed etc.
-        if (same_email_address($email_receive->mail_headers["from"], ALLOC_DEFAULT_FROM_ADDRESS)) {
-          $email_receive->mark_seen();
-          $email_receive->archive();
-        } else {
-          inbox::process_one_email($email_receive);
-        }
-      }
-
-    } catch (Exception $e) {
-
-      // There may have been a database error, so let the database know it can run this next bit
-      db_alloc::$stop_doing_queries = false;
-
-      // Try forwarding the errant email
-      try {
-        $email_receive->forward(
-             config::get_config_item("allocEmailAdmin"),"Email command failed","\n".$e->getMessage()."\n\n".$e->getTraceAsString());
-
-      // If that fails, try last-ditch email send
-      } catch (Exception $e) {
-        mail(config::get_config_item("allocEmailAdmin"),"Email command failed(2)","\n".$e->getMessage()."\n\n".$e->getTraceAsString());
-      }
     }
-  }
 }
 $email_receive->expunge();
 $email_receive->close();
-
-?>

--- a/finance/checkRepeat.php
+++ b/finance/checkRepeat.php
@@ -3,45 +3,46 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_AUTH",true);
-define("IS_GOD",true);
+define("NO_AUTH", true);
+define("IS_GOD", true);
 require_once("../alloc.php");
 
 
-function timeWarp($mostRecent, $basis) {
+function timeWarp($mostRecent, $basis)
+{
 
-  if ($basis == "weekly") {
-    return mktime(0, 0, 0, date("m", $mostRecent), date("d", $mostRecent) + 7, date("Y", $mostRecent));
-  }
-  if ($basis == "fortnightly") {
-    return mktime(0, 0, 0, date("m", $mostRecent), date("d", $mostRecent) + 14, date("Y", $mostRecent));
-  }
-  if ($basis == "monthly") {
-    return mktime(0, 0, 0, date("m", $mostRecent) + 1, date("d", $mostRecent), date("Y", $mostRecent));
-  }
-  if ($basis == "quarterly") {
-    return mktime(0, 0, 0, date("m", $mostRecent) + 3, date("d", $mostRecent), date("Y", $mostRecent));
-  }
-  if ($basis == "yearly") {
-    return mktime(0, 0, 0, date("m", $mostRecent), date("d", $mostRecent), date("Y", $mostRecent) + 1);
-  }
+    if ($basis == "weekly") {
+        return mktime(0, 0, 0, date("m", $mostRecent), date("d", $mostRecent) + 7, date("Y", $mostRecent));
+    }
+    if ($basis == "fortnightly") {
+        return mktime(0, 0, 0, date("m", $mostRecent), date("d", $mostRecent) + 14, date("Y", $mostRecent));
+    }
+    if ($basis == "monthly") {
+        return mktime(0, 0, 0, date("m", $mostRecent) + 1, date("d", $mostRecent), date("Y", $mostRecent));
+    }
+    if ($basis == "quarterly") {
+        return mktime(0, 0, 0, date("m", $mostRecent) + 3, date("d", $mostRecent), date("Y", $mostRecent));
+    }
+    if ($basis == "yearly") {
+        return mktime(0, 0, 0, date("m", $mostRecent), date("d", $mostRecent), date("Y", $mostRecent) + 1);
+    }
 }
 
 
@@ -54,70 +55,67 @@ echo("<br>".date("Y-m-d")."<br>");
 $db->query("select * from transactionRepeat WHERE status = 'approved'");
 
 while ($db->next_record()) {
-  $transactionRepeat = new transactionRepeat();
-  $transactionRepeat->read_db_record($db);
+    $transactionRepeat = new transactionRepeat();
+    $transactionRepeat->read_db_record($db);
 
-  $startDate = format_date("U",$transactionRepeat->get_value("transactionStartDate"));
-  $finishDate = format_date("U",$transactionRepeat->get_value("transactionFinishDate"));
-  $timeBasisString = $transactionRepeat->get_value("paymentBasis");
+    $startDate = format_date("U", $transactionRepeat->get_value("transactionStartDate"));
+    $finishDate = format_date("U", $transactionRepeat->get_value("transactionFinishDate"));
+    $timeBasisString = $transactionRepeat->get_value("paymentBasis");
 
-  $query = prepare("SELECT max(transactionDate) AS latestDate FROM transaction WHERE transactionRepeatID=%d",$transactionRepeat->get_id());
+    $query = prepare("SELECT max(transactionDate) AS latestDate FROM transaction WHERE transactionRepeatID=%d", $transactionRepeat->get_id());
 
-  $dbMaxDate->query($query);
-  $dbMaxDate->next_record();
+    $dbMaxDate->query($query);
+    $dbMaxDate->next_record();
 
-  if (!$dbMaxDate->f("latestDate")) {
-    $nextScheduled = timeWarp($startDate, $timeBasisString);
-  } else {
-    $mostRecentTransactionDate = format_date("U",$dbMaxDate->f("latestDate"));
-    $nextScheduled = timeWarp($mostRecentTransactionDate, $timeBasisString);
-  }
+    if (!$dbMaxDate->f("latestDate")) {
+        $nextScheduled = timeWarp($startDate, $timeBasisString);
+    } else {
+        $mostRecentTransactionDate = format_date("U", $dbMaxDate->f("latestDate"));
+        $nextScheduled = timeWarp($mostRecentTransactionDate, $timeBasisString);
+    }
 
-  echo "<br>Attempting repeating transaction: ".$transactionRepeat->get_value("product")." ... ";
+    echo "<br>Attempting repeating transaction: ".$transactionRepeat->get_value("product")." ... ";
   //echo '<br><br>$nextScheduled <= $today && $nextScheduled >= $startDate && $nextScheduled <= $finishDate';
   //echo "<br>".$nextScheduled." <= ".$today." && ".$nextScheduled." >= ".$startDate." && ".$nextScheduled." <= ".$finishDate;
-  while ($nextScheduled <= $today && $nextScheduled >= $startDate && $nextScheduled <= $finishDate) {
+    while ($nextScheduled <= $today && $nextScheduled >= $startDate && $nextScheduled <= $finishDate) {
+        $tf = new tf();
+        $tf->set_id($transactionRepeat->get_value("tfID"));
+        $tf->select();
+        if (!$tf->get_value("tfActive")) {
+            echo "<br>Skipping because tf not active: ".$tf->get_value("tfName");
+            continue 2;
+        }
 
-    $tf = new tf();
-    $tf->set_id($transactionRepeat->get_value("tfID"));
-    $tf->select();
-    if (!$tf->get_value("tfActive")) {
-      echo "<br>Skipping because tf not active: ".$tf->get_value("tfName");
-      continue 2;
+        $tf = new tf();
+        $tf->set_id($transactionRepeat->get_value("fromTfID"));
+        $tf->select();
+        if (!$tf->get_value("tfActive")) {
+            echo "<br>Skipping because tf not active: ".$tf->get_value("tfName");
+            continue 2;
+        }
+
+        $amount = page::money_out($transactionRepeat->get_value("currencyTypeID"), $transactionRepeat->get_value("amount"));
+
+        $transaction = new transaction();
+        $transaction->set_value("fromTfID", $transactionRepeat->get_value("fromTfID"));
+        $transaction->set_value("tfID", $transactionRepeat->get_value("tfID"));
+        $transaction->set_value("companyDetails", $transactionRepeat->get_value("companyDetails"));
+        $transaction->set_value("amount", $amount);
+        $transaction->set_value("currencyTypeID", $transactionRepeat->get_value("currencyTypeID"));
+        $transaction->set_value("product", $transactionRepeat->get_value("product"));
+        $transaction->set_value("transactionType", $transactionRepeat->get_value("transactionType"));
+        $transaction->set_value("status", "pending");
+        $transaction->set_value("transactionRepeatID", $transactionRepeat->get_id());
+        $transaction->set_value("transactionDate", date("Y-m-d", $nextScheduled));
+        $transaction->save();
+
+        echo "\n<br>".$transaction->get_value("transactionDate");
+        echo " ".$transactionRepeat->get_value("paymentBasis")." $".$transaction->get_value("amount")." for TF: ".tf::get_name($transaction->get_value("tfID"));
+        echo " (transactionID: ".$transaction->get_id()." transactionRepeatID:".$transactionRepeat->get_id()." name:".$transactionRepeat->get_value("product").")";
+
+        $nextScheduled = timeWarp($nextScheduled, $timeBasisString);
     }
-
-    $tf = new tf();
-    $tf->set_id($transactionRepeat->get_value("fromTfID"));
-    $tf->select();
-    if (!$tf->get_value("tfActive")) {
-      echo "<br>Skipping because tf not active: ".$tf->get_value("tfName");
-      continue 2;
-    }
-
-    $amount = page::money_out($transactionRepeat->get_value("currencyTypeID"), $transactionRepeat->get_value("amount"));
-
-    $transaction = new transaction();
-    $transaction->set_value("fromTfID", $transactionRepeat->get_value("fromTfID"));
-    $transaction->set_value("tfID", $transactionRepeat->get_value("tfID"));
-    $transaction->set_value("companyDetails", $transactionRepeat->get_value("companyDetails"));
-    $transaction->set_value("amount", $amount);
-    $transaction->set_value("currencyTypeID", $transactionRepeat->get_value("currencyTypeID"));
-    $transaction->set_value("product", $transactionRepeat->get_value("product"));
-    $transaction->set_value("transactionType", $transactionRepeat->get_value("transactionType"));
-    $transaction->set_value("status", "pending");
-    $transaction->set_value("transactionRepeatID", $transactionRepeat->get_id());
-    $transaction->set_value("transactionDate", date("Y-m-d", $nextScheduled));
-    $transaction->save();
-
-    echo "\n<br>".$transaction->get_value("transactionDate");
-    echo " ".$transactionRepeat->get_value("paymentBasis")." $".$transaction->get_value("amount")." for TF: ".tf::get_name($transaction->get_value("tfID"));
-    echo " (transactionID: ".$transaction->get_id()." transactionRepeatID:".$transactionRepeat->get_id()." name:".$transactionRepeat->get_value("product").")";
-
-    $nextScheduled = timeWarp($nextScheduled, $timeBasisString);
-  }
 }
 
 $TPL["main_alloc_title"] = "Execute Repeating Expenses - ".APPLICATION_NAME;
 include_template("templates/checkRepeatM.tpl");
-
-?>

--- a/finance/expenseForm.php
+++ b/finance/expenseForm.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,104 +23,107 @@
 require_once("../alloc.php");
 
 
-function show_all_exp($template) {
+function show_all_exp($template)
+{
 
-  global $TPL;
-  global $expenseForm;
-  global $db;
-  global $transaction_to_edit;
+    global $TPL;
+    global $expenseForm;
+    global $db;
+    global $transaction_to_edit;
 
-  if ($expenseForm->get_id()) {
+    if ($expenseForm->get_id()) {
+        if ($_POST["transactionID"] && ($_POST["edit"] || ( is_object($transaction_to_edit) && $transaction_to_edit->get_id() ) )) {   // if edit is clicked OR if we've rejected changes made to something so are still editing it
+            $query = prepare(
+                "SELECT * FROM transaction WHERE expenseFormID=%d AND transactionID<>%d ORDER BY transactionID DESC",
+                $expenseForm->get_id(),
+                $_POST["transactionID"]
+            );
+        } else {
+            $query = prepare("SELECT * FROM transaction WHERE expenseFormID=%d ORDER BY transactionID DESC", $expenseForm->get_id());
+        }
 
+        $db->query($query);
 
-    if ($_POST["transactionID"] && ($_POST["edit"] || ( is_object($transaction_to_edit) && $transaction_to_edit->get_id() ) )) {   // if edit is clicked OR if we've rejected changes made to something so are still editing it
-      $query = prepare("SELECT * FROM transaction WHERE expenseFormID=%d AND transactionID<>%d ORDER BY transactionID DESC", $expenseForm->get_id()
-                       , $_POST["transactionID"]);
-    } else {
-      $query = prepare("SELECT * FROM transaction WHERE expenseFormID=%d ORDER BY transactionID DESC", $expenseForm->get_id());
-    }
+        while ($db->next_record()) {
+            $transaction = new transaction();
+            $transaction->read_db_record($db);
+            $transaction->set_values();
 
-    $db->query($query);
+            $transaction->get_value("quantity") and $TPL["amount"] = $transaction->get_value("amount") / $transaction->get_value("quantity");
 
-    while ($db->next_record()) {
+            $TPL["lineTotal"] = $TPL["amount"] * $transaction->get_value("quantity");
 
-      $transaction = new transaction();
-      $transaction->read_db_record($db);
-      $transaction->set_values();
+            $tf = new tf();
+            $tf->set_id($transaction->get_value("fromTfID"));
+            $tf->select();
+            $TPL["fromTfIDLink"] = $tf->get_link();
 
-      $transaction->get_value("quantity") and $TPL["amount"] = $transaction->get_value("amount") / $transaction->get_value("quantity");
-
-      $TPL["lineTotal"] = $TPL["amount"] * $transaction->get_value("quantity");
-
-      $tf = new tf();
-      $tf->set_id($transaction->get_value("fromTfID"));
-      $tf->select();
-      $TPL["fromTfIDLink"] = $tf->get_link();
-
-      $tf = new tf();
-      $tf->set_id($transaction->get_value("tfID"));
-      $tf->select();
-      $TPL["tfIDLink"] = $tf->get_link();
+            $tf = new tf();
+            $tf->set_id($transaction->get_value("tfID"));
+            $tf->select();
+            $TPL["tfIDLink"] = $tf->get_link();
   
-      $projectID = $transaction->get_value("projectID");
-      if($projectID) {
-        $project = new project();
-        $project->set_id($transaction->get_value("projectID"));
-        $project->select();
-        $TPL["projectName"] = $project->get_value("projectName");
-      }
+            $projectID = $transaction->get_value("projectID");
+            if ($projectID) {
+                $project = new project();
+                $project->set_id($transaction->get_value("projectID"));
+                $project->select();
+                $TPL["projectName"] = $project->get_value("projectName");
+            }
 
-      if($transaction->get_value("fromTfID") == config::get_config_item("expenseFormTfID")) {
-        $TPL['expense_class'] = "loud";
-      } else {
-        $TPL['expense_class'] = "";
-      }
+            if ($transaction->get_value("fromTfID") == config::get_config_item("expenseFormTfID")) {
+                $TPL['expense_class'] = "loud";
+            } else {
+                $TPL['expense_class'] = "";
+            }
 
-      include_template($template);
+            include_template($template);
+        }
     }
-  }
 }
 
-function check_optional_allow_edit() {
-  global $db;
-  global $expenseForm;
+function check_optional_allow_edit()
+{
+    global $db;
+    global $expenseForm;
 
-  if (is_object($expenseForm) && !$expenseForm->get_id()) { // New Expense Form
-    $allow_edit = true;
+    if (is_object($expenseForm) && !$expenseForm->get_id()) { // New Expense Form
+        $allow_edit = true;
+    } else if (is_object($expenseForm) && $expenseForm->get_value("expenseFormFinalised") != 1 && $expenseForm->get_id() && $expenseForm->is_owner()) {
+        $allow_edit = true;
+    } else {
+        $allow_edit = false;
+    }
 
-  } else if (is_object($expenseForm) && $expenseForm->get_value("expenseFormFinalised") != 1 && $expenseForm->get_id() && $expenseForm->is_owner()) {
-    $allow_edit = true;
-
-  } else {
-    $allow_edit = false;
-  }
-
-  return $allow_edit;
+    return $allow_edit;
 }
 
-function check_optional_no_edit() {
-  $allow_edit = check_optional_allow_edit();
-  return !$allow_edit;
+function check_optional_no_edit()
+{
+    $allow_edit = check_optional_allow_edit();
+    return !$allow_edit;
 }
 
-function check_optional_has_line_items() {
-  global $expenseForm;
-  if (is_object($expenseForm) && $expenseForm->get_id()) {
-    $db = new db_alloc();
-    $q = prepare("SELECT COUNT(*) as tally FROM transaction WHERE expenseFormID = %d",$expenseForm->get_id());
-    $db->query($q);
-    $db->next_record();
-    return $db->f("tally");
-  }
+function check_optional_has_line_items()
+{
+    global $expenseForm;
+    if (is_object($expenseForm) && $expenseForm->get_id()) {
+        $db = new db_alloc();
+        $q = prepare("SELECT COUNT(*) as tally FROM transaction WHERE expenseFormID = %d", $expenseForm->get_id());
+        $db->query($q);
+        $db->next_record();
+        return $db->f("tally");
+    }
 }
 
-function check_optional_show_line_item_add() {
-  global $expenseForm;
-  return (is_object($expenseForm) && $expenseForm->get_id() && $expenseForm->get_value("expenseFormFinalised")!=1);
+function check_optional_show_line_item_add()
+{
+    global $expenseForm;
+    return (is_object($expenseForm) && $expenseForm->get_id() && $expenseForm->get_value("expenseFormFinalised")!=1);
 }
 
 if (!config::get_config_item("mainTfID")) {
-  alloc_error("This functionality will not work until you set a Finance TF on the Setup -> Finance screen.");
+    alloc_error("This functionality will not work until you set a Finance TF on the Setup -> Finance screen.");
 }
 
 $current_user->check_employee();
@@ -133,95 +136,92 @@ $db = new db_alloc();
 $expenseFormID = $_POST["expenseFormID"] or $expenseFormID = $_GET["expenseFormID"];
 
 if ($expenseFormID) {
-  $expenseForm->read_globals();
-  $expenseForm->set_id($expenseFormID);
-  if (!$expenseForm->select()) {
-    alloc_error("Bad Expense Form ID");
-    $expenseForm = new expenseForm();
-  }
-} 
+    $expenseForm->read_globals();
+    $expenseForm->set_id($expenseFormID);
+    if (!$expenseForm->select()) {
+        alloc_error("Bad Expense Form ID");
+        $expenseForm = new expenseForm();
+    }
+}
 
 
 
 if ($_POST["add"]) {
+    $_POST["product"]        or alloc_error("You must enter a Product.");
+    $_POST["companyDetails"] or alloc_error("You must enter the Company Details.");
+    $_POST["fromTfID"]       or alloc_error("You must enter the Source TF.");
+    $_POST["quantity"]       or $_POST["quantity"] = 1;
+    config::get_config_item("mainTfID") or alloc_error("You must configure the Finance Tagged Fund on the Setup -> Finance screen.");
 
-  $_POST["product"]        or alloc_error("You must enter a Product.");
-  $_POST["companyDetails"] or alloc_error("You must enter the Company Details.");
-  $_POST["fromTfID"]       or alloc_error("You must enter the Source TF.");
-  $_POST["quantity"]       or $_POST["quantity"] = 1;
-  config::get_config_item("mainTfID") or alloc_error("You must configure the Finance Tagged Fund on the Setup -> Finance screen.");
-
-  if ($_POST["amount"] === "") {
-    alloc_error("You must enter the Price.");
-  }
-  $_POST["amount"] = $_POST["amount"] * $_POST["quantity"];
+    if ($_POST["amount"] === "") {
+        alloc_error("You must enter the Price.");
+    }
+    $_POST["amount"] = $_POST["amount"] * $_POST["quantity"];
 
 
-  $transaction = new transaction();
-  $transactionID && $transaction->set_id($_POST["transactionID"]);
-  $transaction->read_globals();
+    $transaction = new transaction();
+    $transactionID && $transaction->set_id($_POST["transactionID"]);
+    $transaction->read_globals();
 
   // check we have permission to make the transaction
-  if (!$transaction->have_perm(PERM_CREATE)) {
-    alloc_error("You do not have permission to create transactions for that Source TF.");
-  }
+    if (!$transaction->have_perm(PERM_CREATE)) {
+        alloc_error("You do not have permission to create transactions for that Source TF.");
+    }
 
-  if (!count($TPL["message"])) {
-    $transaction->set_value("transactionType", "expense");
-    $transaction->set_value("expenseFormID", $expenseForm->get_id());
-    $transaction->set_value("tfID",config::get_config_item("mainTfID"));
-    $transaction->save();
-
-  } else {
-    $transaction_to_edit = $transaction;
-  }
+    if (!count($TPL["message"])) {
+        $transaction->set_value("transactionType", "expense");
+        $transaction->set_value("expenseFormID", $expenseForm->get_id());
+        $transaction->set_value("tfID", config::get_config_item("mainTfID"));
+        $transaction->save();
+    } else {
+        $transaction_to_edit = $transaction;
+    }
 }
 
 if ($_POST["edit"] && $_POST["expenseFormID"] && $_POST["transactionID"]) {
-  $transaction_to_edit->set_id($_POST["transactionID"]);
-  $transaction_to_edit->select();
-  $TPL["transactionID"] = $_POST["transactionID"];
+    $transaction_to_edit->set_id($_POST["transactionID"]);
+    $transaction_to_edit->select();
+    $TPL["transactionID"] = $_POST["transactionID"];
 }
 
 $transaction_to_edit->set_values();
 
 if ($transaction_to_edit->get_value("quantity")) {
-  $TPL["amount"] = $transaction_to_edit->get_value("amount",DST_HTML_DISPLAY) / $transaction_to_edit->get_value("quantity");
+    $TPL["amount"] = $transaction_to_edit->get_value("amount", DST_HTML_DISPLAY) / $transaction_to_edit->get_value("quantity");
 }
 
 if ($_POST["delete"] && $_POST["expenseFormID"] && $_POST["transactionID"]) {
-  $expenseForm->delete_transactions($_POST["transactionID"]);
-  $expenseForm->set_id($_POST["expenseFormID"]);
-  $expenseForm->select();
+    $expenseForm->delete_transactions($_POST["transactionID"]);
+    $expenseForm->set_id($_POST["expenseFormID"]);
+    $expenseForm->select();
 }
 
 if ($transaction_to_edit->get_value("fromTfID")) {
-  $selectedTfID = $transaction_to_edit->get_value("fromTfID");
-  $selectedProjectID = $transaction_to_edit->get_value("projectID");
-
+    $selectedTfID = $transaction_to_edit->get_value("fromTfID");
+    $selectedProjectID = $transaction_to_edit->get_value("projectID");
 } else {
-  $query = prepare("SELECT tfID FROM tfPerson WHERE personID=%d LIMIT 1",$current_user->get_id());
-  $db->query($query);
+    $query = prepare("SELECT tfID FROM tfPerson WHERE personID=%d LIMIT 1", $current_user->get_id());
+    $db->query($query);
 
-  if ($db->next_record()) {
-    $selectedTfID = $db->f("tfID");
-  } else {
-    $selectedTfID = 0;
-  }
-  $selectedProject = 0;
+    if ($db->next_record()) {
+        $selectedTfID = $db->f("tfID");
+    } else {
+        $selectedTfID = 0;
+    }
+    $selectedProject = 0;
 }
 
 $tf = new tf();
-$options = $tf->get_assoc_array("tfID","tfName");
+$options = $tf->get_assoc_array("tfID", "tfName");
 $TPL["fromTfOptions"] = page::select_options($options, $selectedTfID);
 
 $m = new meta("currencyType");
-$currencyOps = $m->get_assoc_array("currencyTypeID","currencyTypeID");
-$TPL["currencyTypeOptions"] = page::select_options($currencyOps,$transaction_to_edit->get_value("currencyTypeID"));
+$currencyOps = $m->get_assoc_array("currencyTypeID", "currencyTypeID");
+$TPL["currencyTypeOptions"] = page::select_options($currencyOps, $transaction_to_edit->get_value("currencyTypeID"));
 
 
-if (is_object($expenseForm) && $expenseForm->get_value("clientID")) { 
-  $clientID_sql = prepare(" AND clientID = %d",$expenseForm->get_value("clientID"));
+if (is_object($expenseForm) && $expenseForm->get_value("clientID")) {
+    $clientID_sql = prepare(" AND clientID = %d", $expenseForm->get_value("clientID"));
 }
 
 $q = "SELECT projectID AS value, projectName AS label 
@@ -231,121 +231,110 @@ $q = "SELECT projectID AS value, projectName AS label
     ORDER BY projectName";
 $TPL["projectOptions"] = page::select_options($q, $selectedProjectID);
 
-if (is_object($expenseForm)) { 
-  $expenseForm->set_values();
-  $TPL["expenseFormID"] = $expenseForm->get_id();
+if (is_object($expenseForm)) {
+    $expenseForm->set_values();
+    $TPL["expenseFormID"] = $expenseForm->get_id();
 }
 
 if (is_object($expenseForm) && $expenseForm->get_value("expenseFormCreatedUser")) {
-  $p = new person();
-  $p->set_id($expenseForm->get_value("expenseFormCreatedUser"));
-  $p->select();
-  $TPL["user"] = $p->get_name();
+    $p = new person();
+    $p->set_id($expenseForm->get_value("expenseFormCreatedUser"));
+    $p->select();
+    $TPL["user"] = $p->get_name();
 }
 
 if ($_POST["cancel"]) {
-  if (is_object($expenseForm)) {
-    $expenseForm->delete_transactions();
-    $expenseForm->delete();
+    if (is_object($expenseForm)) {
+        $expenseForm->delete_transactions();
+        $expenseForm->delete();
 
-    alloc_redirect($TPL["url_alloc_expenseFormList"]);
-  } else {
-    alloc_error("Unable to delete Expense Form");
-  }
-
+        alloc_redirect($TPL["url_alloc_expenseFormList"]);
+    } else {
+        alloc_error("Unable to delete Expense Form");
+    }
 } else if ($_POST["changeTransactionStatus"] == "pending") {
-  $expenseForm->set_value("expenseFormComment",rtrim($expenseForm->get_value("expenseFormComment")));
-  $expenseForm->save();
-  $expenseForm->set_status("pending");
-  alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id());
-  exit();
-
-} else if ($_POST["changeTransactionStatus"] == "approved") {
-  $expenseForm->set_value("expenseFormComment",rtrim($expenseForm->get_value("expenseFormComment")));
-  $expenseForm->save();
-  $expenseForm->set_status("approved");
-  alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id());
-  exit();
-
-} else if ($_POST["changeTransactionStatus"] == "rejected") {
-  $expenseForm->set_value("expenseFormComment",rtrim($expenseForm->get_value("expenseFormComment")));
-  $expenseForm->save();
-  $expenseForm->set_status("rejected");
-  alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id());
-  exit();
-
-} else if ($_POST["save"]) {
-  $expenseForm->read_globals();
-  if ($expenseForm->get_value("reimbursementRequired") == 0 || $expenseForm->get_value("reimbursementRequired") == 1) {
-    $expenseForm->set_value("paymentMethod", "");
-  }
-  $expenseForm->set_value("seekClientReimbursement", $_POST["seekClientReimbursement"] ? 1 : 0);
-  $expenseForm->set_value("expenseFormComment",rtrim($expenseForm->get_value("expenseFormComment")));
-  $expenseForm->save();
-  alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id());
-  exit();
-
-} else if ($_POST["finalise"]) {
-
-  $db = new db_alloc();
-  $hasItems = $db->qr("SELECT * FROM transaction WHERE expenseFormID = %d",$expenseForm->get_id());
-  if (!$hasItems) {
-    alloc_error("Unable to submit expense form, no items have been added.");
+    $expenseForm->set_value("expenseFormComment", rtrim($expenseForm->get_value("expenseFormComment")));
+    $expenseForm->save();
+    $expenseForm->set_status("pending");
     alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id());
     exit();
-  }
+} else if ($_POST["changeTransactionStatus"] == "approved") {
+    $expenseForm->set_value("expenseFormComment", rtrim($expenseForm->get_value("expenseFormComment")));
+    $expenseForm->save();
+    $expenseForm->set_status("approved");
+    alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id());
+    exit();
+} else if ($_POST["changeTransactionStatus"] == "rejected") {
+    $expenseForm->set_value("expenseFormComment", rtrim($expenseForm->get_value("expenseFormComment")));
+    $expenseForm->save();
+    $expenseForm->set_status("rejected");
+    alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id());
+    exit();
+} else if ($_POST["save"]) {
+    $expenseForm->read_globals();
+    if ($expenseForm->get_value("reimbursementRequired") == 0 || $expenseForm->get_value("reimbursementRequired") == 1) {
+        $expenseForm->set_value("paymentMethod", "");
+    }
+    $expenseForm->set_value("seekClientReimbursement", $_POST["seekClientReimbursement"] ? 1 : 0);
+    $expenseForm->set_value("expenseFormComment", rtrim($expenseForm->get_value("expenseFormComment")));
+    $expenseForm->save();
+    alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id());
+    exit();
+} else if ($_POST["finalise"]) {
+    $db = new db_alloc();
+    $hasItems = $db->qr("SELECT * FROM transaction WHERE expenseFormID = %d", $expenseForm->get_id());
+    if (!$hasItems) {
+        alloc_error("Unable to submit expense form, no items have been added.");
+        alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id());
+        exit();
+    }
 
-  $expenseForm->read_globals();
-  if ($expenseForm->get_value("reimbursementRequired") == 0 || $expenseForm->get_value("reimbursementRequired") == 1) {
-    $expenseForm->set_value("paymentMethod", "");
-  }
-  $expenseForm->set_value("seekClientReimbursement", $_POST["seekClientReimbursement"] ? 1 : 0);
-  $expenseForm->set_value("expenseFormFinalised", 1);
-  $expenseForm->set_value("expenseFormComment",rtrim($expenseForm->get_value("expenseFormComment")));
-  $expenseForm->save();
-  alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id());
-  exit();
-
+    $expenseForm->read_globals();
+    if ($expenseForm->get_value("reimbursementRequired") == 0 || $expenseForm->get_value("reimbursementRequired") == 1) {
+        $expenseForm->set_value("paymentMethod", "");
+    }
+    $expenseForm->set_value("seekClientReimbursement", $_POST["seekClientReimbursement"] ? 1 : 0);
+    $expenseForm->set_value("expenseFormFinalised", 1);
+    $expenseForm->set_value("expenseFormComment", rtrim($expenseForm->get_value("expenseFormComment")));
+    $expenseForm->save();
+    alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id());
+    exit();
 } else if ($_POST["unfinalise"]) {
-  $expenseForm->read_globals();
-  $expenseForm->set_value("expenseFormFinalised", 0);
-  $expenseForm->set_value("expenseFormComment",rtrim($expenseForm->get_value("expenseFormComment")));
-  $expenseForm->save();
-  alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id());
-  exit();
-
+    $expenseForm->read_globals();
+    $expenseForm->set_value("expenseFormFinalised", 0);
+    $expenseForm->set_value("expenseFormComment", rtrim($expenseForm->get_value("expenseFormComment")));
+    $expenseForm->save();
+    alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id());
+    exit();
 } else if ($_POST["attach_transactions_to_invoice"] && $current_user->have_role("admin")) {
-  $expenseForm->save_to_invoice($_POST["attach_to_invoiceID"]);
+    $expenseForm->save_to_invoice($_POST["attach_to_invoiceID"]);
 }
 
 
 if (is_object($expenseForm) && $expenseForm->get_value("expenseFormFinalised") && $current_user->get_id() == $expenseForm->get_value("expenseFormCreatedUser")) {
-  $TPL["message_help"][] = "Step 4/4: Print out the Expense Form using the Printer Friendly Version link, attach receipts and hand in to office admin.";
-
-} else if (check_optional_has_line_items() && !$expenseForm->get_value("expenseFormFinalised")) {  
-  $TPL["message_help"][] = "Step 3/4: When finished adding Expense Form Line Items, click the To Admin button to finalise the Expense Form.";
-
+    $TPL["message_help"][] = "Step 4/4: Print out the Expense Form using the Printer Friendly Version link, attach receipts and hand in to office admin.";
+} else if (check_optional_has_line_items() && !$expenseForm->get_value("expenseFormFinalised")) {
+    $TPL["message_help"][] = "Step 3/4: When finished adding Expense Form Line Items, click the To Admin button to finalise the Expense Form.";
 } else if (is_object($expenseForm) && $expenseForm->get_id() && !$expenseForm->get_value("expenseFormFinalised")) {
-  $TPL["message_help"][] = "Step 2/4: Add Expense Form Line Items by filling in the details and clicking the Add Expense Form Line Item button.";
-
+    $TPL["message_help"][] = "Step 2/4: Add Expense Form Line Items by filling in the details and clicking the Add Expense Form Line Item button.";
 } else if (!is_object($expenseForm) || !$expenseForm->get_id()) {
-  $TPL["message_help"][] = "Step 1/4: Begin an Expense Form by choosing the Payment Method and then clicking the Create Expense Form button.";
+    $TPL["message_help"][] = "Step 1/4: Begin an Expense Form by choosing the Payment Method and then clicking the Create Expense Form button.";
 }
 
 $paymentOptionNames = array("", "COD", "Cheque", "Company Amex Charge", "Company Amex Blue", "Company Virgin MasterCard", "Other Credit Card", "Account", "Direct Deposit");
 $paymentOptions = page::select_options($paymentOptionNames, $expenseForm->get_value("paymentMethod"));
 
 $rr_options = expenseForm::get_reimbursementRequired_array();
-$rr_checked[sprintf("%d",$expenseForm->get_value("reimbursementRequired"))] = " checked";
+$rr_checked[sprintf("%d", $expenseForm->get_value("reimbursementRequired"))] = " checked";
 $expenseForm->get_value("paymentMethod") and $extra = " (".$paymentOptionNames[$expenseForm->get_value("paymentMethod")].")";
 $rr_label = $rr_options[$expenseForm->get_value("reimbursementRequired")].$extra;
 $TPL["rr_label"] = $rr_options[$expenseForm->get_value("reimbursementRequired")].$extra;
 
 foreach ($rr_options as $value => $label) {
-  unset($extra);
-  $value == 2 and $extra = " <select name=\"paymentMethod\">".$paymentOptions."</select>";
-  $reimbursementRequiredRadios.= $br."<input type=\"radio\" name=\"reimbursementRequired\" value=\"".$value."\"".$rr_checked[$value].">".$label.$extra;
-  $br = "<br>";
+    unset($extra);
+    $value == 2 and $extra = " <select name=\"paymentMethod\">".$paymentOptions."</select>";
+    $reimbursementRequiredRadios.= $br."<input type=\"radio\" name=\"reimbursementRequired\" value=\"".$value."\"".$rr_checked[$value].">".$label.$extra;
+    $br = "<br>";
 }
 
 
@@ -354,8 +343,8 @@ $TPL["reimbursementRequiredOption"] = $rr_label;
 
 $scr_label = "No";
 if ($expenseForm->get_value("seekClientReimbursement")) {
-  $scr_sel = " checked";
-  $scr_label = "Yes";
+    $scr_sel = " checked";
+    $scr_label = "Yes";
 }
 
 $TPL["seekClientReimbursementLabel"] = $scr_label;
@@ -368,98 +357,92 @@ $c->set_id($expenseForm->get_value("clientID"));
 $c->select();
 $clientName = page::htmlentities($c->get_name());
 $clientName and $TPL["printer_clientID"] = $clientName;
-$TPL["field_expenseFormComment"] = $expenseForm->get_value("expenseFormComment",DST_HTML_DISPLAY);
+$TPL["field_expenseFormComment"] = $expenseForm->get_value("expenseFormComment", DST_HTML_DISPLAY);
 
 if (is_object($expenseForm) && $expenseForm->get_id() && check_optional_allow_edit()) {
-  $TPL["expenseFormButtons"].= '
+    $TPL["expenseFormButtons"].= '
   <button type="submit" name="cancel" value="1" class="delete_button">Delete<i class="icon-trash"></i></button>
   <button type="submit" name="save" value="1" class="save_button">Save<i class="icon-ok-sign"></i></button>
   <button type="submit" name="finalise" value="1" class="save_button">To Admin<i class="icon-arrow-right"></i></button>
   ';
 
-  $TPL["paymentMethodOptions"] = "<select name=\"paymentMethod\">".$paymentOptions."</select>";
-  $TPL["reimbursementRequiredOption"] = $reimbursementRequiredRadios; 
-  $TPL["seekClientReimbursementOption"] = $seekClientReimbursementOption;
-  $options["clientStatus"] = "Current";
-  $ops = client::get_list($options);
-  $ops = array_kv($ops,"clientID","clientName");
-  $TPL["field_clientID"] = "<select name=\"clientID\"><option value=\"\">".page::select_options($ops,$expenseForm->get_value("clientID"))."</select>";
-  $TPL["field_expenseFormComment"] = page::textarea("expenseFormComment",$expenseForm->get_value("expenseFormComment",DST_HTML_DISPLAY));
-
+    $TPL["paymentMethodOptions"] = "<select name=\"paymentMethod\">".$paymentOptions."</select>";
+    $TPL["reimbursementRequiredOption"] = $reimbursementRequiredRadios;
+    $TPL["seekClientReimbursementOption"] = $seekClientReimbursementOption;
+    $options["clientStatus"] = "Current";
+    $ops = client::get_list($options);
+    $ops = array_kv($ops, "clientID", "clientName");
+    $TPL["field_clientID"] = "<select name=\"clientID\"><option value=\"\">".page::select_options($ops, $expenseForm->get_value("clientID"))."</select>";
+    $TPL["field_expenseFormComment"] = page::textarea("expenseFormComment", $expenseForm->get_value("expenseFormComment", DST_HTML_DISPLAY));
 } else if (is_object($expenseForm) && $expenseForm->get_id() && $current_user->have_role("admin")) {
-
-  $TPL["expenseFormButtons"].= '
+    $TPL["expenseFormButtons"].= '
   <button type="submit" name="unfinalise" value="1" class="save_button"><i class="icon-arrow-left" style="margin:0px; margin-right:5px;"></i>Edit</button>
   <button type="submit" name="save" value="1" class="save_button">Save<i class="icon-ok-sign"></i></button>
   <select name="changeTransactionStatus"><option value="">Transaction Status<option value="approved">Approve<option value="rejected">Reject<option value="pending">Pending</select>
   ';
 
 
-  $TPL["field_clientID"] = $clientName;
-  $TPL["field_expenseFormComment"] = page::textarea("expenseFormComment",$expenseForm->get_value("expenseFormComment",DST_HTML_DISPLAY));
-
+    $TPL["field_clientID"] = $clientName;
+    $TPL["field_expenseFormComment"] = page::textarea("expenseFormComment", $expenseForm->get_value("expenseFormComment", DST_HTML_DISPLAY));
 } else if (is_object($expenseForm) && !$expenseForm->get_value("expenseFormFinalised")) {
-  $TPL["expenseFormButtons"].= '&nbsp;
+    $TPL["expenseFormButtons"].= '&nbsp;
          <button type="submit" name="save" value="1" class="save_button">Create Expense Form<i class="icon-ok-sign"></i></button>';
-  $TPL["paymentMethodOptions"] = "<select name=\"paymentMethod\">".$paymentOptions."</select>";
-  $TPL["reimbursementRequiredOption"] = $reimbursementRequiredRadios;
-  $TPL["seekClientReimbursementOption"] = $seekClientReimbursementOption;
-  $options["clientStatus"] = "Current";
-  $ops = client::get_list($options);
-  $ops = array_kv($ops,"clientID","clientName");
-  $TPL["field_clientID"] = "<select name=\"clientID\"><option value=\"\">".page::select_options($ops,$expenseForm->get_value("clientID"))."</select>";
-  $TPL["field_expenseFormComment"] = page::textarea("expenseFormComment",$expenseForm->get_value("expenseFormComment",DST_HTML_DISPLAY));
+    $TPL["paymentMethodOptions"] = "<select name=\"paymentMethod\">".$paymentOptions."</select>";
+    $TPL["reimbursementRequiredOption"] = $reimbursementRequiredRadios;
+    $TPL["seekClientReimbursementOption"] = $seekClientReimbursementOption;
+    $options["clientStatus"] = "Current";
+    $ops = client::get_list($options);
+    $ops = array_kv($ops, "clientID", "clientName");
+    $TPL["field_clientID"] = "<select name=\"clientID\"><option value=\"\">".page::select_options($ops, $expenseForm->get_value("clientID"))."</select>";
+    $TPL["field_expenseFormComment"] = page::textarea("expenseFormComment", $expenseForm->get_value("expenseFormComment", DST_HTML_DISPLAY));
 }
 
 if (is_object($expenseForm) && $expenseForm->get_id()) {
-  $db = new db_alloc();
-  $db->query(prepare("SELECT SUM(amount * pow(10,-currencyType.numberToBasic)) AS amount, 
+    $db = new db_alloc();
+    $db->query(prepare("SELECT SUM(amount * pow(10,-currencyType.numberToBasic)) AS amount, 
                              transaction.currencyTypeID as currency
                         FROM transaction
                    LEFT JOIN currencyType on transaction.currencyTypeID = currencyType.currencyTypeID
                        WHERE expenseFormID = %d
                     GROUP BY transaction.currencyTypeID
-                  ",$expenseForm->get_id()));
-  while ($row = $db->row()) {
-    $rows[] = $row;
-  }
-  $TPL["formTotal"] = page::money_print($rows);
+                  ", $expenseForm->get_id()));
+    while ($row = $db->row()) {
+        $rows[] = $row;
+    }
+    $TPL["formTotal"] = page::money_print($rows);
 }
 
 if (is_object($expenseForm) && $current_user->have_role("admin")
 && !$expenseForm->get_invoice_link() && $expenseForm->get_value("expenseFormFinalised") && $expenseForm->get_value("seekClientReimbursement")) {
-
-  $ops["invoiceStatus"] = "edit";
-  $ops["clientID"] = $expenseForm->get_value("clientID");
-  $invoice_list = invoice::get_list($ops);
-  $invoice_list = array_kv($invoice_list,"invoiceID",array("invoiceNum","invoiceName"));
-  $q = prepare("SELECT * FROM invoiceItem WHERE expenseFormID = %d",$expenseForm->get_id());
-  $db = new db_alloc();
-  $db->query($q);
-  $row = $db->row();
-  $sel_invoice = $row["invoiceID"];
-  $TPL["attach_to_invoice_button"] = "<select name=\"attach_to_invoiceID\">";
-  $TPL["attach_to_invoice_button"].= "<option value=\"create_new\">Create New Invoice</option>";
-  $TPL["attach_to_invoice_button"].= page::select_options($invoice_list,$sel_invoice)."</select>";
-  $TPL["attach_to_invoice_button"].= "<input type=\"submit\" name=\"attach_transactions_to_invoice\" value=\"Add to Invoice\"> ";
-  $TPL["invoice_label"] = "Invoice:";
+    $ops["invoiceStatus"] = "edit";
+    $ops["clientID"] = $expenseForm->get_value("clientID");
+    $invoice_list = invoice::get_list($ops);
+    $invoice_list = array_kv($invoice_list, "invoiceID", array("invoiceNum","invoiceName"));
+    $q = prepare("SELECT * FROM invoiceItem WHERE expenseFormID = %d", $expenseForm->get_id());
+    $db = new db_alloc();
+    $db->query($q);
+    $row = $db->row();
+    $sel_invoice = $row["invoiceID"];
+    $TPL["attach_to_invoice_button"] = "<select name=\"attach_to_invoiceID\">";
+    $TPL["attach_to_invoice_button"].= "<option value=\"create_new\">Create New Invoice</option>";
+    $TPL["attach_to_invoice_button"].= page::select_options($invoice_list, $sel_invoice)."</select>";
+    $TPL["attach_to_invoice_button"].= "<input type=\"submit\" name=\"attach_transactions_to_invoice\" value=\"Add to Invoice\"> ";
+    $TPL["invoice_label"] = "Invoice:";
 }
 
 if (is_object($expenseForm)) {
-  $invoice_link = $expenseForm->get_invoice_link();
-  if ($invoice_link) {
-    $TPL["invoice_label"] = "Invoice:";
-    $TPL["invoice_link"] = $invoice_link;
-  }
+    $invoice_link = $expenseForm->get_invoice_link();
+    if ($invoice_link) {
+        $TPL["invoice_label"] = "Invoice:";
+        $TPL["invoice_link"] = $invoice_link;
+    }
 }
 
 $TPL["taxName"] = config::get_config_item("taxName");
 
 $TPL["main_alloc_title"] = "Expense Form - ".APPLICATION_NAME;
 if ($_GET["printVersion"]) {
-  include_template("templates/expenseFormPrintableM.tpl");
+    include_template("templates/expenseFormPrintableM.tpl");
 } else {
-  include_template("templates/expenseFormM.tpl");
+    include_template("templates/expenseFormM.tpl");
 }
-
-?>

--- a/finance/expenseFormList.php
+++ b/finance/expenseFormList.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -27,7 +27,3 @@ $TPL["expenseFormRows"] = expenseForm::get_list($ops);
 $TPL["transactionRows"] = expenseForm::get_pending_repeat_transaction_list();
 $TPL["main_alloc_title"] = "Expense Form List - ".APPLICATION_NAME;
 include_template("templates/expenseFormListM.tpl");
-
-
-
-?>

--- a/finance/expenseUpload.php
+++ b/finance/expenseUpload.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,97 +23,95 @@
 require_once("../alloc.php");
 
 if (!config::get_config_item("mainTfID")) {
-  alloc_error("This functionality will not work until you set a Finance TF on the Setup -> Finance screen.");
+    alloc_error("This functionality will not work until you set a Finance TF on the Setup -> Finance screen.");
 }
 
 $field_map = array("date"=>0, "account"=>1, "num"=>2, "description"=>3, "memo"=>4, "category"=>5, "clr"=>6, "amount"=>7);
 
 if ($_POST["upload"]) {
-  $db = new db_alloc();
-  is_uploaded_file($_FILES["expenses_file"]["tmp_name"]) || alloc_error("File referred to was not an uploaded file",true); // Prevent attacks by setting $expenses_file in URL
-  $lines = file($_FILES["expenses_file"]["tmp_name"]);
+    $db = new db_alloc();
+    is_uploaded_file($_FILES["expenses_file"]["tmp_name"]) || alloc_error("File referred to was not an uploaded file", true); // Prevent attacks by setting $expenses_file in URL
+    $lines = file($_FILES["expenses_file"]["tmp_name"]);
 
-  reset($lines);
-  while (list(, $line) = each($lines)) {
-    // Ignore blank lines
-    if (trim($line) == "") {
-      continue;
-    }
-    // Read field values from the line
-    $fields = explode("\t", $line);
+    reset($lines);
+    while (list(, $line) = each($lines)) {
+      // Ignore blank lines
+        if (trim($line) == "") {
+            continue;
+        }
+      // Read field values from the line
+        $fields = explode("\t", $line);
 
-    $date = trim($fields[$field_map["date"]]);
-    $account = trim($fields[$field_map["account"]]);
-    $num = trim($fields[$field_map["num"]]);
-    $description = trim($fields[$field_map["description"]]);
-    $memo = trim($fields[$field_map["memo"]]);
-    $category = trim($fields[$field_map["category"]]);
-    $clr = trim($fields[$field_map["clr"]]);
-    $amount = trim($fields[$field_map["amount"]]);
+        $date = trim($fields[$field_map["date"]]);
+        $account = trim($fields[$field_map["account"]]);
+        $num = trim($fields[$field_map["num"]]);
+        $description = trim($fields[$field_map["description"]]);
+        $memo = trim($fields[$field_map["memo"]]);
+        $category = trim($fields[$field_map["category"]]);
+        $clr = trim($fields[$field_map["clr"]]);
+        $amount = trim($fields[$field_map["amount"]]);
 
-    // Idenitify lines containing totals as the date field will contain the text TOTAL
-    // Identify the column headings as the date field will be "Date"
-    // Ignore ignore these lines
-    if (stripos("total", $date) !== FALSE || $date == "Date") {
-      continue;
-    }
-    // Convert the date to yyyy-mm-dd
-    if (!preg_match("|^([0-9]{1,2})/([0-9]{1,2})'([0-9])$|i", $date, $matches)) {
-      $msg.= "<b>Warning: Could not convert date '$date'</b><br>";
-      continue;
-    }
-    $date = sprintf("200%d-%02d-%02d", $matches[3], $matches[2], $matches[1]);
+      // Idenitify lines containing totals as the date field will contain the text TOTAL
+      // Identify the column headings as the date field will be "Date"
+      // Ignore ignore these lines
+        if (stripos("total", $date) !== false || $date == "Date") {
+            continue;
+        }
+      // Convert the date to yyyy-mm-dd
+        if (!preg_match("|^([0-9]{1,2})/([0-9]{1,2})'([0-9])$|i", $date, $matches)) {
+            $msg.= "<b>Warning: Could not convert date '$date'</b><br>";
+            continue;
+        }
+        $date = sprintf("200%d-%02d-%02d", $matches[3], $matches[2], $matches[1]);
 
 
-    // Strip $ and , from amount
-    $amount = str_replace(array('$',','), array(), $amount);
-    if (!preg_match("/^-?[0-9]+(\\.[0-9]+)?$/", $amount)) {
-      $msg.= "<b>Warning: Could not convert amount '$amount'</b><br>";
-      continue;
-    }
-    // Ignore positive amounts
-    if ($amount > 0) {
-      $msg.= "<b>Warning: Ignored positive '$amount' for $memo on $date</b><br>";
-      continue;
-    }
-    // Find the TF ID for the expense
-    $query = prepare("SELECT * FROM tf WHERE tfActive = 1 AND quickenAccount='%s'", $account);
-    echo $query;
-    $db->query($query);
-    if ($db->next_record()) {
-      $fromTfID = $db->f("tfID");
-    } else {
-      $msg.= "<b>Warning: Could not find active TF for account '$account'</b><br>";
-      continue;
-    }
+      // Strip $ and , from amount
+        $amount = str_replace(array('$',','), array(), $amount);
+        if (!preg_match("/^-?[0-9]+(\\.[0-9]+)?$/", $amount)) {
+            $msg.= "<b>Warning: Could not convert amount '$amount'</b><br>";
+            continue;
+        }
+      // Ignore positive amounts
+        if ($amount > 0) {
+            $msg.= "<b>Warning: Ignored positive '$amount' for $memo on $date</b><br>";
+            continue;
+        }
+      // Find the TF ID for the expense
+        $query = prepare("SELECT * FROM tf WHERE tfActive = 1 AND quickenAccount='%s'", $account);
+        echo $query;
+        $db->query($query);
+        if ($db->next_record()) {
+            $fromTfID = $db->f("tfID");
+        } else {
+            $msg.= "<b>Warning: Could not find active TF for account '$account'</b><br>";
+            continue;
+        }
 
-    // Check for an existing transaction
-    $query = prepare("SELECT * FROM transaction WHERE transactionType='expense' AND transactionDate='%s' AND product='%s' AND amount > %0.3f and amount < %0.3f", $date, $memo, $amount - 0.004, $amount + 0.004);
-    $db->query($query);
-    if ($db->next_record()) {
-      $msg.= "Warning: Expense '$memo' on $date already exixsts.<br>";
-      continue;
-    }
-    // Create a transaction object and then save it
-    $transaction = new transaction();
-    $transaction->set_value("companyDetails", $description);
-    $transaction->set_value("product", $memo);
-    $transaction->set_value("amount", $amount);
-    $transaction->set_value("status", "pending");
-    $transaction->set_value("expenseFormID", "0");
-    $transaction->set_value("fromTfID", $fromTfID);
-    $transaction->set_value("tfID", config::get_config_item("mainTfID"));
-    $transaction->set_value("quantity", 1);
-    $transaction->set_value("invoiceItemID", "0");
-    $transaction->set_value("transactionType", "expense");
-    $transaction->set_value("transactionDate", "$date");
-    $transaction->save();
+      // Check for an existing transaction
+        $query = prepare("SELECT * FROM transaction WHERE transactionType='expense' AND transactionDate='%s' AND product='%s' AND amount > %0.3f and amount < %0.3f", $date, $memo, $amount - 0.004, $amount + 0.004);
+        $db->query($query);
+        if ($db->next_record()) {
+            $msg.= "Warning: Expense '$memo' on $date already exixsts.<br>";
+            continue;
+        }
+      // Create a transaction object and then save it
+        $transaction = new transaction();
+        $transaction->set_value("companyDetails", $description);
+        $transaction->set_value("product", $memo);
+        $transaction->set_value("amount", $amount);
+        $transaction->set_value("status", "pending");
+        $transaction->set_value("expenseFormID", "0");
+        $transaction->set_value("fromTfID", $fromTfID);
+        $transaction->set_value("tfID", config::get_config_item("mainTfID"));
+        $transaction->set_value("quantity", 1);
+        $transaction->set_value("invoiceItemID", "0");
+        $transaction->set_value("transactionType", "expense");
+        $transaction->set_value("transactionDate", "$date");
+        $transaction->save();
 
-    $msg.= "Expense '$memo' on $date saved.<br>";
-  }
-  $TPL["msg"] = $msg;
+        $msg.= "Expense '$memo' on $date saved.<br>";
+    }
+    $TPL["msg"] = $msg;
 }
 
 include_template("templates/expenseUploadM.tpl");
-
-?>

--- a/finance/lib/exchangeRate.inc.php
+++ b/finance/lib/exchangeRate.inc.php
@@ -3,113 +3,121 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class exchangeRate extends db_entity {
-  public $data_table = "exchangeRate";
-  public $display_field_name = "exchangeRate";
-  public $key_field = "exchangeRateID";
-  public $data_fields = array("exchangeRateCreatedDate"
+class exchangeRate extends db_entity
+{
+    public $data_table = "exchangeRate";
+    public $display_field_name = "exchangeRate";
+    public $key_field = "exchangeRateID";
+    public $data_fields = array("exchangeRateCreatedDate"
                              ,"exchangeRateCreatedTime"
                              ,"fromCurrency"
                              ,"toCurrency"
                              ,"exchangeRate"
                              );
 
-  public static function get_er($from, $to, $date="") {
-    static $cache;
-    if (imp($cache[$from][$to][$date])) {
-      return $cache[$from][$to][$date];
-    }
-    $db = new db_alloc();
-    if ($date) {
-      $q = prepare("SELECT *
+    public static function get_er($from, $to, $date = "")
+    {
+        static $cache;
+        if (imp($cache[$from][$to][$date])) {
+            return $cache[$from][$to][$date];
+        }
+        $db = new db_alloc();
+        if ($date) {
+            $q = prepare(
+                "SELECT *
                       FROM exchangeRate 
                      WHERE exchangeRateCreatedDate = '%s'
                        AND fromCurrency = '%s'
                        AND toCurrency = '%s'
-                   ",$date
-                    ,$from
-                    ,$to
-                  );
-      $db->query($q);
-      $row = $db->row();
-    } 
+                   ",
+                $date,
+                $from,
+                $to
+            );
+            $db->query($q);
+            $row = $db->row();
+        }
 
-    if (!$row) {
-      $q = prepare("SELECT *
+        if (!$row) {
+            $q = prepare(
+                "SELECT *
                       FROM exchangeRate 
                      WHERE fromCurrency = '%s'
                        AND toCurrency = '%s'
                   ORDER BY exchangeRateCreatedTime DESC
                      LIMIT 1
-                   ",$from
-                    ,$to
-                  );
-      $db->query($q);
-      $row = $db->row();
+                   ",
+                $from,
+                $to
+            );
+            $db->query($q);
+            $row = $db->row();
+        }
+        $cache[$from][$to][$date] = $row["exchangeRate"];
+        return $row["exchangeRate"];
     }
-    $cache[$from][$to][$date] = $row["exchangeRate"];
-    return $row["exchangeRate"];
-  }
 
-  public static function convert($currency, $amount, $destCurrency=false, $date=false, $format="%m") {
-    $date or $date = date("Y-m-d");
-    $destCurrency or $destCurrency = config::get_config_item("currency");
-    $er = exchangeRate::get_er($currency,$destCurrency,$date);
-    return page::money($destCurrency,$amount*$er,$format);
-  }
-
-  public static function update_rate($from, $to) {
-    $rate = get_exchange_rate($from,$to);
-    if ($rate) {
-      $er = new exchangeRate();
-      $er->set_value("exchangeRateCreatedDate",date("Y-m-d"));
-      $er->set_value("fromCurrency",$from);
-      $er->set_value("toCurrency",$to);
-      $er->set_value("exchangeRate",$rate);
-      $er->save();
-      return $from." -> ".$to.":".$rate." ";
-    } else {
-      echo date("Y-m-d H:i:s")."Unable to obtain exchange rate information for ".$from." to ".$to."!";
+    public static function convert($currency, $amount, $destCurrency = false, $date = false, $format = "%m")
+    {
+        $date or $date = date("Y-m-d");
+        $destCurrency or $destCurrency = config::get_config_item("currency");
+        $er = exchangeRate::get_er($currency, $destCurrency, $date);
+        return page::money($destCurrency, $amount*$er, $format);
     }
-  }
 
-  public static function download() {
-    // Get default currency
-    $default_currency = config::get_config_item("currency");
-
-    // Get list of active currencies
-    $meta = new meta("currencyType");
-    $currencies = $meta->get_list();
-
-    foreach ((array)$currencies as $code => $currency) {
-      if ($code == $default_currency)
-      	continue;
-      if ($ret = exchangeRate::update_rate($code, $default_currency))
-      	$rtn []= $ret;
-      if ($ret = exchangeRate::update_rate($default_currency, $code))
-      	$rtn []= $ret;
-
+    public static function update_rate($from, $to)
+    {
+        $rate = get_exchange_rate($from, $to);
+        if ($rate) {
+            $er = new exchangeRate();
+            $er->set_value("exchangeRateCreatedDate", date("Y-m-d"));
+            $er->set_value("fromCurrency", $from);
+            $er->set_value("toCurrency", $to);
+            $er->set_value("exchangeRate", $rate);
+            $er->save();
+            return $from." -> ".$to.":".$rate." ";
+        } else {
+            echo date("Y-m-d H:i:s")."Unable to obtain exchange rate information for ".$from." to ".$to."!";
+        }
     }
-    return $rtn;
-  }
 
+    public static function download()
+    {
+      // Get default currency
+        $default_currency = config::get_config_item("currency");
+
+      // Get list of active currencies
+        $meta = new meta("currencyType");
+        $currencies = $meta->get_list();
+
+        foreach ((array)$currencies as $code => $currency) {
+            if ($code == $default_currency) {
+                continue;
+            }
+            if ($ret = exchangeRate::update_rate($code, $default_currency)) {
+                $rtn []= $ret;
+            }
+            if ($ret = exchangeRate::update_rate($default_currency, $code)) {
+                $rtn []= $ret;
+            }
+        }
+        return $rtn;
+    }
 }
-
-?>

--- a/finance/lib/expenseForm.inc.php
+++ b/finance/lib/expenseForm.inc.php
@@ -3,27 +3,28 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class expenseForm extends db_entity {
-  public $data_table = "expenseForm";
-  public $key_field = "expenseFormID";
-  public $data_fields = array("expenseFormModifiedUser"
+class expenseForm extends db_entity
+{
+    public $data_table = "expenseForm";
+    public $key_field = "expenseFormID";
+    public $data_fields = array("expenseFormModifiedUser"
                              ,"expenseFormModifiedTime"
                              ,"paymentMethod"
                              ,"reimbursementRequired"=>array("empty_to_null"=>false)
@@ -36,205 +37,218 @@ class expenseForm extends db_entity {
                              ,"expenseFormComment"
                              );
 
-  function is_owner($person = "") {
-    $current_user = &singleton("current_user");
+    function is_owner($person = "")
+    {
+        $current_user = &singleton("current_user");
 
-    if ($person == "") {
-      $person = $current_user;
-    }
-    // Return true if this user created the expense form
-    if ($person->get_id() == $this->get_value("expenseFormCreatedUser", DST_VARIABLE)) {
-      return true;
-    }
-
-    if ($this->get_id()) {
-      // Return true if any of the transactions on the expense form are accessible by the current user
-      $current_user_tfIDs = $current_user->get_tfIDs();
-      $query = prepare("SELECT * FROM transaction WHERE expenseFormID=%d",$this->get_id());
-      $db = new db_alloc();
-      $db->query($query);
-      while ($db->next_record()) {
-        if (is_array($current_user_tfIDs) && (in_array($db->f("tfID"),$current_user_tfIDs) || in_array($db->f("fromTfID"),$current_user_tfIDs))) {
-          return true;
+        if ($person == "") {
+            $person = $current_user;
         }
-      }
+      // Return true if this user created the expense form
+        if ($person->get_id() == $this->get_value("expenseFormCreatedUser", DST_VARIABLE)) {
+            return true;
+        }
 
-    // If no expenseForm ID, then it hasn't been created yet...
-    } else {
-      return true;
+        if ($this->get_id()) {
+          // Return true if any of the transactions on the expense form are accessible by the current user
+            $current_user_tfIDs = $current_user->get_tfIDs();
+            $query = prepare("SELECT * FROM transaction WHERE expenseFormID=%d", $this->get_id());
+            $db = new db_alloc();
+            $db->query($query);
+            while ($db->next_record()) {
+                if (is_array($current_user_tfIDs) && (in_array($db->f("tfID"), $current_user_tfIDs) || in_array($db->f("fromTfID"), $current_user_tfIDs))) {
+                    return true;
+                }
+            }
+
+        // If no expenseForm ID, then it hasn't been created yet...
+        } else {
+            return true;
+        }
+
+        if ($current_user->have_role("admin")) {
+            return true;
+        }
+
+        return false;
     }
 
-    if ($current_user->have_role("admin")) {
-      return true;
-    }
-
-    return false;
-  }
-
-  public static function get_reimbursementRequired_array() {
-    return array("0"=>"Unpaid"
+    public static function get_reimbursementRequired_array()
+    {
+        return array("0"=>"Unpaid"
                 ,"1"=>"Paid by me"
                 ,"2"=>"Paid by company"
                 );
-  }
-
-  function set_status($status) {
-    // This sets the status of the expense form. Actually, the expense form
-    // doesn't have its own status - this sets the status of the transactions on the
-    // expense form
-    $current_user = &singleton("current_user");
-    $transactions = $this->get_foreign_objects("transaction");
-    while (list(, $transaction) = each($transactions)) {
-      $transaction->set_value("status", $status);
-      $transaction->save();
     }
-  }
 
-  function get_status() {
-    $q = prepare("SELECT status FROM transaction WHERE expenseFormID = %d",$this->get_id());
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $arr[$row["status"]] = 1;
+    function set_status($status)
+    {
+      // This sets the status of the expense form. Actually, the expense form
+      // doesn't have its own status - this sets the status of the transactions on the
+      // expense form
+        $current_user = &singleton("current_user");
+        $transactions = $this->get_foreign_objects("transaction");
+        while (list(, $transaction) = each($transactions)) {
+            $transaction->set_value("status", $status);
+            $transaction->save();
+        }
     }
-    $arr or $arr = array();
-    foreach ($arr as $s => $v) {
-      $return .= $sp.$s;
-      $sp = "&nbsp;&amp;&nbsp;";
+
+    function get_status()
+    {
+        $q = prepare("SELECT status FROM transaction WHERE expenseFormID = %d", $this->get_id());
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $arr[$row["status"]] = 1;
+        }
+        $arr or $arr = array();
+        foreach ($arr as $s => $v) {
+            $return .= $sp.$s;
+            $sp = "&nbsp;&amp;&nbsp;";
+        }
+        return $return;
     }
-    return $return;
-  }
 
-  function delete_transactions($transactionID="") {
-    global $TPL;
+    function delete_transactions($transactionID = "")
+    {
+        global $TPL;
 
-    $transactionID and $extra_sql = prepare("AND transactionID = %d",$transactionID);
+        $transactionID and $extra_sql = prepare("AND transactionID = %d", $transactionID);
 
-    $db = new db_alloc();
-    if ($this->is_owner()) {
-      $db->query(prepare("DELETE FROM transaction WHERE expenseFormID = %d ".$extra_sql,$this->get_id()));
-      $transactionID and $TPL["message_good"][] = "Expense Form Line Item deleted.";
+        $db = new db_alloc();
+        if ($this->is_owner()) {
+            $db->query(prepare("DELETE FROM transaction WHERE expenseFormID = %d ".$extra_sql, $this->get_id()));
+            $transactionID and $TPL["message_good"][] = "Expense Form Line Item deleted.";
+        }
     }
-  }
 
-  function get_invoice_link() {
-    global $TPL;
-    $db = new db_alloc();
-    if ($this->get_id()) {
-      $db->query("SELECT invoice.* FROM invoiceItem LEFT JOIN invoice on invoice.invoiceID = invoiceItem.invoiceID WHERE expenseFormID = %d",$this->get_id());
-      while ($row = $db->next_record()) {
-        $str.= $sp."<a href=\"".$TPL["url_alloc_invoice"]."invoiceID=".$row["invoiceID"]."\">".$row["invoiceNum"]."</a>";
-        $sp = "&nbsp;&nbsp;";
-      }
-      return $str;
+    function get_invoice_link()
+    {
+        global $TPL;
+        $db = new db_alloc();
+        if ($this->get_id()) {
+            $db->query("SELECT invoice.* FROM invoiceItem LEFT JOIN invoice on invoice.invoiceID = invoiceItem.invoiceID WHERE expenseFormID = %d", $this->get_id());
+            while ($row = $db->next_record()) {
+                $str.= $sp."<a href=\"".$TPL["url_alloc_invoice"]."invoiceID=".$row["invoiceID"]."\">".$row["invoiceNum"]."</a>";
+                $sp = "&nbsp;&nbsp;";
+            }
+            return $str;
+        }
     }
-  }
 
-  function save_to_invoice($invoiceID=false) {
+    function save_to_invoice($invoiceID = false)
+    {
 
-    if ($this->get_value("clientID")) {
-      $invoiceID and $extra = prepare(" AND invoiceID = %d",$invoiceID);
-      $client = $this->get_foreign_object("client");
-      $db = new db_alloc();
-      $q = prepare("SELECT * FROM invoice WHERE clientID = %d AND invoiceStatus = 'edit' ".$extra,$this->get_value("clientID"));
-      $db->query($q);
+        if ($this->get_value("clientID")) {
+            $invoiceID and $extra = prepare(" AND invoiceID = %d", $invoiceID);
+            $client = $this->get_foreign_object("client");
+            $db = new db_alloc();
+            $q = prepare("SELECT * FROM invoice WHERE clientID = %d AND invoiceStatus = 'edit' ".$extra, $this->get_value("clientID"));
+            $db->query($q);
 
-      // Create invoice
-      if (!$db->next_record()) {
-        $invoice = new invoice();
-        $invoice->set_value("clientID",$this->get_value("clientID"));
-        $invoice->set_value("invoiceDateFrom",$this->get_min_date());
-        $invoice->set_value("invoiceDateTo",$this->get_max_date());
-        $invoice->set_value("invoiceNum",invoice::get_next_invoiceNum());
-        $invoice->set_value("invoiceName",$client->get_value("clientName"));
-        $invoice->set_value("invoiceStatus","edit");
-        $invoice->save();
-        $invoiceID = $invoice->get_id();
+          // Create invoice
+            if (!$db->next_record()) {
+                $invoice = new invoice();
+                $invoice->set_value("clientID", $this->get_value("clientID"));
+                $invoice->set_value("invoiceDateFrom", $this->get_min_date());
+                $invoice->set_value("invoiceDateTo", $this->get_max_date());
+                $invoice->set_value("invoiceNum", invoice::get_next_invoiceNum());
+                $invoice->set_value("invoiceName", $client->get_value("clientName"));
+                $invoice->set_value("invoiceStatus", "edit");
+                $invoice->save();
+                $invoiceID = $invoice->get_id();
 
-      // Use existing invoice
-      } else {
-        $invoiceID = $db->f("invoiceID");
-      }
+              // Use existing invoice
+            } else {
+                $invoiceID = $db->f("invoiceID");
+            }
 
-      // Add invoiceItem and add expense form transactions to invoiceItem
-      if ($_POST["split_invoice"]) {
-        invoiceEntity::save_invoice_expenseFormItems($invoiceID,$this->get_id());
-      } else {
-        invoiceEntity::save_invoice_expenseForm($invoiceID,$this->get_id());
-      }
+          // Add invoiceItem and add expense form transactions to invoiceItem
+            if ($_POST["split_invoice"]) {
+                invoiceEntity::save_invoice_expenseFormItems($invoiceID, $this->get_id());
+            } else {
+                invoiceEntity::save_invoice_expenseForm($invoiceID, $this->get_id());
+            }
+        }
     }
-  }
 
-  function get_min_date() {
-    $db = new db_alloc();
-    $q = prepare("SELECT min(transactionDate) as date FROM transaction WHERE expenseFormID = %d",$this->get_id());
-    $db->query($q);
-    $db->next_record();
-    return $db->f('date');
-  }
-
-  function get_max_date() {
-    $db = new db_alloc();
-    $q = prepare("SELECT max(transactionDate) as date FROM transaction WHERE expenseFormID = %d",$this->get_id());
-    $db->query($q);
-    $db->next_record();
-    return $db->f('date');
-  }
-
-  function get_url() {
-    global $sess;
-    $sess or $sess = new session();
-
-    $url = "finance/expenseForm.php?expenseFormID=".$this->get_id();
-
-    if ($sess->Started()) {
-      $url = $sess->url(SCRIPT_PATH.$url);
-
-    // This for urls that are emailed
-    } else {
-      static $prefix;
-      $prefix or $prefix = config::get_config_item("allocURL");
-      $url = $prefix.$url;
+    function get_min_date()
+    {
+        $db = new db_alloc();
+        $q = prepare("SELECT min(transactionDate) as date FROM transaction WHERE expenseFormID = %d", $this->get_id());
+        $db->query($q);
+        $db->next_record();
+        return $db->f('date');
     }
-    return $url;
-  }
 
-  function get_abs_sum_transactions($id=false) {
-    if (is_object($this)) {
-      $id = $this->get_id();
+    function get_max_date()
+    {
+        $db = new db_alloc();
+        $q = prepare("SELECT max(transactionDate) as date FROM transaction WHERE expenseFormID = %d", $this->get_id());
+        $db->query($q);
+        $db->next_record();
+        return $db->f('date');
     }
-    $db = new db_alloc();
-    $q = prepare("SELECT sum(amount * pow(10,-currencyType.numberToBasic) * exchangeRate) AS amount
+
+    function get_url()
+    {
+        global $sess;
+        $sess or $sess = new session();
+
+        $url = "finance/expenseForm.php?expenseFormID=".$this->get_id();
+
+        if ($sess->Started()) {
+            $url = $sess->url(SCRIPT_PATH.$url);
+
+        // This for urls that are emailed
+        } else {
+            static $prefix;
+            $prefix or $prefix = config::get_config_item("allocURL");
+            $url = $prefix.$url;
+        }
+        return $url;
+    }
+
+    function get_abs_sum_transactions($id = false)
+    {
+        if (is_object($this)) {
+            $id = $this->get_id();
+        }
+        $db = new db_alloc();
+        $q = prepare("SELECT sum(amount * pow(10,-currencyType.numberToBasic) * exchangeRate) AS amount
                     FROM transaction 
                LEFT JOIN currencyType on transaction.currencyTypeID = currencyType.currencyTypeID
-                   WHERE expenseFormID = %d",$id);
-    $db->query($q);
-    $row = $db->row();
-    return $row["amount"];
-  } 
-
-  public static function get_list_filter($filter=array()) {
-    $filter["projectID"] and $sql[] = prepare("transaction.projectID = %d",$filter["projectID"]);
-    $filter["status"]    and $sql[] = prepare("transaction.status = '%s'",$filter["status"]);
-    isset($filter["finalised"]) and $sql[] = prepare("expenseForm.expenseFormFinalised = %d",$filter["finalised"]);
-    return $sql;
-  }
-
-  public static function get_list($_FORM=array()) {
-    global $TPL;
-    $filter = expenseForm::get_list_filter($_FORM);
-    if (is_array($filter) && count($filter)) {
-      $f = " AND ".implode(" AND ",$filter);
+                   WHERE expenseFormID = %d", $id);
+        $db->query($q);
+        $row = $db->row();
+        return $row["amount"];
     }
 
-    $db = new db_alloc();
-    $dbTwo = new db_alloc();
-    $transDB = new db_alloc();
-    $expenseForm = new expenseForm();
-    $transaction = new transaction();
-    $rr_options = expenseForm::get_reimbursementRequired_array();
+    public static function get_list_filter($filter = array())
+    {
+        $filter["projectID"] and $sql[] = prepare("transaction.projectID = %d", $filter["projectID"]);
+        $filter["status"]    and $sql[] = prepare("transaction.status = '%s'", $filter["status"]);
+        isset($filter["finalised"]) and $sql[] = prepare("expenseForm.expenseFormFinalised = %d", $filter["finalised"]);
+        return $sql;
+    }
 
-    $q = prepare("SELECT expenseForm.*
+    public static function get_list($_FORM = array())
+    {
+        global $TPL;
+        $filter = expenseForm::get_list_filter($_FORM);
+        if (is_array($filter) && count($filter)) {
+            $f = " AND ".implode(" AND ", $filter);
+        }
+
+        $db = new db_alloc();
+        $dbTwo = new db_alloc();
+        $transDB = new db_alloc();
+        $expenseForm = new expenseForm();
+        $transaction = new transaction();
+        $rr_options = expenseForm::get_reimbursementRequired_array();
+
+        $q = prepare("SELECT expenseForm.*
                         ,SUM(transaction.amount * pow(10,-currencyType.numberToBasic)) as formTotal
                         ,transaction.currencyTypeID
                     FROM expenseForm, transaction
@@ -244,58 +258,54 @@ class expenseForm extends db_entity {
                 GROUP BY expenseForm.expenseFormID, transaction.currencyTypeID
                 ORDER BY expenseFormID");
 
-    $db->query($q);
+        $db->query($q);
 
-    while ($row = $db->row()) {
-      $amounts[$row["expenseFormID"]].= $sp[$row["expenseFormID"]].page::money($row["currencyTypeID"],$row["formTotal"],"%s%m");
-      $sp[$row["expenseFormID"]] = " + ";
-      $allrows[$row["expenseFormID"]] = $row;
+        while ($row = $db->row()) {
+            $amounts[$row["expenseFormID"]].= $sp[$row["expenseFormID"]].page::money($row["currencyTypeID"], $row["formTotal"], "%s%m");
+            $sp[$row["expenseFormID"]] = " + ";
+            $allrows[$row["expenseFormID"]] = $row;
+        }
+        foreach ((array)$allrows as $expenseFormID => $row) {
+            $expenseForm = new expenseForm();
+            if ($expenseForm->read_row_record($row)) {
+                $expenseForm->set_values();
+                $row["formTotal"] = $amounts[$expenseFormID];
+                $row["expenseFormModifiedUser"] = person::get_fullname($expenseForm->get_value("expenseFormModifiedUser"));
+                $row["expenseFormModifiedTime"] = $expenseForm->get_value("expenseFormModifiedTime");
+                $row["expenseFormCreatedUser"] = person::get_fullname($expenseForm->get_value("expenseFormCreatedUser"));
+                $row["expenseFormCreatedTime"] = $expenseForm->get_value("expenseFormCreatedTime");
+                unset($extra);
+                $expenseForm->get_value("paymentMethod") and $extra = " (".$expenseForm->get_value("paymentMethod").")";
+                $row["rr_label"] = $rr_options[$expenseForm->get_value("reimbursementRequired")].$extra;
+                $rows[] = $row;
+            }
+        }
+        return (array)$rows;
     }
-    foreach ((array)$allrows as $expenseFormID => $row) {
-      $expenseForm = new expenseForm();
-      if ($expenseForm->read_row_record($row)) {
-        $expenseForm->set_values();
-        $row["formTotal"] = $amounts[$expenseFormID];
-        $row["expenseFormModifiedUser"] = person::get_fullname($expenseForm->get_value("expenseFormModifiedUser"));
-        $row["expenseFormModifiedTime"] = $expenseForm->get_value("expenseFormModifiedTime");
-        $row["expenseFormCreatedUser"] = person::get_fullname($expenseForm->get_value("expenseFormCreatedUser"));
-        $row["expenseFormCreatedTime"] = $expenseForm->get_value("expenseFormCreatedTime");
-        unset($extra);
-        $expenseForm->get_value("paymentMethod") and $extra = " (".$expenseForm->get_value("paymentMethod").")";
-        $row["rr_label"] = $rr_options[$expenseForm->get_value("reimbursementRequired")].$extra;
-        $rows[] = $row;
-      }
-    }
-    return (array)$rows;
-  }
 
-  function get_pending_repeat_transaction_list() {
-    global $TPL;
-    $transactionTypes = transaction::get_transactionTypes();
-    $q = "SELECT * FROM transaction 
+    function get_pending_repeat_transaction_list()
+    {
+        global $TPL;
+        $transactionTypes = transaction::get_transactionTypes();
+        $q = "SELECT * FROM transaction 
               LEFT JOIN transactionRepeat on transactionRepeat.transactionRepeatID = transaction.transactionRepeatID 
                   WHERE transaction.transactionRepeatID IS NOT NULL AND transaction.status = 'pending'";
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $transaction = new transaction();
-      $transaction->read_db_record($db);
-      $transaction->set_values();
-      $transactionRepeat = new transactionRepeat();
-      $transactionRepeat->read_db_record($db);
-      $transactionRepeat->set_values();
-      $row["transactionType"] = $transactionTypes[$transaction->get_value("transactionType")];
-      $row["formTotal"] =  $db->f("amount");
-      $row["transactionModifiedTime"] = $transaction->get_value("transactionModifiedTime");
-      $row["transactionCreatedTime"] = $transaction->get_value("transactionCreatedTime");
-      $row["transactionCreatedUser"] = person::get_fullname($transaction->get_value("transactionCreatedUser"));
-      $rows[] = $row;
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $transaction = new transaction();
+            $transaction->read_db_record($db);
+            $transaction->set_values();
+            $transactionRepeat = new transactionRepeat();
+            $transactionRepeat->read_db_record($db);
+            $transactionRepeat->set_values();
+            $row["transactionType"] = $transactionTypes[$transaction->get_value("transactionType")];
+            $row["formTotal"] =  $db->f("amount");
+            $row["transactionModifiedTime"] = $transaction->get_value("transactionModifiedTime");
+            $row["transactionCreatedTime"] = $transaction->get_value("transactionCreatedTime");
+            $row["transactionCreatedUser"] = person::get_fullname($transaction->get_value("transactionCreatedUser"));
+            $rows[] = $row;
+        }
+        return (array)$rows;
     }
-    return (array)$rows;
-  }
-
 }
-
-
-
-?>

--- a/finance/lib/init.php
+++ b/finance/lib/init.php
@@ -3,27 +3,27 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class finance_module extends module {
-  var $module = "finance";
-  var $db_entities = array("tf", "transaction", "expenseForm", "tfPerson", "transactionRepeat");
-  var $home_items = array("tfList_home_item","pendingAdminExpenseForm");
+class finance_module extends module
+{
+    var $module = "finance";
+    var $db_entities = array("tf", "transaction", "expenseForm", "tfPerson", "transactionRepeat");
+    var $home_items = array("tfList_home_item","pendingAdminExpenseForm");
 }
-?>

--- a/finance/lib/pendingAdminExpenseForm.inc.php
+++ b/finance/lib/pendingAdminExpenseForm.inc.php
@@ -3,47 +3,48 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class pendingAdminExpenseForm extends home_item {
+class pendingAdminExpenseForm extends home_item
+{
 
-  function __construct() {
-    parent::__construct("pending_admin_expense_form", "Expense Forms Pending Admin Approval", "finance", "pendingAdminExpenseFormM.tpl", "narrow", 42);
-  }
-
-  function visible() {
-    $current_user = &singleton("current_user");
-    if (isset($current_user) && $current_user->have_role("admin")) {
-      return true;
+    function __construct()
+    {
+        parent::__construct("pending_admin_expense_form", "Expense Forms Pending Admin Approval", "finance", "pendingAdminExpenseFormM.tpl", "narrow", 42);
     }
-  }
 
-  function render() {
-    global $TPL;
-    $ops["status"] = "pending";
-    $ops["finalised"] = 1;
-    $TPL["expenseFormRows"] = expenseForm::get_list($ops);
-    if (count($TPL["expenseFormRows"])) {
-      return true;
+    function visible()
+    {
+        $current_user = &singleton("current_user");
+        if (isset($current_user) && $current_user->have_role("admin")) {
+            return true;
+        }
     }
-  }
 
+    function render()
+    {
+        global $TPL;
+        $ops["status"] = "pending";
+        $ops["finalised"] = 1;
+        $TPL["expenseFormRows"] = expenseForm::get_list($ops);
+        if (count($TPL["expenseFormRows"])) {
+            return true;
+        }
+    }
 }
-
-?>

--- a/finance/lib/tf.inc.php
+++ b/finance/lib/tf.inc.php
@@ -3,28 +3,29 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class tf extends db_entity {
-  public $data_table = "tf";
-  public $display_field_name = "tfName";
-  public $key_field = "tfID";
-  public $data_fields = array("tfName"
+class tf extends db_entity
+{
+    public $data_table = "tf";
+    public $display_field_name = "tfName";
+    public $key_field = "tfID";
+    public $data_fields = array("tfName"
                              ,"tfComments"
                              ,"tfModifiedUser"
                              ,"tfModifiedTime"
@@ -33,245 +34,253 @@ class tf extends db_entity {
                              ,"tfActive"
                              );
 
-  function get_balance($where = array(), $debug="") {
-    $current_user = &singleton("current_user");
+    function get_balance($where = array(), $debug = "")
+    {
+        $current_user = &singleton("current_user");
  
-    // If no status is requested then default to approved.  
-    $where["status"] or $where["status"] = "approved";
+      // If no status is requested then default to approved.
+        $where["status"] or $where["status"] = "approved";
     
-    if (!$this->is_owner() && !$current_user->have_role("admin")) {
-      return false;
-    }
+        if (!$this->is_owner() && !$current_user->have_role("admin")) {
+            return false;
+        }
 
-    // Get belance
-    $db = new db_alloc();
-    $query = prepare("SELECT sum( if(fromTfID=%d,-amount,amount) * pow(10,-currencyType.numberToBasic) * exchangeRate) AS balance 
+      // Get belance
+        $db = new db_alloc();
+        $query = prepare(
+            "SELECT sum( if(fromTfID=%d,-amount,amount) * pow(10,-currencyType.numberToBasic) * exchangeRate) AS balance 
                         FROM transaction 
                    LEFT JOIN currencyType ON transaction.currencyTypeID = currencyType.currencyTypeID
-                       WHERE (tfID = %d or fromTfID = %d) "
-                    ,$this->get_id(),$this->get_id(),$this->get_id());
+                       WHERE (tfID = %d or fromTfID = %d) ",
+            $this->get_id(),
+            $this->get_id(),
+            $this->get_id()
+        );
 
-    // Build up the rest of the WHERE sql
-    foreach($where as $column_name=>$value) {
-      $op = " = ";
-      if (is_array($value)) {
-        $op = $value[0];
-        $value = $value[1];
-      }
-      $query.= " AND ".$column_name.$op." '".db_esc($value)."'";
-    }
-
-    #echo "<br>".$debug." q: ".$query;
-    $db->query($query);
-    $db->next_record() || alloc_error("TF $tfID not found in tf::get_balance");
-    return $db->f("balance");
-  }
-
-  function is_owner($person = "") {
-    $current_user = &singleton("current_user");
-    static $owners;
-    if ($person == "") {
-      $person = $current_user;
-    }
-
-    if (!$this->get_id()) {
-      return false;
-    }
-  
-    // optimization
-    if (isset($owners[$person->get_id()])) {
-      return in_array($this->get_id(),$owners[$person->get_id()]);
-    }
-    $owners[$person->get_id()] = $this->get_tfs_for_person($person->get_id());
-    return in_array($this->get_id(),(array)$owners[$person->get_id()]);
-  }
-
-  function get_tfs_for_person($personID) {
-    $query = prepare("SELECT * FROM tfPerson WHERE personID=%d",$personID);
-    $db = new db_alloc();
-    $db->query($query);
-    while ($row = $db->row()) {
-      $owners[] = $row["tfID"];
-    }
-    return $owners;
-  }
-
-  function get_nav_links() {
-    global $TPL;
-    $current_user = &singleton("current_user");
-
-    $nav_links = array();
-
-    // Alla melded the have entity perm for transactionRepeat into the 
-    // have entity perm for transaction because I figured they were the 
-    // same and it nukes the error message!
-
-    if (have_entity_perm("tf", PERM_UPDATE, $current_user, $this->is_owner())) {
-      $statement_url = $TPL["url_alloc_tf"]."tfID=".$this->get_id();
-      $statement_link = "<a href=\"$statement_url\">Edit TF</a>";
-      $nav_links[] = $statement_link;
-    }
-
-    return $nav_links;
-  }
-
-  function get_link() {
-    $current_user = &singleton("current_user");
-    global $TPL;
-    if (have_entity_perm("transaction", PERM_READ, $current_user, $this->is_owner())) {
-      return "<a href=\"".$TPL["url_alloc_transactionList"]."tfID=".$this->get_id()."\">".$this->get_value("tfName",DST_HTML_DISPLAY)."</a>";
-    } else {
-      return $this->get_value("tfName",DST_HTML_DISPLAY);
-    }
-  }
-
-  function get_name($tfID=false) {
-    if ($tfID) {
-      $db = new db_alloc();
-      $db->query(prepare("SELECT tfName FROM tf WHERE tfID=%d",$tfID));
-      $db->next_record();
-      return $db->f("tfName");
-    }
-  }
-
-  function get_tfID($name) {
-    if ($name) {
-      $db = new db_alloc();
-      $q = "SELECT tfID FROM tf WHERE ".sprintf_implode("tfName = '%s'",$name);
-      $db->query($q);
-      while ($row = $db->row()) {
-        $rtn[] = $row["tfID"];
-      }
-    }
-    return (array)$rtn;
-  }
-
-  public static function get_permitted_tfs($requested_tfs=array()) {
-    $current_user = &singleton("current_user");
-    // If admin, just use the requested tfs
-    if ($current_user->have_role('admin')) {
-      $rtn = $requested_tfs;
-
-    // If not admin, then remove the items from $requested_tfs that the user can't access
-    } else {
-      $allowed_tfs = (array)tf::get_tfs_for_person($current_user->get_id());
-      foreach ((array)$requested_tfs as $tf) {
-        if (in_array($tf,$allowed_tfs)) {
-          $rtn[] = $tf;
+      // Build up the rest of the WHERE sql
+        foreach ($where as $column_name => $value) {
+            $op = " = ";
+            if (is_array($value)) {
+                $op = $value[0];
+                $value = $value[1];
+            }
+            $query.= " AND ".$column_name.$op." '".db_esc($value)."'";
         }
-      }
+
+      #echo "<br>".$debug." q: ".$query;
+        $db->query($query);
+        $db->next_record() || alloc_error("TF $tfID not found in tf::get_balance");
+        return $db->f("balance");
     }
-    
-    // db_esc everything
-    foreach ((array)$rtn as $tf) {
-      $r[] = db_esc($tf);
-    }
-    return (array)array_unique((array)$r);
-  }
 
-  public static function get_list_filter($_FORM=array()) {
-    $current_user = &singleton("current_user");
+    function is_owner($person = "")
+    {
+        $current_user = &singleton("current_user");
+        static $owners;
+        if ($person == "") {
+            $person = $current_user;
+        }
 
-    if (!$_FORM["tfIDs"] && !$current_user->have_role('admin')) {
-      $_FORM["owner"] = true;
-    }
-    $_FORM["owner"] and $filter1[] = sprintf_implode("tfPerson.personID = %d",$current_user->get_id());
-
-    $tfIDs = tf::get_permitted_tfs($_FORM["tfIDs"]);
-    $tfIDs and $filter1[] = sprintf_implode("tf.tfID = %d",$tfIDs);
-    $tfIDs and $filter2[] = sprintf_implode("tf.tfID = %d",$tfIDs);
-    $_FORM["showall"] or $filter1[] = "(tf.tfActive = 1)";
-    $_FORM["showall"] or $filter2[] = "(tf.tfActive = 1)";
-
-    return array($filter1,$filter2);
-  }
-
-  public static function get_list($_FORM=array()) {
-    $current_user = &singleton("current_user");
-
-    list($filter1,$filter2) = tf::get_list_filter($_FORM);
-
-    if (is_array($filter1) && count($filter1)) {
-      $f = " AND ".implode(" AND ",$filter1);
-    }
-    if (is_array($filter2) && count($filter2)) {
-      $f2 = " AND ".implode(" AND ",$filter2);
-    }
+        if (!$this->get_id()) {
+            return false;
+        }
   
-    $db = new db_alloc();
-    $q = prepare("SELECT transaction.tfID as id, tf.tfName, transactionID, transaction.status,
+      // optimization
+        if (isset($owners[$person->get_id()])) {
+            return in_array($this->get_id(), $owners[$person->get_id()]);
+        }
+        $owners[$person->get_id()] = $this->get_tfs_for_person($person->get_id());
+        return in_array($this->get_id(), (array)$owners[$person->get_id()]);
+    }
+
+    function get_tfs_for_person($personID)
+    {
+        $query = prepare("SELECT * FROM tfPerson WHERE personID=%d", $personID);
+        $db = new db_alloc();
+        $db->query($query);
+        while ($row = $db->row()) {
+            $owners[] = $row["tfID"];
+        }
+        return $owners;
+    }
+
+    function get_nav_links()
+    {
+        global $TPL;
+        $current_user = &singleton("current_user");
+
+        $nav_links = array();
+
+      // Alla melded the have entity perm for transactionRepeat into the
+      // have entity perm for transaction because I figured they were the
+      // same and it nukes the error message!
+
+        if (have_entity_perm("tf", PERM_UPDATE, $current_user, $this->is_owner())) {
+            $statement_url = $TPL["url_alloc_tf"]."tfID=".$this->get_id();
+            $statement_link = "<a href=\"$statement_url\">Edit TF</a>";
+            $nav_links[] = $statement_link;
+        }
+
+        return $nav_links;
+    }
+
+    function get_link()
+    {
+        $current_user = &singleton("current_user");
+        global $TPL;
+        if (have_entity_perm("transaction", PERM_READ, $current_user, $this->is_owner())) {
+            return "<a href=\"".$TPL["url_alloc_transactionList"]."tfID=".$this->get_id()."\">".$this->get_value("tfName", DST_HTML_DISPLAY)."</a>";
+        } else {
+            return $this->get_value("tfName", DST_HTML_DISPLAY);
+        }
+    }
+
+    function get_name($tfID = false)
+    {
+        if ($tfID) {
+            $db = new db_alloc();
+            $db->query(prepare("SELECT tfName FROM tf WHERE tfID=%d", $tfID));
+            $db->next_record();
+            return $db->f("tfName");
+        }
+    }
+
+    function get_tfID($name)
+    {
+        if ($name) {
+            $db = new db_alloc();
+            $q = "SELECT tfID FROM tf WHERE ".sprintf_implode("tfName = '%s'", $name);
+            $db->query($q);
+            while ($row = $db->row()) {
+                $rtn[] = $row["tfID"];
+            }
+        }
+        return (array)$rtn;
+    }
+
+    public static function get_permitted_tfs($requested_tfs = array())
+    {
+        $current_user = &singleton("current_user");
+      // If admin, just use the requested tfs
+        if ($current_user->have_role('admin')) {
+            $rtn = $requested_tfs;
+
+        // If not admin, then remove the items from $requested_tfs that the user can't access
+        } else {
+            $allowed_tfs = (array)tf::get_tfs_for_person($current_user->get_id());
+            foreach ((array)$requested_tfs as $tf) {
+                if (in_array($tf, $allowed_tfs)) {
+                    $rtn[] = $tf;
+                }
+            }
+        }
+    
+      // db_esc everything
+        foreach ((array)$rtn as $tf) {
+            $r[] = db_esc($tf);
+        }
+        return (array)array_unique((array)$r);
+    }
+
+    public static function get_list_filter($_FORM = array())
+    {
+        $current_user = &singleton("current_user");
+
+        if (!$_FORM["tfIDs"] && !$current_user->have_role('admin')) {
+            $_FORM["owner"] = true;
+        }
+        $_FORM["owner"] and $filter1[] = sprintf_implode("tfPerson.personID = %d", $current_user->get_id());
+
+        $tfIDs = tf::get_permitted_tfs($_FORM["tfIDs"]);
+        $tfIDs and $filter1[] = sprintf_implode("tf.tfID = %d", $tfIDs);
+        $tfIDs and $filter2[] = sprintf_implode("tf.tfID = %d", $tfIDs);
+        $_FORM["showall"] or $filter1[] = "(tf.tfActive = 1)";
+        $_FORM["showall"] or $filter2[] = "(tf.tfActive = 1)";
+
+        return array($filter1,$filter2);
+    }
+
+    public static function get_list($_FORM = array())
+    {
+        $current_user = &singleton("current_user");
+
+        list($filter1,$filter2) = tf::get_list_filter($_FORM);
+
+        if (is_array($filter1) && count($filter1)) {
+            $f = " AND ".implode(" AND ", $filter1);
+        }
+        if (is_array($filter2) && count($filter2)) {
+            $f2 = " AND ".implode(" AND ", $filter2);
+        }
+  
+        $db = new db_alloc();
+        $q = prepare("SELECT transaction.tfID as id, tf.tfName, transactionID, transaction.status,
                          sum(amount * pow(10,-currencyType.numberToBasic) * exchangeRate) AS balance
                     FROM transaction
                LEFT JOIN currencyType ON currencyType.currencyTypeID = transaction.currencyTypeID
                LEFT JOIN tf on transaction.tfID = tf.tfID
                    WHERE 1 AND transaction.status != 'rejected' ".$f2."
-                GROUP BY transaction.status,transaction.tfID"
-                );
-    $db->query($q);
-    while ($row = $db->row()) {
-      if ($row["status"] == "approved") {
-        $adds[$row["id"]] = $row["balance"];
-      } else if ($row["status"] == "pending") {
-        $pending_adds[$row["id"]] = $row["balance"];
-      }
-    }
+                GROUP BY transaction.status,transaction.tfID");
+        $db->query($q);
+        while ($row = $db->row()) {
+            if ($row["status"] == "approved") {
+                $adds[$row["id"]] = $row["balance"];
+            } else if ($row["status"] == "pending") {
+                $pending_adds[$row["id"]] = $row["balance"];
+            }
+        }
 
         
-    $q = prepare("SELECT transaction.fromTfID as id, tf.tfName, transactionID, transaction.status,
+        $q = prepare("SELECT transaction.fromTfID as id, tf.tfName, transactionID, transaction.status,
                          sum(amount * pow(10,-currencyType.numberToBasic) * exchangeRate) AS balance
                     FROM transaction
                LEFT JOIN currencyType ON currencyType.currencyTypeID = transaction.currencyTypeID
                LEFT JOIN tf on transaction.fromTfID = tf.tfID
                    WHERE 1 AND transaction.status != 'rejected' ".$f2."
-                GROUP BY transaction.status,transaction.fromTfID"
-                );
-    $db->query($q);
-    while ($row = $db->row()) {
-      if ($row["status"] == "approved") {
-        $subs[$row["id"]] = $row["balance"];
-      } else if ($row["status"] == "pending") {
-        $pending_subs[$row["id"]] = $row["balance"];
-      }
-    }
+                GROUP BY transaction.status,transaction.fromTfID");
+        $db->query($q);
+        while ($row = $db->row()) {
+            if ($row["status"] == "approved") {
+                $subs[$row["id"]] = $row["balance"];
+            } else if ($row["status"] == "pending") {
+                $pending_subs[$row["id"]] = $row["balance"];
+            }
+        }
 
-    $q = prepare("SELECT tf.* 
+        $q = prepare("SELECT tf.* 
                     FROM tf 
                LEFT JOIN tfPerson ON tf.tfID = tfPerson.tfID 
                    WHERE 1 ".$f."
                 GROUP BY tf.tfID 
-                ORDER BY tf.tfName");  
+                ORDER BY tf.tfName");
 
-    $db->query($q);
-    while ($row = $db->row()) {
-      $tf = new tf();
-      $tf->read_db_record($db);
-      $tf->set_values();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $tf = new tf();
+            $tf->read_db_record($db);
+            $tf->set_values();
 
-      $total = $adds[$db->f("tfID")] - $subs[$db->f("tfID")];
-      $pending_total = $pending_adds[$db->f("tfID")] - $pending_subs[$db->f("tfID")];
+            $total = $adds[$db->f("tfID")] - $subs[$db->f("tfID")];
+            $pending_total = $pending_adds[$db->f("tfID")] - $pending_subs[$db->f("tfID")];
 
-      if (have_entity_perm("transaction", PERM_READ, $current_user, $tf->is_owner())) {
-        $row["tfBalance"] = page::money(config::get_config_item("currency"),$total,"%s%m %c");
-        $row["tfBalancePending"] = page::money(config::get_config_item("currency"),$pending_total,"%s%m %c");
-        $row["total"] = $total;
-        $row["pending_total"] = $pending_total;
-      } else {
-        $row["tfBalance"] = "";
-        $row["tfBalancePending"] = "";
-        $row["total"] = "";
-        $row["pending_total"] = "";
-      }
+            if (have_entity_perm("transaction", PERM_READ, $current_user, $tf->is_owner())) {
+                $row["tfBalance"] = page::money(config::get_config_item("currency"), $total, "%s%m %c");
+                $row["tfBalancePending"] = page::money(config::get_config_item("currency"), $pending_total, "%s%m %c");
+                $row["total"] = $total;
+                $row["pending_total"] = $pending_total;
+            } else {
+                $row["tfBalance"] = "";
+                $row["tfBalancePending"] = "";
+                $row["total"] = "";
+                $row["pending_total"] = "";
+            }
 
-      $nav_links = $tf->get_nav_links();
-      $row["nav_links"] = implode(" ", $nav_links);
-      $row["tfActive_label"] = "";
-      $tf->get_value("tfActive") and $row["tfActive_label"] = "Y";
-      $rows[$tf->get_id()] = $row;
+            $nav_links = $tf->get_nav_links();
+            $row["nav_links"] = implode(" ", $nav_links);
+            $row["tfActive_label"] = "";
+            $tf->get_value("tfActive") and $row["tfActive_label"] = "Y";
+            $rows[$tf->get_id()] = $row;
+        }
+        return (array)$rows;
     }
-    return (array)$rows;
-  }
-
-
 }
-
-?>

--- a/finance/lib/tfList_home_item.inc.php
+++ b/finance/lib/tfList_home_item.inc.php
@@ -3,42 +3,42 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class tfList_home_item extends home_item {
-  function __construct() {
-    parent::__construct("", "Tagged Funds", "finance", "tfListH.tpl", "narrow",20);
-  }
-
-  function visible() {
-    return true;
-  }
-
-  function render() {
-    global $TPL;
-    $ops["owner"] = 1;
-    $TPL["tfListRows"] = tf::get_list($ops);
-    if ($TPL["tfListRows"]) {
-      return true;
+class tfList_home_item extends home_item
+{
+    function __construct()
+    {
+        parent::__construct("", "Tagged Funds", "finance", "tfListH.tpl", "narrow", 20);
     }
-  }
+
+    function visible()
+    {
+        return true;
+    }
+
+    function render()
+    {
+        global $TPL;
+        $ops["owner"] = 1;
+        $TPL["tfListRows"] = tf::get_list($ops);
+        if ($TPL["tfListRows"]) {
+            return true;
+        }
+    }
 }
-
-
-
-?>

--- a/finance/lib/tfPerson.inc.php
+++ b/finance/lib/tfPerson.inc.php
@@ -3,33 +3,29 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class tfPerson extends db_entity {
-  public $data_table = "tfPerson";
-  public $display_field_name = "personID";
-  public $key_field = "tfPersonID";
-  public $data_fields = array("tfID"
+class tfPerson extends db_entity
+{
+    public $data_table = "tfPerson";
+    public $display_field_name = "personID";
+    public $key_field = "tfPersonID";
+    public $data_fields = array("tfID"
                              ,"personID"
                              );
-
 }
-
-
-
-?>

--- a/finance/lib/transaction.inc.php
+++ b/finance/lib/transaction.inc.php
@@ -3,38 +3,39 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class transaction extends db_entity {
-  public $classname = "transaction";
-  public $data_table = "transaction";
-  public $display_field_name = "product";
-  public $key_field = "transactionID";
-  public $data_fields = array("companyDetails" => array("empty_to_null"=>false)
+class transaction extends db_entity
+{
+    public $classname = "transaction";
+    public $data_table = "transaction";
+    public $display_field_name = "product";
+    public $key_field = "transactionID";
+    public $data_fields = array("companyDetails" => array("empty_to_null"=>false)
                              ,"product" => array("empty_to_null"=>false)
-                             ,"amount" => array("type"=>"money") 
-                             ,"currencyTypeID" 
-                             ,"destCurrencyTypeID" 
-                             ,"exchangeRate" 
+                             ,"amount" => array("type"=>"money")
+                             ,"currencyTypeID"
+                             ,"destCurrencyTypeID"
+                             ,"exchangeRate"
                              ,"status"
                              ,"dateApproved"
-                             ,"expenseFormID" 
+                             ,"expenseFormID"
                              ,"invoiceID"
                              ,"invoiceItemID"
                              ,"tfID"
@@ -55,106 +56,108 @@ class transaction extends db_entity {
                              ,"transactionGroupID"
                              );
 
-  function save() {
+    function save()
+    {
 
-    // These need to be in here instead of validate(), because
-    // validate is called after save() and we need these values set for save().
-    $this->get_value("currencyTypeID") or $this->set_value("currencyTypeID",config::get_config_item("currency"));
-    $this->get_value("destCurrencyTypeID") or $this->set_value("destCurrencyTypeID",config::get_config_item("currency"));
+      // These need to be in here instead of validate(), because
+      // validate is called after save() and we need these values set for save().
+        $this->get_value("currencyTypeID") or $this->set_value("currencyTypeID", config::get_config_item("currency"));
+        $this->get_value("destCurrencyTypeID") or $this->set_value("destCurrencyTypeID", config::get_config_item("currency"));
 
-    // The data prior to the save
-    $old = $this->all_row_fields;
-    if ($old["status"] != $this->get_value("status") && $this->get_value("status") == "approved") {
-      $this->set_value("dateApproved",date("Y-m-d"));
-      $field_changed = true;
-    } else if ($this->get_value("status") != "approved") {
-      $this->set_value("dateApproved","");
+      // The data prior to the save
+        $old = $this->all_row_fields;
+        if ($old["status"] != $this->get_value("status") && $this->get_value("status") == "approved") {
+            $this->set_value("dateApproved", date("Y-m-d"));
+            $field_changed = true;
+        } else if ($this->get_value("status") != "approved") {
+            $this->set_value("dateApproved", "");
+        }
+
+        if ($old["currencyTypeID"] != $this->get_value("currencyTypeID")) {
+            $field_changed = true;
+        }
+        if ($old["destCurrencyTypeID"] != $this->get_value("destCurrencyTypeID")) {
+            $field_changed = true;
+        }
+        $db = new db_alloc();
+
+      // If there already is an exchange rate set for an approved
+      // transaction, then there's no need to update the exchange rate
+        if ($this->get_value("exchangeRate") && $this->get_value("dateApproved") && !$field_changed) {
+        // Else update the transaction's exchange rate
+        } else {
+            $this->get_value("transactionCreatedTime")  and $date = format_date("Y-m-d", $this->get_value("transactionCreatedTime"));
+            $this->get_value("transactionModifiedTime") and $date = format_date("Y-m-d", $this->get_value("transactionModifiedTime"));
+            $this->get_value("transactionDate")         and $date = $this->get_value("transactionDate");
+            $this->get_value("dateApproved")            and $date = $this->get_value("dateApproved");
+
+            $er = exchangeRate::get_er($this->get_value("currencyTypeID"), $this->get_value("destCurrencyTypeID"), $date);
+            if (!$er) {
+                alloc_error("Unable to determine exchange rate for ".$this->get_value("currencyTypeID")." to ".$this->get_value("destCurrencyTypeID")." for date: ".$date);
+            } else {
+                $this->set_value("exchangeRate", $er);
+            }
+        }
+
+        return parent::save();
     }
 
-    if ($old["currencyTypeID"] != $this->get_value("currencyTypeID")) {
-      $field_changed = true;
-    }
-    if ($old["destCurrencyTypeID"] != $this->get_value("destCurrencyTypeID")) {
-      $field_changed = true;
-    }
-    $db = new db_alloc();
-
-    // If there already is an exchange rate set for an approved
-    // transaction, then there's no need to update the exchange rate
-    if ($this->get_value("exchangeRate") && $this->get_value("dateApproved") && !$field_changed) {
-
-    // Else update the transaction's exchange rate
-    } else {
-      $this->get_value("transactionCreatedTime")  and $date = format_date("Y-m-d",$this->get_value("transactionCreatedTime"));
-      $this->get_value("transactionModifiedTime") and $date = format_date("Y-m-d",$this->get_value("transactionModifiedTime"));
-      $this->get_value("transactionDate")         and $date = $this->get_value("transactionDate");
-      $this->get_value("dateApproved")            and $date = $this->get_value("dateApproved");
-
-      $er = exchangeRate::get_er($this->get_value("currencyTypeID"), $this->get_value("destCurrencyTypeID"), $date);
-      if (!$er) {
-        alloc_error("Unable to determine exchange rate for ".$this->get_value("currencyTypeID")." to ".$this->get_value("destCurrencyTypeID")." for date: ".$date);
-      } else {
-        $this->set_value("exchangeRate",$er);
-      }
-    }
-
-    return parent::save();
-
-  }
-
-  function validate() {
-    $current_user = &singleton("current_user");
+    function validate()
+    {
+        $current_user = &singleton("current_user");
     
-    $this->get_value("fromTfID") or $err[] = "Unable to save transaction without a Source TF.";
-    $this->get_value("fromTfID") && $this->get_value("fromTfID") == $this->get_value("tfID") and $err[] = "Unable to save transaction with Source TF (".tf::get_name($this->get_value("fromTfID")).") being the same as the Destination TF (".tf::get_name($this->get_value("tfID")).") \"".$this->get_value("product")."\"";
-    $this->get_value("quantity") or $this->set_value("quantity",1);
-    $this->get_value("transactionDate") or $this->set_value("transactionDate",date("Y-m-d"));
+        $this->get_value("fromTfID") or $err[] = "Unable to save transaction without a Source TF.";
+        $this->get_value("fromTfID") && $this->get_value("fromTfID") == $this->get_value("tfID") and $err[] = "Unable to save transaction with Source TF (".tf::get_name($this->get_value("fromTfID")).") being the same as the Destination TF (".tf::get_name($this->get_value("tfID")).") \"".$this->get_value("product")."\"";
+        $this->get_value("quantity") or $this->set_value("quantity", 1);
+        $this->get_value("transactionDate") or $this->set_value("transactionDate", date("Y-m-d"));
 
-    $old = $this->all_row_fields;
-    $status = $old["status"] or $status = $this->get_value("status");
-    if ($status != "pending" && !$current_user->have_role("admin")) {
-      $err[] = "Unable to save transaction unless status is pending.";
-    }
-    if ($old["status"] == "pending" && $old["status"] != $this->get_value("status") && !$current_user->have_role("admin")) {
-      $err[] = "Unable to change transaction status unless you have admin perm.";
-    }
-    return parent::validate($err);
-  }
-
-  function is_owner($person = "") {
-    $current_user = &singleton("current_user");
-    if ($person == "") {
-      $person = $current_user;
+        $old = $this->all_row_fields;
+        $status = $old["status"] or $status = $this->get_value("status");
+        if ($status != "pending" && !$current_user->have_role("admin")) {
+            $err[] = "Unable to save transaction unless status is pending.";
+        }
+        if ($old["status"] == "pending" && $old["status"] != $this->get_value("status") && !$current_user->have_role("admin")) {
+            $err[] = "Unable to change transaction status unless you have admin perm.";
+        }
+        return parent::validate($err);
     }
 
+    function is_owner($person = "")
+    {
+        $current_user = &singleton("current_user");
+        if ($person == "") {
+            $person = $current_user;
+        }
 
-    if ($this->get_value("expenseFormID")) {
-      $expenseForm = $this->get_foreign_object("expenseForm");
-      return $expenseForm->is_owner($person);
+
+        if ($this->get_value("expenseFormID")) {
+            $expenseForm = $this->get_foreign_object("expenseForm");
+            return $expenseForm->is_owner($person);
+        }
+        if ($this->get_value("timeSheetID")) {
+            $timeSheet = $this->get_foreign_object("timeSheet");
+            return $timeSheet->is_owner($person);
+        }
+        if ($this->get_value("productSaleItemID")) {
+            $productSaleItem = $this->get_foreign_object("productSaleItem");
+            return $productSaleItem->is_owner();
+        }
+
+        $toTf = new tf();
+        $toTf->set_id($this->get_value('tfID'));
+        $toTf->select();
+
+        $fromTf = new tf();
+        $fromTf->set_id($this->get_value('fromTfID'));
+        $fromTf->select();
+
+        return ($toTf->is_owner($person) || $fromTf->is_owner($person));
     }
-    if ($this->get_value("timeSheetID")) {
-      $timeSheet = $this->get_foreign_object("timeSheet");
-      return $timeSheet->is_owner($person);
-    }
-    if ($this->get_value("productSaleItemID")) {
-      $productSaleItem = $this->get_foreign_object("productSaleItem");
-      return $productSaleItem->is_owner();
-    }
 
-    $toTf = new tf();
-    $toTf->set_id($this->get_value('tfID'));
-    $toTf->select();
-
-    $fromTf = new tf();
-    $fromTf->set_id($this->get_value('fromTfID'));
-    $fromTf->select();
-
-    return ($toTf->is_owner($person) || $fromTf->is_owner($person));
-  }
-
-  function get_transactionTypes() {
-    $taxName = config::get_config_item("taxName") or $taxName = "Tax";
-    return array('invoice'=>'Invoice'
+    function get_transactionTypes()
+    {
+        $taxName = config::get_config_item("taxName") or $taxName = "Tax";
+        return array('invoice'=>'Invoice'
                 ,'expense'=>'Expense'
                 ,'salary'=>'Salary'
                 ,'commission'=>'Commission'
@@ -162,195 +165,201 @@ class transaction extends db_entity {
                 ,'adjustment'=>'Adjustment'
                 ,'sale'=>'Sale'
                 ,'tax'=>$taxName);
-  }
-
-  function get_transactionStatii() {
-    return array("pending"=>"Pending", "approved"=>"Approved", "rejected"=>"Rejected");
-  }
-
-  function get_url() {
-    global $sess;
-    $sess or $sess = new session();
-
-    $url = "finance/transaction.php?transactionID=".$this->get_id();
-
-    if ($sess->Started()) {
-      $url = $sess->url(SCRIPT_PATH.$url);
-
-    // This for urls that are emailed
-    } else {
-      static $prefix;
-      $prefix or $prefix = config::get_config_item("allocURL");
-      $url = $prefix.$url;
     }
-    return $url;
-  }
 
-  function get_transaction_link($_FORM=array()) {
-    $_FORM["return"] or $_FORM["return"] = "html";
-    $rtn = "<a href=\"".$this->get_url()."\">";
-    $rtn.= $this->get_name($_FORM);
-    $rtn.= "</a>";
-    return $rtn;
-  }
-
-  function get_name($_FORM=array()) {
-    if ($_FORM["return"] == "html") {
-      return $this->get_value("product",DST_HTML_DISPLAY);
-    } else {
-      return $this->get_value("product");
+    function get_transactionStatii()
+    {
+        return array("pending"=>"Pending", "approved"=>"Approved", "rejected"=>"Rejected");
     }
-  }
 
-  function get_transaction_type_link() {
-    global $TPL;
-    $type = $this->get_value("transactionType");
-    $transactionTypes = transaction::get_transactionTypes();
-    
-    // Transaction stems from an invoice
-    if ($type == "invoice") {
-        $invoice = $this->get_foreign_object("invoice");
-        if (!$invoice->get_id()) {
-          $invoiceItem = $this->get_foreign_object("invoiceItem");
-          $invoice = $invoiceItem->get_foreign_object("invoice");
+    function get_url()
+    {
+        global $sess;
+        $sess or $sess = new session();
+
+        $url = "finance/transaction.php?transactionID=".$this->get_id();
+
+        if ($sess->Started()) {
+            $url = $sess->url(SCRIPT_PATH.$url);
+
+        // This for urls that are emailed
+        } else {
+            static $prefix;
+            $prefix or $prefix = config::get_config_item("allocURL");
+            $url = $prefix.$url;
         }
-        $invoice->get_id() and $str = "<a href=\"".$invoice->get_url()."\">".$transactionTypes[$type]." ".$invoice->get_value("invoiceNum")."</a>";
+        return $url;
+    }
 
-    // Transaction is from an expenseform
-    } else if ($type == "expense") {
-      $expenseForm = $this->get_foreign_object("expenseForm");
-      if ($expenseForm->get_id() && $expenseForm->have_perm(PERM_READ_WRITE)) {
-        $str = "<a href=\"".$expenseForm->get_url()."\">".$transactionTypes[$type]." ".$this->get_value("expenseFormID")."</a>";
-      } 
+    function get_transaction_link($_FORM = array())
+    {
+        $_FORM["return"] or $_FORM["return"] = "html";
+        $rtn = "<a href=\"".$this->get_url()."\">";
+        $rtn.= $this->get_name($_FORM);
+        $rtn.= "</a>";
+        return $rtn;
+    }
+
+    function get_name($_FORM = array())
+    {
+        if ($_FORM["return"] == "html") {
+            return $this->get_value("product", DST_HTML_DISPLAY);
+        } else {
+            return $this->get_value("product");
+        }
+    }
+
+    function get_transaction_type_link()
+    {
+        global $TPL;
+        $type = $this->get_value("transactionType");
+        $transactionTypes = transaction::get_transactionTypes();
+    
+      // Transaction stems from an invoice
+        if ($type == "invoice") {
+            $invoice = $this->get_foreign_object("invoice");
+            if (!$invoice->get_id()) {
+                $invoiceItem = $this->get_foreign_object("invoiceItem");
+                $invoice = $invoiceItem->get_foreign_object("invoice");
+            }
+            $invoice->get_id() and $str = "<a href=\"".$invoice->get_url()."\">".$transactionTypes[$type]." ".$invoice->get_value("invoiceNum")."</a>";
+
+        // Transaction is from an expenseform
+        } else if ($type == "expense") {
+            $expenseForm = $this->get_foreign_object("expenseForm");
+            if ($expenseForm->get_id() && $expenseForm->have_perm(PERM_READ_WRITE)) {
+                $str = "<a href=\"".$expenseForm->get_url()."\">".$transactionTypes[$type]." ".$this->get_value("expenseFormID")."</a>";
+            }
       
-    // Had to rewrite this so that people who had transactions on other peoples timesheets 
-    // could see their own transactions, but not the other persons timesheet.
-    } else if ($type == "timesheet" && $this->get_value("timeSheetID")) {
-      $timeSheet = new timeSheet();
-      $timeSheet->set_id($this->get_value("timeSheetID"));
-      $str = "<a href=\"".$timeSheet->get_url()."\">".$transactionTypes[$type]." ".$this->get_value("timeSheetID")."</a>";
+        // Had to rewrite this so that people who had transactions on other peoples timesheets
+        // could see their own transactions, but not the other persons timesheet.
+        } else if ($type == "timesheet" && $this->get_value("timeSheetID")) {
+            $timeSheet = new timeSheet();
+            $timeSheet->set_id($this->get_value("timeSheetID"));
+            $str = "<a href=\"".$timeSheet->get_url()."\">".$transactionTypes[$type]." ".$this->get_value("timeSheetID")."</a>";
+        } else if (($type == "commission" || $type == "tax") && $this->get_value("timeSheetID")) {
+            $timeSheet = new timeSheet();
+            $timeSheet->set_id($this->get_value("timeSheetID"));
+            $str = "<a href=\"".$timeSheet->get_url()."\">".$transactionTypes[$type]." (Time Sheet ".$this->get_value("timeSheetID").")</a>";
+        } else {
+            $str = $transactionTypes[$type];
+        }
 
-    } else if (($type == "commission" || $type == "tax") && $this->get_value("timeSheetID")) {
-      $timeSheet = new timeSheet();
-      $timeSheet->set_id($this->get_value("timeSheetID"));
-      $str = "<a href=\"".$timeSheet->get_url()."\">".$transactionTypes[$type]." (Time Sheet ".$this->get_value("timeSheetID").")</a>";
+        if ($this->get_value("transactionGroupID")) {
+            $str.= " <a href=\"".$TPL["url_alloc_transactionGroup"]."transactionGroupID=".$this->get_value("transactionGroupID")."\">Group ".$this->get_value("transactionGroupID")."</a>";
+        }
 
-    } else {
-      $str = $transactionTypes[$type];
+        return $str;
     }
 
-    if ($this->get_value("transactionGroupID")) {
-      $str.= " <a href=\"".$TPL["url_alloc_transactionGroup"]."transactionGroupID=".$this->get_value("transactionGroupID")."\">Group ".$this->get_value("transactionGroupID")."</a>";
+    function reduce_tfs($_FORM)
+    {
+        if ($_FORM["tfName"]) {
+            $q = prepare("SELECT * FROM tf WHERE tfName = '%s'", $_FORM["tfName"]);
+            $db = new db_alloc();
+            $db->query($q);
+            $db->next_record();
+            $tfIDs[] = $db->f("tfID");
+        }
+        if ($_FORM["tfID"]) {
+            $tfIDs[] = $_FORM["tfID"];
+        }
+        if ($_FORM["tfIDs"]) {
+            $tfIDs = array_merge((array)$tfIDs, (array)$_FORM["tfIDs"]);
+        }
+        return tf::get_permitted_tfs($tfIDs);
     }
 
-    return $str;
-  }
+    function get_list_filter($_FORM)
+    {
+        $current_user = &singleton("current_user");
 
-  function reduce_tfs($_FORM) {
-    if ($_FORM["tfName"]) {
-      $q = prepare("SELECT * FROM tf WHERE tfName = '%s'",$_FORM["tfName"]);
-      $db = new db_alloc();
-      $db->query($q);
-      $db->next_record();
-      $tfIDs[] = $db->f("tfID");
-    }
-    if ($_FORM["tfID"]) {
-      $tfIDs[] = $_FORM["tfID"];
-    }
-    if ($_FORM["tfIDs"]) {
-      $tfIDs = array_merge((array)$tfIDs,(array)$_FORM["tfIDs"]);
-    }
-    return tf::get_permitted_tfs($tfIDs);
-  }
+        if (is_array($_FORM["tfIDs"]) && count($_FORM["tfIDs"])) {
+            $sql["tfIDs"] = sprintf_implode("transaction.tfID = %d or transaction.fromTfID = %d", $_FORM["tfIDs"], $_FORM["tfIDs"]);
+        }
 
-  function get_list_filter($_FORM) {
-    $current_user = &singleton("current_user");
+        if ($_FORM["monthDate"]) {
+            $_FORM["startDate"] = format_date("Y-m-", $_FORM["monthDate"])."01";
+            $t = format_date("U", $_FORM["monthDate"]);
+            $_FORM["endDate"] = date("Y-m-d", mktime(1, 1, 1, date("m", $t)+1, 1, date("Y", $t)));
+        }
 
-    if (is_array($_FORM["tfIDs"]) && count($_FORM["tfIDs"])) {
-      $sql["tfIDs"] = sprintf_implode("transaction.tfID = %d or transaction.fromTfID = %d",$_FORM["tfIDs"],$_FORM["tfIDs"]);
-    }
+        $_FORM["sortTransactions"] or $_FORM["sortTransactions"] = "transactionDate";
 
-    if ($_FORM["monthDate"]) {
-      $_FORM["startDate"] = format_date("Y-m-",$_FORM["monthDate"])."01";
-      $t = format_date("U",$_FORM["monthDate"]);
-      $_FORM["endDate"] = date("Y-m-d",mktime(1,1,1,date("m",$t)+1,1,date("Y",$t)));
-    }
+        if ($_FORM["sortTransactions"] == "transactionSortDate") {
+            $_FORM["sortTransactions"] = "if(transactionModifiedTime,transactionModifiedTime,transactionCreatedTime)";
+        }
 
-    $_FORM["sortTransactions"] or $_FORM["sortTransactions"] = "transactionDate";
+        $_FORM["startDate"]       and $sql["startDate"]       = prepare("(%s >= '%s')", $_FORM["sortTransactions"], $_FORM["startDate"]);
+        $_FORM["startDate"]       and $sql["prevBalance"]     = prepare("(%s < '%s')", $_FORM["sortTransactions"], $_FORM["startDate"]);
+        $_FORM["endDate"]         and $sql["endDate"]         = prepare("(%s < '%s')", $_FORM["sortTransactions"], $_FORM["endDate"]);
+        $_FORM["status"]          and $sql["status"]          = prepare("(status = '%s')", $_FORM["status"]);
+        $_FORM["transactionType"] and $sql["transactionType"] = prepare("(transactionType = '%s')", $_FORM["transactionType"]);
 
-    if ($_FORM["sortTransactions"] == "transactionSortDate") {
-      $_FORM["sortTransactions"] = "if(transactionModifiedTime,transactionModifiedTime,transactionCreatedTime)";
+        $_FORM["fromTfID"]        and $sql["fromTfID"]        = prepare("(fromTfID=%d)", $_FORM["fromTfID"]);
+        $_FORM["expenseFormID"]   and $sql["expenseFormID"]   = prepare("(expenseFormID=%d)", $_FORM["expenseFormID"]);
+        $_FORM["transactionID"]   and $sql["transactionID"]   = prepare("(transactionID=%d)", $_FORM["transactionID"]);
+        $_FORM["product"]         and $sql["product"]         = prepare("(product LIKE \"%%%s%%\")", $_FORM["product"]);
+        $_FORM["amount"]          and $sql["amount"]          = prepare("(amount = '%s')", $_FORM["amount"]);
+
+        return $sql;
     }
 
-    $_FORM["startDate"]       and $sql["startDate"]       = prepare("(%s >= '%s')",$_FORM["sortTransactions"],$_FORM["startDate"]);
-    $_FORM["startDate"]       and $sql["prevBalance"]     = prepare("(%s < '%s')",$_FORM["sortTransactions"],$_FORM["startDate"]);
-    $_FORM["endDate"]         and $sql["endDate"]         = prepare("(%s < '%s')",$_FORM["sortTransactions"],$_FORM["endDate"]);
-    $_FORM["status"]          and $sql["status"]          = prepare("(status = '%s')",$_FORM["status"]);
-    $_FORM["transactionType"] and $sql["transactionType"] = prepare("(transactionType = '%s')",$_FORM["transactionType"]);
+    public static function get_list($_FORM)
+    {
+        $current_user = &singleton("current_user");
+        global $TPL;
 
-    $_FORM["fromTfID"]        and $sql["fromTfID"]        = prepare("(fromTfID=%d)",$_FORM["fromTfID"]);
-    $_FORM["expenseFormID"]   and $sql["expenseFormID"]   = prepare("(expenseFormID=%d)",$_FORM["expenseFormID"]);
-    $_FORM["transactionID"]   and $sql["transactionID"]   = prepare("(transactionID=%d)",$_FORM["transactionID"]);
-    $_FORM["product"]         and $sql["product"]         = prepare("(product LIKE \"%%%s%%\")",$_FORM["product"]);
-    $_FORM["amount"]          and $sql["amount"]          = prepare("(amount = '%s')",$_FORM["amount"]);
+      /*
+       * This is the definitive method of getting a list of transactions that need a sophisticated level of filtering
+       *
+       */
 
-    return $sql;
-  }
+        $_FORM["tfIDs"] = transaction::reduce_tfs($_FORM);
 
-  public static function get_list($_FORM) {
-    $current_user = &singleton("current_user");
-    global $TPL;
+      // Non-admin users must specify a valid TF
+        if (!$current_user->have_role("admin") && !$_FORM["tfIDs"]) {
+            return;
+        }
 
-    /*
-     * This is the definitive method of getting a list of transactions that need a sophisticated level of filtering
-     *
-     */
+        $filter = transaction::get_list_filter($_FORM);
+        $debug = $_FORM["debug"];
+        $debug and print "\n<pre>_FORM: ".print_r($_FORM, 1)."</pre>";
+        $debug and print "\n<pre>filter: ".print_r($filter, 1)."</pre>";
 
-    $_FORM["tfIDs"] = transaction::reduce_tfs($_FORM);
+        $_FORM["return"] or $_FORM["return"] = "html";
 
-    // Non-admin users must specify a valid TF
-    if (!$current_user->have_role("admin") && !$_FORM["tfIDs"]) {
-      return;
-    }
+        $filter["prevBalance"] and $filter2[] = $filter["prevBalance"];
+        $filter["tfIDs"]       and $filter2[] = $filter["tfIDs"];
+        $filter2               and $filter2[] = " (status = 'approved') ";
+        unset($filter["prevBalance"]);
 
-    $filter = transaction::get_list_filter($_FORM);
-    $debug = $_FORM["debug"];
-    $debug and print "\n<pre>_FORM: ".print_r($_FORM,1)."</pre>";
-    $debug and print "\n<pre>filter: ".print_r($filter,1)."</pre>";
+        if (is_array($filter2) && count($filter2)) {
+            $filter2 = " WHERE ".implode(" AND ", $filter2);
+        }
+        if (is_array($filter) && count($filter)) {
+            $filter = " WHERE ".implode(" AND ", $filter);
+        }
 
-    $_FORM["return"] or $_FORM["return"] = "html";
-
-    $filter["prevBalance"] and $filter2[] = $filter["prevBalance"];
-    $filter["tfIDs"]       and $filter2[] = $filter["tfIDs"];
-    $filter2               and $filter2[] = " (status = 'approved') ";
-    unset($filter["prevBalance"]);
-
-    if (is_array($filter2) && count($filter2)) {
-      $filter2 = " WHERE ".implode(" AND ",$filter2);
-    }
-    if (is_array($filter) && count($filter)) {
-      $filter = " WHERE ".implode(" AND ",$filter);
-    }
-
-    $_FORM["sortTransactions"] or $_FORM["sortTransactions"] = "transactionDate";
-    $order_by = "ORDER BY ".$_FORM["sortTransactions"];
+        $_FORM["sortTransactions"] or $_FORM["sortTransactions"] = "transactionDate";
+        $order_by = "ORDER BY ".$_FORM["sortTransactions"];
 
   
-    // Determine opening balance
-    if (is_array($_FORM['tfIDs']) && count($_FORM['tfIDs'])) {
-      $q = prepare("SELECT SUM( IF(fromTfID IN (%s),-amount,amount) * pow(10,-currencyType.numberToBasic) * exchangeRate) AS balance
+      // Determine opening balance
+        if (is_array($_FORM['tfIDs']) && count($_FORM['tfIDs'])) {
+            $q = prepare("SELECT SUM( IF(fromTfID IN (%s),-amount,amount) * pow(10,-currencyType.numberToBasic) * exchangeRate) AS balance
                       FROM transaction 
                  LEFT JOIN currencyType ON currencyType.currencyTypeID = transaction.currencyTypeID
                     ".$filter2, $_FORM['tfIDs']);
-      $debug and print "\n<br>QUERY: ".$q;
-      $db = new db_alloc();
-      $db->query($q);
-      $db->row();
-      $_FORM["opening_balance"] = $db->f("balance");
-      $running_balance = $db->f("balance");
-    }
+            $debug and print "\n<br>QUERY: ".$q;
+            $db = new db_alloc();
+            $db->query($q);
+            $db->row();
+            $_FORM["opening_balance"] = $db->f("balance");
+            $running_balance = $db->f("balance");
+        }
 
-    $q = "SELECT *, 
+        $q = "SELECT *, 
                  (amount * pow(10,-currencyType.numberToBasic)) as amount1,
                  (amount * pow(10,-currencyType.numberToBasic) * exchangeRate) as amount2,
                  if(transactionModifiedTime,transactionModifiedTime,transactionCreatedTime) AS transactionSortDate,
@@ -363,71 +372,73 @@ class transaction extends db_entity {
          ".$filter." 
          ".$order_by;
 
-    $debug and print "\n<br>QUERY2: ".$q;
-    $db = new db_alloc();
-    $db->query($q);
-    $for_cyber = config::for_cyber();
-    while ($row = $db->next_record()) {
-      #echo "<pre>".print_r($row,1)."</pre>";
-      $i++;
-      $t = new transaction();
-      if (!$t->read_db_record($db))
-        continue;
+        $debug and print "\n<br>QUERY2: ".$q;
+        $db = new db_alloc();
+        $db->query($q);
+        $for_cyber = config::for_cyber();
+        while ($row = $db->next_record()) {
+          #echo "<pre>".print_r($row,1)."</pre>";
+            $i++;
+            $t = new transaction();
+            if (!$t->read_db_record($db)) {
+                continue;
+            }
 
-      $print = true;
+            $print = true;
   
-      // If the destination of this TF is not the current TfID, then invert the $amount
-      $amount = $row["amount2"];
-      if (!in_array($row["tfID"],(array)$_FORM["tfIDs"])) {
-        $amount = -$amount;
-        $row["amount1"] = -$row["amount1"];
-      }
+          // If the destination of this TF is not the current TfID, then invert the $amount
+            $amount = $row["amount2"];
+            if (!in_array($row["tfID"], (array)$_FORM["tfIDs"])) {
+                $amount = -$amount;
+                $row["amount1"] = -$row["amount1"];
+            }
 
-      $row["amount"] = $amount;
-      $row["transactionURL"] = $t->get_url();
-      $row["transactionName"] = $t->get_name($_FORM);
-      $row["transactionLink"] = $t->get_transaction_link($_FORM);
-      $row["transactionTypeLink"] = $t->get_transaction_type_link() or $row["transactionTypeLink"] = $row["transactionType"];
-      $row["transactionSortDate"] = format_date("Y-m-d",$row["transactionSortDate"]); 
+            $row["amount"] = $amount;
+            $row["transactionURL"] = $t->get_url();
+            $row["transactionName"] = $t->get_name($_FORM);
+            $row["transactionLink"] = $t->get_transaction_link($_FORM);
+            $row["transactionTypeLink"] = $t->get_transaction_type_link() or $row["transactionTypeLink"] = $row["transactionType"];
+            $row["transactionSortDate"] = format_date("Y-m-d", $row["transactionSortDate"]);
 
-      $row["fromTfIDLink"] = "<a href=\"".$TPL["url_alloc_transactionList"]."tfID=".$row["fromTfID"]."\">".page::htmlentities($row["fromTfName"])."</a>";
-      $row["tfIDLink"] = "<a href=\"".$TPL["url_alloc_transactionList"]."tfID=".$row["tfID"]."\">".page::htmlentities($row["tfName"])."</a>";
+            $row["fromTfIDLink"] = "<a href=\"".$TPL["url_alloc_transactionList"]."tfID=".$row["fromTfID"]."\">".page::htmlentities($row["fromTfName"])."</a>";
+            $row["tfIDLink"] = "<a href=\"".$TPL["url_alloc_transactionList"]."tfID=".$row["tfID"]."\">".page::htmlentities($row["tfName"])."</a>";
 
-      if ($t->get_value("status") == "approved") {
-        $running_balance += $amount;
-        $row["running_balance"] = page::money(config::get_config_item("currency"),$running_balance,"%m %c");
-      }
+            if ($t->get_value("status") == "approved") {
+                $running_balance += $amount;
+                $row["running_balance"] = page::money(config::get_config_item("currency"), $running_balance, "%m %c");
+            }
  
-      if ($amount > 0) {
-        $row["amount_positive"] = page::money($row["currencyTypeID"],$row["amount1"],"%m %c");
-        $total_amount_positive += $amount;
-      } else {
-        $row["amount_negative"] = page::money($row["currencyTypeID"],$row["amount1"],"%m %c");
-        $total_amount_negative += $amount;
-      }
+            if ($amount > 0) {
+                $row["amount_positive"] = page::money($row["currencyTypeID"], $row["amount1"], "%m %c");
+                $total_amount_positive += $amount;
+            } else {
+                $row["amount_negative"] = page::money($row["currencyTypeID"], $row["amount1"], "%m %c");
+                $total_amount_negative += $amount;
+            }
 
-      // Cyber only hackery for ext ref field on product sales
-      if ($for_cyber && $row["productSaleID"]) {
-        $ps = new productSale();
-        $ps->set_id($row["productSaleID"]);
-        if ($ps->select()) {
-          $ps->get_value("extRef") and $row["product"].= " (Ext ref: ".$ps->get_value("extRef").")";
+          // Cyber only hackery for ext ref field on product sales
+            if ($for_cyber && $row["productSaleID"]) {
+                $ps = new productSale();
+                $ps->set_id($row["productSaleID"]);
+                if ($ps->select()) {
+                    $ps->get_value("extRef") and $row["product"].= " (Ext ref: ".$ps->get_value("extRef").")";
+                }
+            }
+
+            $transactions[$row["transactionID"]] = $row;
         }
-      }
 
-      $transactions[$row["transactionID"]] = $row;
+        $_FORM["total_amount_positive"] = page::money(config::get_config_item("currency"), $total_amount_positive, "%s%m %c");
+        $_FORM["total_amount_negative"] = page::money(config::get_config_item("currency"), $total_amount_negative, "%s%m %c");
+        $_FORM["running_balance"] =       page::money(config::get_config_item("currency"), $running_balance, "%s%m %c");
+
+        return array("totals"=>$_FORM, "rows"=>(array)$transactions);
     }
 
-    $_FORM["total_amount_positive"] = page::money(config::get_config_item("currency"),$total_amount_positive,"%s%m %c");
-    $_FORM["total_amount_negative"] = page::money(config::get_config_item("currency"),$total_amount_negative,"%s%m %c");
-    $_FORM["running_balance"] =       page::money(config::get_config_item("currency"),$running_balance,"%s%m %c");
-
-    return array("totals"=>$_FORM, "rows"=>(array)$transactions);
-  }
-
-  function arr_to_csv($rows=array()) {
+    function arr_to_csv($rows = array())
+    {
        
-    $csvHeaders = array("transactionID"
+        $csvHeaders = array("transactionID"
                        ,"transactionType"
                        ,"fromTfID"
                        ,"tfID"
@@ -442,20 +453,21 @@ class transaction extends db_entity {
                        ,"amount_negative"
                        ,"running_balance");
     
-    foreach ((array)$rows as $row) {
-      $csv_data = array();
-      foreach($csvHeaders as $header) {  
-        $csv_data[] = $row[$header];
-      }
-      $csv.= $nl.implode(",",array_map('export_escape_csv', $csv_data));
-      $nl = "\n";
+        foreach ((array)$rows as $row) {
+            $csv_data = array();
+            foreach ($csvHeaders as $header) {
+                $csv_data[] = $row[$header];
+            }
+            $csv.= $nl.implode(",", array_map('export_escape_csv', $csv_data));
+            $nl = "\n";
+        }
+        return implode(",", array_map('export_escape_csv', $csvHeaders))."\n".$csv;
     }
-    return implode(",",array_map('export_escape_csv', $csvHeaders))."\n".$csv;
-  }
 
-  function get_list_vars() {
+    function get_list_vars()
+    {
   
-    return array("return"            => "[MANDATORY] eg: html | csv | array"
+        return array("return"            => "[MANDATORY] eg: html | csv | array"
                 ,"tfID"              => "Transactions that are for this TF"
                 ,"tfIDs"             => "Transactions that are for this array of TF's"
                 ,"tfName"            => "Transactions that are for this TF name"
@@ -475,168 +487,165 @@ class transaction extends db_entity {
                 ,"product"           => "Transactions with a description like *something* (fuzzy)"
                 ,"amount"            => "Get Transactions that are for a certain amount"
                 );
-  }
+    }
 
-  function load_form_data($defaults=array()) {
-    $current_user = &singleton("current_user");
+    function load_form_data($defaults = array())
+    {
+        $current_user = &singleton("current_user");
 
-    $page_vars = array_keys(transaction::get_list_vars());
+        $page_vars = array_keys(transaction::get_list_vars());
   
-    $_FORM = get_all_form_data($page_vars,$defaults);
+        $_FORM = get_all_form_data($page_vars, $defaults);
 
-    #echo "<pre>".print_r($_FORM,1)."</pre>";
+      #echo "<pre>".print_r($_FORM,1)."</pre>";
 
-    #if (!$_FORM["applyFilter"]) {
-    #  $_FORM = $current_user->prefs[$_FORM["form_name"]];
-    #  if (!isset($current_user->prefs[$_FORM["form_name"]])) {
-    #    #$_FORM["personID"] = $current_user->get_id();
-    #    list($_FORM["startDate"], $_FORM["endDate"]) = transaction::get_statement_start_and_end_dates(date("m"),date("Y"));
-    #  }
+      #if (!$_FORM["applyFilter"]) {
+      #  $_FORM = $current_user->prefs[$_FORM["form_name"]];
+      #  if (!isset($current_user->prefs[$_FORM["form_name"]])) {
+      #    #$_FORM["personID"] = $current_user->get_id();
+      #    list($_FORM["startDate"], $_FORM["endDate"]) = transaction::get_statement_start_and_end_dates(date("m"),date("Y"));
+      #  }
 
-    #} else if ($_FORM["applyFilter"] && is_object($current_user) && !$_FORM["dontSave"]) {
-    #  $url = $_FORM["url_form_action"];
-    #  unset($_FORM["url_form_action"]);
-    #  $current_user->prefs[$_FORM["form_name"]] = $_FORM;
-    #  $_FORM["url_form_action"] = $url;
-    #}
+      #} else if ($_FORM["applyFilter"] && is_object($current_user) && !$_FORM["dontSave"]) {
+      #  $url = $_FORM["url_form_action"];
+      #  unset($_FORM["url_form_action"]);
+      #  $current_user->prefs[$_FORM["form_name"]] = $_FORM;
+      #  $_FORM["url_form_action"] = $url;
+      #}
 
-    return $_FORM;
-  }
-
-  function load_transaction_filter($_FORM) {
-    global $TPL;
-
-    $rtn["statusOptions"] = page::select_options(array(""=>"","pending"=>"Pending","approved"=>"Approved","rejected"=>"Rejected"),$_FORM["status"]);
-
-    $transactionTypeOptions = transaction::get_transactionTypes();
-    $rtn["transactionTypeOptions"] = page::select_options($transactionTypeOptions,$_FORM["transactionType"]);
-
-    $rtn["startDate"] = $_FORM["startDate"];
-    $rtn["endDate"] = $_FORM["endDate"];
-
-    if ($_FORM["monthDate"]) {
-      $rtn["startDate"] = format_date("Y-m-",$_FORM["monthDate"])."01";
-      $t = format_date("U",$_FORM["monthDate"]);
-      $rtn["endDate"] = date("Y-m-d",mktime(1,1,1,date("m",$t)+1,1,date("Y",$t)));
+        return $_FORM;
     }
 
-    $display_format = "M";
+    function load_transaction_filter($_FORM)
+    {
+        global $TPL;
 
-    // Fiddle $_FORM["monthDate"]. It may be a real date (2010-11-23) so change the last 2 chars to "01".
-    $_FORM["monthDate"] = substr_replace($_FORM["monthDate"], "01", 8);
+        $rtn["statusOptions"] = page::select_options(array(""=>"","pending"=>"Pending","approved"=>"Approved","rejected"=>"Rejected"), $_FORM["status"]);
 
-    // If this month is January, go from last Feb to this Feb
-    $m = date("m") + 1;
-    $y = date("Y");
+        $transactionTypeOptions = transaction::get_transactionTypes();
+        $rtn["transactionTypeOptions"] = page::select_options($transactionTypeOptions, $_FORM["transactionType"]);
 
-    // jump back a year iff it's December now
-    if ($m == 13)
-    	$m = 1;
-    else
-        $y -= 1;
+        $rtn["startDate"] = $_FORM["startDate"];
+        $rtn["endDate"] = $_FORM["endDate"];
 
-    $label_monthDate = date($display_format);
+        if ($_FORM["monthDate"]) {
+            $rtn["startDate"] = format_date("Y-m-", $_FORM["monthDate"])."01";
+            $t = format_date("U", $_FORM["monthDate"]);
+            $rtn["endDate"] = date("Y-m-d", mktime(1, 1, 1, date("m", $t)+1, 1, date("Y", $t)));
+        }
 
-    for ($j = 0;$j < 13;$j++) {
+        $display_format = "M";
 
-      $label = date($display_format,mktime(0,0,0,$m,1,$y));
-      $monthDate = date("Y-m-d",mktime(0,0,0,$m,1,$y));
+      // Fiddle $_FORM["monthDate"]. It may be a real date (2010-11-23) so change the last 2 chars to "01".
+        $_FORM["monthDate"] = substr_replace($_FORM["monthDate"], "01", 8);
 
-      $bold = false;
-      if ($monthDate == format_date("Y-m-d",$_FORM["monthDate"])) {
-        $bold = true;
-      } 
+      // If this month is January, go from last Feb to this Feb
+        $m = date("m") + 1;
+        $y = date("Y");
 
-      $link = $TPL["url_alloc_transactionList"]."tfID=".$_FORM["tfID"]."&monthDate=".$monthDate."&applyFilter=true";
-      $bold and $rtn["month_links"] .= "<b>";
-      $rtn["month_links"] .= $sp."<a href=\"".$link."\">".$label."</a>";
-      $bold and $rtn["month_links"] .= "</b>";
-      $sp = "&nbsp;&nbsp;";
+      // jump back a year iff it's December now
+        if ($m == 13) {
+            $m = 1;
+        } else {
+            $y -= 1;
+        }
 
-      if ($m == 12) {
-          $m = 1;
-          $y += 1;
-      } else {
-          $m += 1;
-      }
+        $label_monthDate = date($display_format);
+
+        for ($j = 0; $j < 13; $j++) {
+            $label = date($display_format, mktime(0, 0, 0, $m, 1, $y));
+            $monthDate = date("Y-m-d", mktime(0, 0, 0, $m, 1, $y));
+
+            $bold = false;
+            if ($monthDate == format_date("Y-m-d", $_FORM["monthDate"])) {
+                $bold = true;
+            }
+
+            $link = $TPL["url_alloc_transactionList"]."tfID=".$_FORM["tfID"]."&monthDate=".$monthDate."&applyFilter=true";
+            $bold and $rtn["month_links"] .= "<b>";
+            $rtn["month_links"] .= $sp."<a href=\"".$link."\">".$label."</a>";
+            $bold and $rtn["month_links"] .= "</b>";
+            $sp = "&nbsp;&nbsp;";
+
+            if ($m == 12) {
+                $m = 1;
+                $y += 1;
+            } else {
+                $m += 1;
+            }
+        }
+
+        if ($_FORM["sortTransactions"] == "transactionSortDate") {
+            $rtn["checked_transactionSortDate"] = " checked";
+        } else {
+            $rtn["checked_transactionDate"] = " checked";
+        }
+
+        $tf = new tf();
+        $options = $tf->get_assoc_array("tfID", "tfName");
+        $rtn["tfOptions"] = page::select_options($options, $_FORM["tfID"]);
+        $rtn["fromTfOptions"] = page::select_options($options, $_FORM["fromTfID"]);
+        $rtn["transactionID"] = $_FORM["transactionID"];
+        $rtn["expenseFormID"] = $_FORM["expenseFormID"];
+        $rtn["product"] = $_FORM["product"];
+        $rtn["amount"] = $_FORM["amount"];
+
+        return $rtn;
     }
 
-    if ($_FORM["sortTransactions"] == "transactionSortDate") {
-      $rtn["checked_transactionSortDate"] = " checked";
-    } else {
-      $rtn["checked_transactionDate"] = " checked";
-    }
+    function get_actual_amount_used($rows = array())
+    {
 
-    $tf = new tf();
-    $options = $tf->get_assoc_array("tfID","tfName");
-    $rtn["tfOptions"] = page::select_options($options, $_FORM["tfID"]);
-    $rtn["fromTfOptions"] = page::select_options($options, $_FORM["fromTfID"]);
-    $rtn["transactionID"] = $_FORM["transactionID"];
-    $rtn["expenseFormID"] = $_FORM["expenseFormID"];
-    $rtn["product"] = $_FORM["product"];
-    $rtn["amount"] = $_FORM["amount"];
+      /*
+       *  The purpose of this function is to turn the below three transactions
+       *  not into their sum of $48 but into the amount used, which is $10.
+       *
+       *  Amount   Source     Dest
+       *  $20       A    ->    B   -->  A -20   B 20
+       *  $18       B    ->    C   -->  B 2     C 18
+       *  $10       C    ->    A   -->  C 8     A -10
+       *
+       *  So, actually:
+       *
+       *  A gets $-10
+       *  B gets $2
+       *  C gets $8
+       *
+       *  So i.e. -10 +10 the amount actually *used* is ten dollars.
+       *
+       *  This function is useful for ensuring that if say a time sheet has
+       *  100 dollars to be allocated, that no more than that limit is spent.
+       *
+       */
 
-    return $rtn;
-  }
+        $rows or $rows = array();
+        $tallies or $tallies = array();
+        foreach ($rows as $k => $row) {
+            $tallies[$row["fromTfID"]] -= $row["amount"];
+            $tallies[$row["tfID"]] += $row["amount"];
+        }
 
-  function get_actual_amount_used($rows=array()) {
+        foreach ($tallies as $tfID => $amount) {
+            $amount >0 and $sum+=$amount;
+        }
 
-    /*
-     *  The purpose of this function is to turn the below three transactions
-     *  not into their sum of $48 but into the amount used, which is $10.
-     *
-     *  Amount   Source     Dest
-     *  $20       A    ->    B   -->  A -20   B 20
-     *  $18       B    ->    C   -->  B 2     C 18
-     *  $10       C    ->    A   -->  C 8     A -10
-     *
-     *  So, actually:
-     *
-     *  A gets $-10
-     *  B gets $2
-     *  C gets $8
-     *
-     *  So i.e. -10 +10 the amount actually *used* is ten dollars.
-     *
-     *  This function is useful for ensuring that if say a time sheet has
-     *  100 dollars to be allocated, that no more than that limit is spent.
-     *
-     */
-
-    $rows or $rows = array();
-    $tallies or $tallies = array();
-    foreach ($rows as $k => $row) {
-      $tallies[$row["fromTfID"]] -= $row["amount"];
-      $tallies[$row["tfID"]] += $row["amount"];
-    }
-
-    foreach ($tallies as $tfID => $amount) {
-      $amount >0 and $sum+=$amount;
-    }
-
-    return $sum;
+        return $sum;
     
-    # for debugging
-    #$rows[] = array("amount"=>"20","fromTfID"=>"alla","tfID"=>"twb");
-    #$rows[] = array("amount"=>"17","fromTfID"=>"twb","tfID"=>"alla");
-    #$rows[] = array("amount"=>"2","fromTfID"=>"alla","tfID"=>"pete");
-    #$rows[] = array("amount"=>"-4","fromTfID"=>"pete","tfID"=>"alla");
-    #$rows[] = array("amount"=>"200","fromTfID"=>"zebra","tfID"=>"ghost");
-    #echo "<br>SUM: ".transaction::get_actual_amount_used($rows);
-  }
+      # for debugging
+      #$rows[] = array("amount"=>"20","fromTfID"=>"alla","tfID"=>"twb");
+      #$rows[] = array("amount"=>"17","fromTfID"=>"twb","tfID"=>"alla");
+      #$rows[] = array("amount"=>"2","fromTfID"=>"alla","tfID"=>"pete");
+      #$rows[] = array("amount"=>"-4","fromTfID"=>"pete","tfID"=>"alla");
+      #$rows[] = array("amount"=>"200","fromTfID"=>"zebra","tfID"=>"ghost");
+      #echo "<br>SUM: ".transaction::get_actual_amount_used($rows);
+    }
 
-  function get_next_transactionGroupID() {
-    $q = "SELECT coalesce(max(transactionGroupID)+1,1) as newNum FROM transaction";
-    $db = new db_alloc();
-    $db->query($q);
-    $db->row();
-    return $db->f("newNum");
-  }  
-
-
+    function get_next_transactionGroupID()
+    {
+        $q = "SELECT coalesce(max(transactionGroupID)+1,1) as newNum FROM transaction";
+        $db = new db_alloc();
+        $db->query($q);
+        $db->row();
+        return $db->f("newNum");
+    }
 }
-
-
-
-
-?>

--- a/finance/lib/transactionRepeat.inc.php
+++ b/finance/lib/transactionRepeat.inc.php
@@ -3,28 +3,29 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class transactionRepeat extends db_entity {
-  public $data_table = "transactionRepeat";
-  public $display_field_name = "product";
-  public $key_field = "transactionRepeatID";
-  public $data_fields = array("companyDetails" => array("empty_to_null"=>false)
+class transactionRepeat extends db_entity
+{
+    public $data_table = "transactionRepeat";
+    public $display_field_name = "product";
+    public $key_field = "transactionRepeatID";
+    public $data_fields = array("companyDetails" => array("empty_to_null"=>false)
                              ,"payToName" => array("empty_to_null"=>false)
                              ,"payToAccount" => array("empty_to_null"=>false)
                              ,"tfID"
@@ -47,15 +48,11 @@ class transactionRepeat extends db_entity {
                              );
 
 
-  function is_owner() {
-    $tf = new tf();
-    $tf->set_id($this->get_value("tfID"));
-    $tf->select();
-    return $tf->is_owner();
-  }
-
+    function is_owner()
+    {
+        $tf = new tf();
+        $tf->set_id($this->get_value("tfID"));
+        $tf->select();
+        return $tf->is_owner();
+    }
 }
-
-
-
-?>

--- a/finance/searchTransaction.php
+++ b/finance/searchTransaction.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -30,37 +30,35 @@ $defaults = array("url_form_action"=>$TPL["url_alloc_searchTransaction"]
                  ,"applyFilter"=>$applyFilter
                  );
 
-function show_filter() {
-  global $TPL;
-  global $defaults;
-  $_FORM = transaction::load_form_data($defaults);
-  $arr = transaction::load_transaction_filter($_FORM);
-  is_array($arr) and $TPL = array_merge($TPL,$arr);
-  include_template("templates/searchTransactionFilterS.tpl");
+function show_filter()
+{
+    global $TPL;
+    global $defaults;
+    $_FORM = transaction::load_form_data($defaults);
+    $arr = transaction::load_transaction_filter($_FORM);
+    is_array($arr) and $TPL = array_merge($TPL, $arr);
+    include_template("templates/searchTransactionFilterS.tpl");
 }
 
 if ($download) {
-  $_FORM = transaction::load_form_data($defaults);
-  $rtn = transaction::get_list($_FORM);
-  $totals = $rtn["totals"];
-  $rows = $rtn["rows"];
-  $csv = transaction::arr_to_csv($rows);
-  header('Content-Type: application/octet-stream');
-  header("Content-Length: ".strlen($csv));
-  header('Content-Disposition: attachment; filename="'.date("Ymd_His").'.csv"');
-  echo $csv;
-  exit();
+    $_FORM = transaction::load_form_data($defaults);
+    $rtn = transaction::get_list($_FORM);
+    $totals = $rtn["totals"];
+    $rows = $rtn["rows"];
+    $csv = transaction::arr_to_csv($rows);
+    header('Content-Type: application/octet-stream');
+    header("Content-Length: ".strlen($csv));
+    header('Content-Disposition: attachment; filename="'.date("Ymd_His").'.csv"');
+    echo $csv;
+    exit();
 }
 
 if ($applyFilter) {
-  $_FORM = transaction::load_form_data($defaults);
-  $rtn = transaction::get_list($_FORM);
-  $TPL["totals"] = $rtn["totals"];
-  $TPL["transactionListRows"] = $rtn["rows"];
+    $_FORM = transaction::load_form_data($defaults);
+    $rtn = transaction::get_list($_FORM);
+    $TPL["totals"] = $rtn["totals"];
+    $TPL["transactionListRows"] = $rtn["rows"];
 }
 
 $TPL["main_alloc_title"] = "Search Transactions - ".APPLICATION_NAME;
 include_template("templates/searchTransactionM.tpl");
-
-
-?>

--- a/finance/tf.php
+++ b/finance/tf.php
@@ -3,62 +3,65 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function show_person_list($template) {
-  global $TPL;
-  global $tf;
-  $db = new db_alloc();
-  $TPL["person_buttons"] = '
+function show_person_list($template)
+{
+    global $TPL;
+    global $tf;
+    $db = new db_alloc();
+    $TPL["person_buttons"] = '
         <button type="submit" name="person_delete" value="1" class="delete_button">Delete<i class="icon-trash"></i></button>
         <button type="submit" name="person_save" value="1" class="save_button">Save<i class="icon-ok-sign"></i></button>';
 
-  $tfID = $tf->get_id();
+    $tfID = $tf->get_id();
 
-  if ($tfID) {
-    $query = prepare("SELECT * from tfPerson WHERE tfID=%d", $tfID);
-    $db->query($query);
-    while ($db->next_record()) {
-      $tfPerson = new tfPerson();
-      $tfPerson->read_db_record($db);
-      $tfPerson->set_values("person_");
-      $person = $tfPerson->get_foreign_object("person");
-      $TPL["person_username"] = $person->get_value("username");
-      include_template($template);
+    if ($tfID) {
+        $query = prepare("SELECT * from tfPerson WHERE tfID=%d", $tfID);
+        $db->query($query);
+        while ($db->next_record()) {
+            $tfPerson = new tfPerson();
+            $tfPerson->read_db_record($db);
+            $tfPerson->set_values("person_");
+            $person = $tfPerson->get_foreign_object("person");
+            $TPL["person_username"] = $person->get_value("username");
+            include_template($template);
+        }
     }
-  }
 }
 
-function show_new_person($template) {
-  global $TPL;
-  $TPL["person_buttons"] = '
+function show_new_person($template)
+{
+    global $TPL;
+    $TPL["person_buttons"] = '
         <button type="submit" name="person_save" value="1" class="save_button">Add<i class="icon-plus-sign"></i></button>';
 
-  $tfPerson = new tfPerson();
-  $tfPerson->set_values("person_");
-  include_template($template);
+    $tfPerson = new tfPerson();
+    $tfPerson->set_values("person_");
+    include_template($template);
 }
 
-function show_person_options() {
-  global $TPL;
-  echo page::select_options(person::get_username_list($TPL["person_personID"]), $TPL["person_personID"]);
+function show_person_options()
+{
+    global $TPL;
+    echo page::select_options(person::get_username_list($TPL["person_personID"]), $TPL["person_personID"]);
 }
 
 $db = new db_alloc();
@@ -66,66 +69,61 @@ $tf = new tf();
 
 $tfID = $_GET["tfID"] or $tfID = $_POST["tfID"];
 if ($tfID) {
-  $tf->set_id($tfID);
-  $tf->select();
+    $tf->set_id($tfID);
+    $tf->select();
 } else {
-  $tf_is_new = true;
+    $tf_is_new = true;
 }
 
 if ($_POST["save"]) {
-  $tf->read_globals();
+    $tf->read_globals();
 
-  if ($_POST["isActive"]) {
-    $tf->set_value("tfActive", 1);
-  } else {
-    $tf->set_value("tfActive", 0);
-  }
-
-  if ($tf->get_value("tfName") == "") {
-    alloc_error("You must enter a name.");
-  } else {
-
-    if (!$tf->get_id()) {
-      $db = new db_alloc();
-      $q = prepare("SELECT count(*) AS tally FROM tf WHERE tfName = '%s'",$tf->get_value("tfName"));
-      $db->query($q);
-      $db->next_record();
-      $tf_is_taken = $db->f("tally");
-    }
-
-    if ($tf_is_taken) {
-      alloc_error("That TF name is taken, please choose another.");
+    if ($_POST["isActive"]) {
+        $tf->set_value("tfActive", 1);
     } else {
-      $tf->set_value("tfComments",rtrim($tf->get_value("tfComments")));
-      $tf->save();
-      $TPL["message_good"][] = "Your TF has been saved.";
-      $tf_is_new and $TPL["message_help"][] = "Please now add the TF Owners who are allowed to access this TF.";
+        $tf->set_value("tfActive", 0);
     }
-  }
 
+    if ($tf->get_value("tfName") == "") {
+        alloc_error("You must enter a name.");
+    } else {
+        if (!$tf->get_id()) {
+            $db = new db_alloc();
+            $q = prepare("SELECT count(*) AS tally FROM tf WHERE tfName = '%s'", $tf->get_value("tfName"));
+            $db->query($q);
+            $db->next_record();
+            $tf_is_taken = $db->f("tally");
+        }
 
+        if ($tf_is_taken) {
+            alloc_error("That TF name is taken, please choose another.");
+        } else {
+            $tf->set_value("tfComments", rtrim($tf->get_value("tfComments")));
+            $tf->save();
+            $TPL["message_good"][] = "Your TF has been saved.";
+            $tf_is_new and $TPL["message_help"][] = "Please now add the TF Owners who are allowed to access this TF.";
+        }
+    }
 } else {
-
-  if ($_POST["delete"]) {
-    $tf->delete();
-    alloc_redirect($TPL["url_alloc_tfList"]);
-    exit();
-  }
+    if ($_POST["delete"]) {
+        $tf->delete();
+        alloc_redirect($TPL["url_alloc_tfList"]);
+        exit();
+    }
 }
 
 if ($_POST["person_save"] || $_POST["person_delete"]) {
-
-  $tfPerson = new tfPerson();
-  $tfPerson->read_globals();
-  $tfPerson->read_globals("person_");
-  if (!$_POST["person_personID"]) {
-    alloc_error("Please select a person from the dropdown list.");
-  } else if ($_POST["person_save"]) {
-    $tfPerson->save();
-    $TPL["message_good"][] = "Person added to TF.";
-  } else if ($_POST["person_delete"]) {
-    $tfPerson->delete();
-  }
+    $tfPerson = new tfPerson();
+    $tfPerson->read_globals();
+    $tfPerson->read_globals("person_");
+    if (!$_POST["person_personID"]) {
+        alloc_error("Please select a person from the dropdown list.");
+    } else if ($_POST["person_save"]) {
+        $tfPerson->save();
+        $TPL["message_good"][] = "Person added to TF.";
+    } else if ($_POST["person_delete"]) {
+        $tfPerson->delete();
+    }
 }
 
 
@@ -134,7 +132,7 @@ $tf->set_values();
 
 $TPL["tfModifiedTime"] = $tf->get_value("tfModifiedTime");
 if ($tf->get_value("tfModifiedUser")) {
-  $TPL["tfModifiedUser"] = person::get_fullname($tf->get_value("tfModifiedUser"));
+    $TPL["tfModifiedUser"] = person::get_fullname($tf->get_value("tfModifiedUser"));
 }
 
 $tf->get_value("tfActive") || !$tf->get_id() and $TPL["tfIsActive"] = " checked";
@@ -142,12 +140,9 @@ $tf->get_value("tfActive") || !$tf->get_id() and $TPL["tfIsActive"] = " checked"
 $TPL["main_alloc_title"] = "Edit TF - ".APPLICATION_NAME;
 
 if (!$tf->get_id()) {
-  $TPL["message_help"][] = "Enter the details below and click the Save button to create a new Tagged Fund. 
+    $TPL["message_help"][] = "Enter the details below and click the Save button to create a new Tagged Fund. 
                             <br><br>A Tagged Fund or TF, is like a sort of bank account within allocPSA. 
                             It contains transactions which track the transfer of monies.";
 }
 
 include_template("templates/tfM.tpl");
-
-
-?>

--- a/finance/tfList.php
+++ b/finance/tfList.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -25,13 +25,13 @@ require_once("../alloc.php");
 $current_user->check_employee();
 
 if ($_REQUEST["owner"]) {
-  $TPL["owner_checked"] = " checked";
+    $TPL["owner_checked"] = " checked";
 } else {
-  $TPL["owner_checked"] = "";
+    $TPL["owner_checked"] = "";
 }
 
 if ($_REQUEST["showall"]) {
-  $TPL["showall_checked"] = " checked";
+    $TPL["showall_checked"] = " checked";
 }
 
 $TPL["main_alloc_title"] = "TF List - ".APPLICATION_NAME;
@@ -40,5 +40,3 @@ $TPL["tfListRows"] = tf::get_list($_REQUEST);
 
 
 include_template("templates/tfListM.tpl");
-
-?>

--- a/finance/transaction.php
+++ b/finance/transaction.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -30,17 +30,18 @@ global $save;
 global $saveAndNew;
 global $saveGoTf;
 
-function add_tf($tfID, $options, $warningKey, $warningValue) {
+function add_tf($tfID, $options, $warningKey, $warningValue)
+{
   // add a tf to the array of options, if it's not already there
-  global $TPL;
-  if($tfID && !array_key_exists($tfID, $options)) {
-    $tf = new tf();
-    $tf->set_id($tfID);
-    $tf->select();
-    $options[$tfID] = $tf->get_value("tfName");
-    $TPL[$warningKey] = sprintf($warningValue, $tf->get_value("tfName"));
-  }
-  return $options;
+    global $TPL;
+    if ($tfID && !array_key_exists($tfID, $options)) {
+        $tf = new tf();
+        $tf->set_id($tfID);
+        $tf->select();
+        $options[$tfID] = $tf->get_value("tfName");
+        $TPL[$warningKey] = sprintf($warningValue, $tf->get_value("tfName"));
+    }
+    return $options;
 }
 
 $db = new db_alloc();
@@ -49,30 +50,30 @@ $transaction->read_globals();
 $transactionID = $_POST["transactionID"] or $transactionID = $_GET["transactionID"];
 
 if ($transactionID && !$_GET["new"]) {
-  $transaction->set_id($transactionID);
-  $transaction->select();
+    $transaction->set_id($transactionID);
+    $transaction->select();
 }
 
 $invoice_item = $transaction->get_foreign_object("invoiceItem");
 $invoice_item->set_values();
 $invoice = $invoice_item->get_foreign_object("invoice");
 if (!$invoice->get_id()) {
-  $invoice = $transaction->get_foreign_object("invoice");
+    $invoice = $transaction->get_foreign_object("invoice");
 }
 $invoice->set_values();
 if ($invoice->get_id()) {
-  $TPL["invoice_link"] = "<a href=\"".$TPL["url_alloc_invoice"]."invoiceID=".$invoice->get_id()."\">#".$invoice->get_value("invoiceNum");
-  $TPL["invoice_link"].= " ".$invoice->get_value("invoiceDateFrom")." to ". $invoice->get_value("invoiceDateTo")."</a>";
+    $TPL["invoice_link"] = "<a href=\"".$TPL["url_alloc_invoice"]."invoiceID=".$invoice->get_id()."\">#".$invoice->get_value("invoiceNum");
+    $TPL["invoice_link"].= " ".$invoice->get_value("invoiceDateFrom")." to ". $invoice->get_value("invoiceDateTo")."</a>";
 }
 
 $expenseForm = $transaction->get_foreign_object("expenseForm");
 if ($expenseForm->get_id()) {
-  $TPL["expenseForm_link"] = "<a href=\"".$TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id()."\">#".$expenseForm->get_id()."</a>";
+    $TPL["expenseForm_link"] = "<a href=\"".$TPL["url_alloc_expenseForm"]."expenseFormID=".$expenseForm->get_id()."\">#".$expenseForm->get_id()."</a>";
 }
 
 $timeSheet = $transaction->get_foreign_object("timeSheet");
 if ($timeSheet->get_id()) {
-  $TPL["timeSheet_link"] = "<a href=\"".$TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheet->get_id()."\">#".$timeSheet->get_id()."</a>";
+    $TPL["timeSheet_link"] = "<a href=\"".$TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheet->get_id()."\">#".$timeSheet->get_id()."</a>";
 }
 
 $transaction->set_values();
@@ -86,47 +87,46 @@ if ($_POST["save"] || $_POST["saveAndNew"] || $_POST["saveGoTf"]) {
     alloc_error("This transaction is no longer editable.");
   }
 */
-  $transaction->read_globals();
+    $transaction->read_globals();
 
   // Tweaked validation to allow reporting of multiple errors
-  $transaction->get_value("amount")          or alloc_error("You must enter a valid amount");
-  $transaction->get_value("transactionDate") or alloc_error("You must enter a date for the transaction");
-  $transaction->get_value("product")         or alloc_error("You must enter a product");
-  $transaction->get_value("status")          or alloc_error("You must set the status of the transaction");
-  $transaction->get_value("fromTfID")        or alloc_error("You must select a Source Tagged Fund to take this transaction from");
-  $transaction->get_value("tfID")            or alloc_error("You must select a Destination Tagged Fund to add this transaction against");
-  $transaction->get_value("transactionType") or alloc_error("You must set a transaction type");
-  $transaction->get_value("currencyTypeID")  or alloc_error("You must set a transaction currency");
+    $transaction->get_value("amount")          or alloc_error("You must enter a valid amount");
+    $transaction->get_value("transactionDate") or alloc_error("You must enter a date for the transaction");
+    $transaction->get_value("product")         or alloc_error("You must enter a product");
+    $transaction->get_value("status")          or alloc_error("You must set the status of the transaction");
+    $transaction->get_value("fromTfID")        or alloc_error("You must select a Source Tagged Fund to take this transaction from");
+    $transaction->get_value("tfID")            or alloc_error("You must select a Destination Tagged Fund to add this transaction against");
+    $transaction->get_value("transactionType") or alloc_error("You must set a transaction type");
+    $transaction->get_value("currencyTypeID")  or alloc_error("You must set a transaction currency");
   #$transaction->get_value("projectID")       or alloc_error("You must select a project");
   #$transaction->get_value("companyDetails")  or alloc_error("You must enter the company details");
 
-  if (!count($TPL["message"]))  {
-    $transaction->set_value("amount",str_replace(array("$",","),"",$transaction->get_value("amount")));
-    if ($transaction->save()) { // need to check this again as transaction->save might have triggered an error
-      $TPL["message_good"][] = "Transaction Saved";
+    if (!count($TPL["message"])) {
+        $transaction->set_value("amount", str_replace(array("$",","), "", $transaction->get_value("amount")));
+        if ($transaction->save()) { // need to check this again as transaction->save might have triggered an error
+            $TPL["message_good"][] = "Transaction Saved";
 
-      if ($_POST["saveAndNew"]) {
-        alloc_redirect($TPL["url_alloc_transaction"]."new=true");
-      }
+            if ($_POST["saveAndNew"]) {
+                alloc_redirect($TPL["url_alloc_transaction"]."new=true");
+            }
 
-      if ($_POST["saveGoTf"]) {
-        alloc_redirect($TPL["url_alloc_transactionList"]."tfID=".$transaction->get_value("tfID"));
-      }
+            if ($_POST["saveGoTf"]) {
+                alloc_redirect($TPL["url_alloc_transactionList"]."tfID=".$transaction->get_value("tfID"));
+            }
 
-      alloc_redirect($TPL["url_alloc_transaction"]."transactionID=".$transaction->get_id());
+            alloc_redirect($TPL["url_alloc_transaction"]."transactionID=".$transaction->get_id());
+        }
     }
-  }
-    
 } else if ($_POST["delete"]) {
-  $transaction->delete();
-  alloc_redirect($TPL["url_alloc_transactionList"]."tfID=".$transaction->get_value("tfID"));
+    $transaction->delete();
+    alloc_redirect($TPL["url_alloc_transactionList"]."tfID=".$transaction->get_value("tfID"));
 }
 
 $transaction->set_tpl_values();
 
 $t = new meta("currencyType");
-$currency_array = $t->get_assoc_array("currencyTypeID","currencyTypeID");
-$TPL["currencyOptions"] = page::select_options($currency_array,$transaction->get_value("currencyTypeID"));
+$currency_array = $t->get_assoc_array("currencyTypeID", "currencyTypeID");
+$TPL["currencyOptions"] = page::select_options($currency_array, $transaction->get_value("currencyTypeID"));
 $TPL["product"] = page::htmlentities($transaction->get_value("product"));
 $TPL["statusOptions"] = page::select_options(array("pending"=>"Pending", "rejected"=>"Rejected", "approved"=>"Approved"), $transaction->get_value("status"));
 $transactionTypes = transaction::get_transactionTypes();
@@ -137,7 +137,7 @@ is_object($transaction) and $TPL["transactionTypeLink"] = $transaction->get_tran
 $db = new db_alloc();
 
 $tf = new tf();
-$options = $tf->get_assoc_array("tfID","tfName");
+$options = $tf->get_assoc_array("tfID", "tfName");
 // Special cases for the current tfID and fromTfID
 $options = add_tf($transaction->get_value("tfID"), $options, "tfIDWarning", " (warning: the TF <b>%s</b> is currently inactive)");
 $options = add_tf($transaction->get_value("fromTfID"), $options, "fromTfIDWarning", " (warning: the TF <b>%s</b> is currently inactive)");
@@ -167,13 +167,10 @@ $TPL["project_link"] = $p->get_link();
 
 $TPL["taxName"] = config::get_config_item("taxName");
 
-if (is_object($current_user) && !$current_user->have_role("admin") && is_object($transaction) && in_array($transaction->get_value("status"),array("approved","rejected"))) {
-  $TPL["main_alloc_title"] = "View Transaction - ".APPLICATION_NAME;
-  include_template("templates/viewTransactionM.tpl");
+if (is_object($current_user) && !$current_user->have_role("admin") && is_object($transaction) && in_array($transaction->get_value("status"), array("approved","rejected"))) {
+    $TPL["main_alloc_title"] = "View Transaction - ".APPLICATION_NAME;
+    include_template("templates/viewTransactionM.tpl");
 } else {
-  $TPL["main_alloc_title"] = "Create Transaction - ".APPLICATION_NAME;
-  include_template("templates/editTransactionM.tpl");
+    $TPL["main_alloc_title"] = "Create Transaction - ".APPLICATION_NAME;
+    include_template("templates/editTransactionM.tpl");
 }
-
-
-?>

--- a/finance/transactionGroup.php
+++ b/finance/transactionGroup.php
@@ -22,91 +22,93 @@
 
 require_once("../alloc.php");
 
-function show_transaction_list($template) {
-  global $TPL;
-  global $tflist;
-  global $transactionGroupID;
+function show_transaction_list($template)
+{
+    global $TPL;
+    global $tflist;
+    global $transactionGroupID;
 
-  $q = prepare("SELECT *, amount * pow(10,-currencyType.numberToBasic) as amount
+    $q = prepare("SELECT *, amount * pow(10,-currencyType.numberToBasic) as amount
                   FROM transaction
              LEFT JOIN currencyType on transaction.currencyTypeID = currencyType.currencyTypeID
                  WHERE transactionGroupID = %d
               ORDER BY transactionID
-               ",$transactionGroupID);
-  $db = new db_alloc();
-  $db->query($q);
+               ", $transactionGroupID);
+    $db = new db_alloc();
+    $db->query($q);
 
-  while ($row = $db->row()) {
+    while ($row = $db->row()) {
+        $transaction = new transaction();
+        $transaction->read_array($row);
+        $transaction->set_values();
+
+        $tflist = add_inactive_tf($transaction->get_value("tfID"), $tflist);
+        $tflist = add_inactive_tf($transaction->get_value("fromTfID"), $tflist);
+
+        $TPL["display"] = "";
+        $TPL["tfList_dropdown"] = page::select_options($tflist, $transaction->get_value("tfID"), 500);
+        $TPL["fromTfList_dropdown"] = page::select_options($tflist, $transaction->get_value("fromTfID"), 500);
+        $TPL["transactionType_dropdown"] = page::select_options(transaction::get_transactionTypes(), $transaction->get_value("transactionType"));
+        $TPL["status_dropdown"] = page::select_options(transaction::get_transactionStatii(), $transaction->get_value("status"));
+        $TPL["link"] = $transaction->get_link("transactionID");
+        include_template($template);
+    }
+}
+
+function show_transaction_new($template)
+{
+    global $TPL;
+    global $tflist;
     $transaction = new transaction();
-    $transaction->read_array($row);
-    $transaction->set_values();
-
-    $tflist = add_inactive_tf($transaction->get_value("tfID"), $tflist);
-    $tflist = add_inactive_tf($transaction->get_value("fromTfID"), $tflist);
-
-    $TPL["display"] = "";
-    $TPL["tfList_dropdown"] = page::select_options($tflist, $transaction->get_value("tfID"),500);
-    $TPL["fromTfList_dropdown"] = page::select_options($tflist, $transaction->get_value("fromTfID"),500);
-    $TPL["transactionType_dropdown"] = page::select_options(transaction::get_transactionTypes(), $transaction->get_value("transactionType"));
-    $TPL["status_dropdown"] = page::select_options(transaction::get_transactionStatii(),$transaction->get_value("status"));
-    $TPL["link"] = $transaction->get_link("transactionID");
+    $transaction->set_values(); // wipe clean
+    $TPL["display"] = "display:none";
+    $TPL["tfList_dropdown"] = page::select_options($tflist, null, 500);
+    $TPL["fromTfList_dropdown"] = page::select_options($tflist, null, 500);
+    $TPL["transactionType_dropdown"] = page::select_options(transaction::get_transactionTypes());
+    $TPL["status_dropdown"] = page::select_options(transaction::get_transactionStatii());
+    $TPL["link"] = "";
     include_template($template);
-  }
 }
 
-function show_transaction_new($template) {
-  global $TPL;
-  global $tflist;
-  $transaction = new transaction();
-  $transaction->set_values(); // wipe clean
-  $TPL["display"] = "display:none";
-  $TPL["tfList_dropdown"] = page::select_options($tflist,NULL,500);
-  $TPL["fromTfList_dropdown"] = page::select_options($tflist,NULL,500);
-  $TPL["transactionType_dropdown"] = page::select_options(transaction::get_transactionTypes());
-  $TPL["status_dropdown"] = page::select_options(transaction::get_transactionStatii());
-  $TPL["link"] = "";
-  include_template($template);
-}
-
-function add_inactive_tf($tfID, $options) {
+function add_inactive_tf($tfID, $options)
+{
   // add a tf to the array of options, if it's not already there
-  global $TPL;
-  if($tfID && !array_key_exists($tfID, $options)) {
-    $tf = new tf();
-    $tf->set_id($tfID);
-    $tf->select();
-    $options[$tfID] = $tf->get_value("tfName");
-  }
-  return $options;
+    global $TPL;
+    if ($tfID && !array_key_exists($tfID, $options)) {
+        $tf = new tf();
+        $tf->set_id($tfID);
+        $tf->select();
+        $options[$tfID] = $tf->get_value("tfName");
+    }
+    return $options;
 }
 
 $tf = new tf();
-$tflist = $tf->get_assoc_array("tfID","tfName");
+$tflist = $tf->get_assoc_array("tfID", "tfName");
 $transactionGroupID = $_POST["transactionGroupID"] or $transactionGroupID = $_GET["transactionGroupID"];
 if (!$transactionGroupID) {
-  $transactionGroupID = transaction::get_next_transactionGroupID();
+    $transactionGroupID = transaction::get_next_transactionGroupID();
 }
 $TPL["transactionGroupID"] = $transactionGroupID;
 
 
 if ($_POST["save_transactions"]) {
-  is_array($_POST["deleteTransaction"]) or $_POST["deleteTransaction"] = array();
+    is_array($_POST["deleteTransaction"]) or $_POST["deleteTransaction"] = array();
 
-  if (is_array($_POST["transactionID"]) && count($_POST["transactionID"])) {
+    if (is_array($_POST["transactionID"]) && count($_POST["transactionID"])) {
+        foreach ($_POST["transactionID"] as $k => $transactionID) {
+          // Delete
+            if ($transactionID && in_array($transactionID, $_POST["deleteTransaction"])) {
+                $transaction = new transaction();
+                $transaction->set_id($transactionID);
+                $transaction->select();
+                $transaction->delete();
+                $deleted.= $commar1.$transactionID;
+                $commar1 = ", ";
 
-    foreach ($_POST["transactionID"] as $k => $transactionID) {
-      // Delete
-      if ($transactionID && in_array($transactionID, $_POST["deleteTransaction"])) {
-        $transaction = new transaction();
-        $transaction->set_id($transactionID);
-        $transaction->select();
-        $transaction->delete();
-        $deleted.= $commar1.$transactionID;
-        $commar1 = ", ";
-
-      // Save
-      } else if ($_POST["amount"][$k]) {
-        $a = array("amount"             => $_POST["amount"][$k]
+              // Save
+            } else if ($_POST["amount"][$k]) {
+                $a = array("amount"             => $_POST["amount"][$k]
                   ,"tfID"               => $_POST["tfID"][$k]
                   ,"fromTfID"           => $_POST["fromTfID"][$k]
                   ,"product"            => $_POST["product"][$k]
@@ -117,29 +119,28 @@ if ($_POST["save_transactions"]) {
                   ,"transactionGroupID" => $transactionGroupID
                   ,"transactionID"      => $_POST["transactionID"][$k]);
 
-        $transaction = new transaction();
-        if ($_POST["transactionID"][$k]) {
-          $transaction->set_id($_POST["transactionID"][$k]);
-          $transaction->select();
+                $transaction = new transaction();
+                if ($_POST["transactionID"][$k]) {
+                    $transaction->set_id($_POST["transactionID"][$k]);
+                    $transaction->select();
+                }
+                $transaction->read_array($a);
+                $v = $transaction->validate();
+                if ($v == "") {
+                    $transaction->save();
+                    $saved.= $commar2.$transaction->get_id();
+                    $commar2 = ", ";
+                } else {
+                    alloc_error(implode("<br>", $v));
+                }
+            }
         }
-        $transaction->read_array($a);
-        $v = $transaction->validate();
-        if ($v == "") {
-          $transaction->save();
-          $saved.= $commar2.$transaction->get_id();
-          $commar2 = ", ";
-        } else {
-          alloc_error(implode("<br>",$v));
-        }
-      }
     }
-  }
-  $saved and $TPL["message_good"][] = "Transaction ".$saved." saved.";
-  $deleted and $TPL["message_good"][] = "Transaction ".$deleted." deleted.";
-  alloc_redirect($TPL["url_alloc_transactionGroup"]."transactionGroupID=".$transactionGroupID);
+    $saved and $TPL["message_good"][] = "Transaction ".$saved." saved.";
+    $deleted and $TPL["message_good"][] = "Transaction ".$deleted." deleted.";
+    alloc_redirect($TPL["url_alloc_transactionGroup"]."transactionGroupID=".$transactionGroupID);
 }
 
 
 $TPL["main_alloc_title"] = "Edit Transactions - ".APPLICATION_NAME;
 include_template("templates/transactionGroupM.tpl");
-?>

--- a/finance/transactionList.php
+++ b/finance/transactionList.php
@@ -3,32 +3,33 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function show_filter() {
-  global $TPL;
-  global $defaults;
-  $_FORM = transaction::load_form_data($defaults);
-  $arr = transaction::load_transaction_filter($_FORM);
-  is_array($arr) and $TPL = array_merge($TPL,$arr);
-  include_template("templates/transactionFilterS.tpl");
+function show_filter()
+{
+    global $TPL;
+    global $defaults;
+    $_FORM = transaction::load_form_data($defaults);
+    $arr = transaction::load_transaction_filter($_FORM);
+    is_array($arr) and $TPL = array_merge($TPL, $arr);
+    include_template("templates/transactionFilterS.tpl");
 }
 
 $tfID         = $_GET["tfID"]        or $tfID        = $_POST["tfID"];
@@ -39,7 +40,7 @@ $download     = $_GET["download"]    or $download    = $_POST["download"];
 $applyFilter  = $_GET["applyFilter"] or $applyFilter = $_POST["applyFilter"];
 
 if (!$startDate && !$endDate && !$monthDate && !$applyFilter) {
-  $monthDate = date("Y-m-d");
+    $monthDate = date("Y-m-d");
 }
 
 $defaults = array("url_form_action"=>$TPL["url_alloc_transactionList"]
@@ -52,16 +53,16 @@ $defaults = array("url_form_action"=>$TPL["url_alloc_transactionList"]
                  );
 
 if ($download) {
-  $_FORM = transaction::load_form_data($defaults);
-  $rtn = transaction::get_list($_FORM);
-  $totals = $rtn["totals"];
-  $rows = $rtn["rows"];
-  $csv = transaction::arr_to_csv($rows);
-  header('Content-Type: application/octet-stream');
-  header("Content-Length: ".strlen($csv));
-  header('Content-Disposition: attachment; filename="'.date("Ymd_His").'.csv"');
-  echo $csv;
-  exit();
+    $_FORM = transaction::load_form_data($defaults);
+    $rtn = transaction::get_list($_FORM);
+    $totals = $rtn["totals"];
+    $rows = $rtn["rows"];
+    $csv = transaction::arr_to_csv($rows);
+    header('Content-Type: application/octet-stream');
+    header("Content-Length: ".strlen($csv));
+    header('Content-Disposition: attachment; filename="'.date("Ymd_His").'.csv"');
+    echo $csv;
+    exit();
 }
 
 // Check perm of requested tf
@@ -87,4 +88,3 @@ $TPL["title"] = "Statement for tagged fund: ".$tf->get_value("tfName");
 $TPL["main_alloc_title"] =  "TF: ".$tf->get_value("tfName"). " - " .APPLICATION_NAME;
 
 include_template("templates/transactionListM.tpl");
-?>

--- a/finance/transactionRepeat.php
+++ b/finance/transactionRepeat.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -33,58 +33,57 @@ global $transactionRepeatID;
 $transactionRepeatID = $_POST["transactionRepeatID"] or $transactionRepeatID = $_GET["transactionRepeatID"];
 
 if ($transactionRepeatID) {
-  $transactionRepeat->set_id($transactionRepeatID);
-  $transactionRepeat->select();
-  $transactionRepeat->set_values();
-} 
+    $transactionRepeat->set_id($transactionRepeatID);
+    $transactionRepeat->select();
+    $transactionRepeat->set_values();
+}
 
 
 
 if (!isset($_POST["reimbursementRequired"])) {
-  $_POST["reimbursementRequired"] = 0;
+    $_POST["reimbursementRequired"] = 0;
 }
 
 
 if ($_POST["save"] || $_POST["delete"] || $_POST["pending"] || $_POST["approved"] || $_POST["rejected"]) {
+    $transactionRepeat->read_globals();
 
-  $transactionRepeat->read_globals();
-
-  if ($current_user->have_role("admin")) { 
-    if ($_POST["changeTransactionStatus"] == "pending") {
-      $transactionRepeat->set_value("status","pending");
-      $TPL["message_good"][] = "Repeating Expense form Pending.";
-    } else if ($_POST["changeTransactionStatus"] == "approved") {
-      $transactionRepeat->set_value("status","approved");
-      $TPL["message_good"][] = "Repeating Expense form Approved!";
-    } else if ($_POST["changeTransactionStatus"] == "rejected") {
-      $transactionRepeat->set_value("status","rejected");
-      $TPL["message_good"][] = "Repeating Expense form  Rejected.";
+    if ($current_user->have_role("admin")) {
+        if ($_POST["changeTransactionStatus"] == "pending") {
+            $transactionRepeat->set_value("status", "pending");
+            $TPL["message_good"][] = "Repeating Expense form Pending.";
+        } else if ($_POST["changeTransactionStatus"] == "approved") {
+            $transactionRepeat->set_value("status", "approved");
+            $TPL["message_good"][] = "Repeating Expense form Approved!";
+        } else if ($_POST["changeTransactionStatus"] == "rejected") {
+            $transactionRepeat->set_value("status", "rejected");
+            $TPL["message_good"][] = "Repeating Expense form  Rejected.";
+        }
     }
-  }
 
-  if ($_POST["delete"] && $transactionRepeatID) {
-    $transactionRepeat->set_id($transactionRepeatID);
-    $transactionRepeat->delete();
-    alloc_redirect($TPL["url_alloc_transactionRepeatList"]."tfID=".$_POST["tfID"]);
-  }
+    if ($_POST["delete"] && $transactionRepeatID) {
+        $transactionRepeat->set_id($transactionRepeatID);
+        $transactionRepeat->delete();
+        alloc_redirect($TPL["url_alloc_transactionRepeatList"]."tfID=".$_POST["tfID"]);
+    }
 
-  $_POST["product"]  or alloc_error("Please enter a Product");
-  $_POST["amount"]   or alloc_error("Please enter an Amount");
-  $_POST["fromTfID"] or alloc_error("Please select a Source TF");
-  $_POST["tfID"]     or alloc_error("Please select a Destination TF");
-  $_POST["companyDetails"]  or alloc_error("Please provide Company Details");
-  $_POST["transactionType"] or alloc_error("Please select a Transaction Type");
-  $_POST["transactionStartDate"] or alloc_error("You must enter the Start date in the format yyyy-mm-dd");
-  $_POST["transactionFinishDate"] or alloc_error("You must enter the Finish date in the format yyyy-mm-dd");
+    $_POST["product"]  or alloc_error("Please enter a Product");
+    $_POST["amount"]   or alloc_error("Please enter an Amount");
+    $_POST["fromTfID"] or alloc_error("Please select a Source TF");
+    $_POST["tfID"]     or alloc_error("Please select a Destination TF");
+    $_POST["companyDetails"]  or alloc_error("Please provide Company Details");
+    $_POST["transactionType"] or alloc_error("Please select a Transaction Type");
+    $_POST["transactionStartDate"] or alloc_error("You must enter the Start date in the format yyyy-mm-dd");
+    $_POST["transactionFinishDate"] or alloc_error("You must enter the Finish date in the format yyyy-mm-dd");
 
-  if (!$TPL["message"]) {
-    !$transactionRepeat->get_value("status") && $transactionRepeat->set_value("status","pending"); 
-    $transactionRepeat->set_value("companyDetails",rtrim($transactionRepeat->get_value("companyDetails")));
-    $transactionRepeat->save();
-    alloc_redirect($TPL["url_alloc_transactionRepeat"]."transactionRepeatID=".$transactionRepeat->get_id());
-  }
-  $transactionRepeat->set_values();
-}                       
+    if (!$TPL["message"]) {
+        !$transactionRepeat->get_value("status") && $transactionRepeat->set_value("status", "pending");
+        $transactionRepeat->set_value("companyDetails", rtrim($transactionRepeat->get_value("companyDetails")));
+        $transactionRepeat->save();
+        alloc_redirect($TPL["url_alloc_transactionRepeat"]."transactionRepeatID=".$transactionRepeat->get_id());
+    }
+    $transactionRepeat->set_values();
+}
 
 
 
@@ -93,72 +92,81 @@ if ($_POST["save"] || $_POST["delete"] || $_POST["pending"] || $_POST["approved"
 $TPL["reimbursementRequired_checked"] = $transactionRepeat->get_value("reimbursementRequired") ? " checked" : "";
 
 if ($transactionRepeat->get_value("transactionRepeatModifiedUser")) {
-  $db->query("select username from person where personID=%d",$transactionRepeat->get_value("transactionRepeatModifiedUser"));
-  $db->next_record();
-  $TPL["user"] = $db->f("username");
+    $db->query("select username from person where personID=%d", $transactionRepeat->get_value("transactionRepeatModifiedUser"));
+    $db->next_record();
+    $TPL["user"] = $db->f("username");
 }
 
 
 if (have_entity_perm("tf", PERM_READ, $current_user, false)) {
   // Person can access all TF records
-  $q = prepare("SELECT tfID AS value, tfName AS label 
+    $q = prepare(
+        "SELECT tfID AS value, tfName AS label 
                   FROM tf 
                  WHERE tfActive = 1 
                     OR tf.tfID = %d 
                     OR tf.tfID = %d 
-              ORDER BY tfName"
-              , $transactionRepeat->get_value("tfID"), $transactionRepeat->get_value("fromTfID"));
+              ORDER BY tfName",
+        $transactionRepeat->get_value("tfID"),
+        $transactionRepeat->get_value("fromTfID")
+    );
 } else if (have_entity_perm("tf", PERM_READ, $current_user, true)) {
   // Person can only read TF records that they own
-  $q = prepare("SELECT tf.tfID AS value, tf.tfName AS label
+    $q = prepare(
+        "SELECT tf.tfID AS value, tf.tfName AS label
                   FROM tf, tfPerson 
                  WHERE tfPerson.personID=%d 
                    AND tf.tfID=tfPerson.tfID 
                    AND (tf.tfActive = 1 OR tf.tfID = %d OR tf.tfID = %d)
-              ORDER BY tfName"
-              ,$current_user->get_id(), $transactionRepeat->get_value("tfID"), $transactionRepeat->get_value("fromTfID"));
+              ORDER BY tfName",
+        $current_user->get_id(),
+        $transactionRepeat->get_value("tfID"),
+        $transactionRepeat->get_value("fromTfID")
+    );
 } else {
-  alloc_error("No permissions to generate TF list");
+    alloc_error("No permissions to generate TF list");
 }
 
 //special case for disabled TF. Include it in the list, but also add a warning message.
 $tf = new tf();
 $tf->set_id($transactionRepeat->get_value("tfID"));
 if ($tf->select() && !$tf->get_value("tfActive")) {
-  $TPL["message_help"][] = "This expense is allocated to an inactive TF. It will not create transactions.";
+    $TPL["message_help"][] = "This expense is allocated to an inactive TF. It will not create transactions.";
 }
 $tf = new tf();
 $tf->set_id($transactionRepeat->get_value("fromTfID"));
 if ($tf->select() && !$tf->get_value("tfActive")) {
-  $TPL["message_help"][] = "This expense is sourced from an inactive TF. It will not create transactions.";
+    $TPL["message_help"][] = "This expense is sourced from an inactive TF. It will not create transactions.";
 }
 
 
 $m = new meta("currencyType");
-$currencyOps = $m->get_assoc_array("currencyTypeID","currencyTypeID");
-$TPL["currencyTypeOptions"] = page::select_options($currencyOps,$transactionRepeat->get_value("currencyTypeID"));
+$currencyOps = $m->get_assoc_array("currencyTypeID", "currencyTypeID");
+$TPL["currencyTypeOptions"] = page::select_options($currencyOps, $transactionRepeat->get_value("currencyTypeID"));
 
 $TPL["tfOptions"] = page::select_options($q, $transactionRepeat->get_value("tfID"));
 $TPL["fromTfOptions"] = page::select_options($q, $transactionRepeat->get_value("fromTfID"));
-$TPL["basisOptions"] = page::select_options(array("weekly"     =>"weekly"
+$TPL["basisOptions"] = page::select_options(
+    array("weekly"     =>"weekly"
                                                  ,"fortnightly"=>"fortnightly"
                                                  ,"monthly"    =>"monthly"
                                                  ,"quarterly"  =>"quarterly"
-                                                 ,"yearly"     =>"yearly")
-                                            ,$transactionRepeat->get_value("paymentBasis"));
+                                                 ,"yearly"     =>"yearly"),
+    $transactionRepeat->get_value("paymentBasis")
+);
 
 $TPL["transactionTypeOptions"] = page::select_options(transaction::get_transactionTypes(), $transactionRepeat->get_value("transactionType"));
 
 if (is_object($transactionRepeat) && $transactionRepeat->get_id() && $current_user->have_role("admin")) {
-  $TPL["adminButtons"].= '
+    $TPL["adminButtons"].= '
   <select name="changeTransactionStatus"><option value="">Transaction Status<option value="approved">Approve<option value="rejected">Reject<option value="pending">Pending</select>
   ';
 }
 
 if (is_object($transactionRepeat) && $transactionRepeat->get_id() && $transactionRepeat->get_value("status") == "pending") {
-  $TPL["message_help"][] = "This Repeating Expense will only create Transactions once its status is Approved.";
+    $TPL["message_help"][] = "This Repeating Expense will only create Transactions once its status is Approved.";
 } else if (!$transactionRepeat->get_id()) {
-  $TPL["message_help"][] = "Complete all the details and click the Save button to create an automatically Repeating Expense";
+    $TPL["message_help"][] = "Complete all the details and click the Save button to create an automatically Repeating Expense";
 }
 
 $transactionRepeat->get_value("status") and $TPL["statusLabel"] = " - ".ucwords($transactionRepeat->get_value("status"));
@@ -167,5 +175,3 @@ $TPL["taxName"] = config::get_config_item("taxName");
 
 $TPL["main_alloc_title"] = "Create Repeating Expense - ".APPLICATION_NAME;
 include_template("templates/transactionRepeatM.tpl");
-
-?>

--- a/finance/transactionRepeatList.php
+++ b/finance/transactionRepeatList.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -31,36 +31,33 @@ $TPL["tfID"] = $_GET["tfID"];
 $TPL["main_alloc_title"] = "Repeating Expenses List - ".APPLICATION_NAME;
 include_template("templates/transactionRepeatListM.tpl");
 
-function show_expenseFormList($template_name) {
+function show_expenseFormList($template_name)
+{
 
-  global $db;
-  global $TPL;
-  global $transactionRepeat;
-  $current_user = &singleton("current_user");
+    global $db;
+    global $TPL;
+    global $transactionRepeat;
+    $current_user = &singleton("current_user");
 
-  $db = new db_alloc();
-  $transactionRepeat = new transactionRepeat();
+    $db = new db_alloc();
+    $transactionRepeat = new transactionRepeat();
 
-  if (!$_GET["tfID"] && !$current_user->have_role("admin")) {
-    $tfIDs = $current_user->get_tfIDs();
-    $tfIDs and $sql = prepare("WHERE tfID in (%s)",$tfIDs);
+    if (!$_GET["tfID"] && !$current_user->have_role("admin")) {
+        $tfIDs = $current_user->get_tfIDs();
+        $tfIDs and $sql = prepare("WHERE tfID in (%s)", $tfIDs);
+    } else if ($_GET["tfID"]) {
+        $sql = prepare("WHERE tfID = %d", $_GET["tfID"]);
+    }
 
-  } else if ($_GET["tfID"]) {
-    $sql = prepare("WHERE tfID = %d",$_GET["tfID"]);
-  }
+    $db->query("select * FROM transactionRepeat ".$sql);
 
-  $db->query("select * FROM transactionRepeat ".$sql);
-
-  while ($db->next_record()) {
-    $i++;
-    $transactionRepeat->read_db_record($db);
-    $transactionRepeat->set_values();
-    $TPL["tfName"] = tf::get_name($transactionRepeat->get_value("tfID"));
-    $TPL["fromTfName"] = tf::get_name($transactionRepeat->get_value("fromTfID"));
-    include_template($template_name);
-  }
-  $TPL["tfID"] = $tfID;
+    while ($db->next_record()) {
+        $i++;
+        $transactionRepeat->read_db_record($db);
+        $transactionRepeat->set_values();
+        $TPL["tfName"] = tf::get_name($transactionRepeat->get_value("tfID"));
+        $TPL["fromTfName"] = tf::get_name($transactionRepeat->get_value("fromTfID"));
+        include_template($template_name);
+    }
+    $TPL["tfID"] = $tfID;
 }
-
-
-?>

--- a/finance/updateExchangeRates.php
+++ b/finance/updateExchangeRates.php
@@ -3,27 +3,25 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_AUTH",true);
-define("IS_GOD",true);
+define("NO_AUTH", true);
+define("IS_GOD", true);
 require_once("../alloc.php");
 
 exchangeRate::download();
-
-?>

--- a/finance/updateTFList.php
+++ b/finance/updateTFList.php
@@ -3,37 +3,34 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 if ($_GET["projectID"]) {
-  usleep(300000);
-  $project = new project();
-  $project->set_id($_GET["projectID"]);
-  $project->select();
-  $tf_sel = $project->get_value("cost_centre_tfID") or $tf_sel = config::get_config_item("mainTfID");
-  $tf = new tf();
-  $options = page::select_options($tf->get_assoc_array("tfID","tfName"),$tf_sel);
-  echo "<select id=\"tfID\" name=\"tfID\">".$options."</select>";
+    usleep(300000);
+    $project = new project();
+    $project->set_id($_GET["projectID"]);
+    $project->select();
+    $tf_sel = $project->get_value("cost_centre_tfID") or $tf_sel = config::get_config_item("mainTfID");
+    $tf = new tf();
+    $options = page::select_options($tf->get_assoc_array("tfID", "tfName"), $tf_sel);
+    echo "<select id=\"tfID\" name=\"tfID\">".$options."</select>";
 }
-
-
-?>

--- a/finance/wagesUpload.php
+++ b/finance/wagesUpload.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,7 +23,7 @@
 require_once("../alloc.php");
 
 if (!config::get_config_item("outTfID")) {
-  alloc_error("Please select a default Outgoing TF from the Setup -> Finance menu.");
+    alloc_error("Please select a default Outgoing TF from the Setup -> Finance menu.");
 }
 
 #$field_map = array("transactionDate"=>0, "employeeNum"=>1, "name"=>2, ""=>3, ""=>4, ""=>5, ""=>6, ""=>7, ""=>8, ""=>9, "amount"=>10, ""=>11, ""=>12);
@@ -38,110 +38,106 @@ $field_map = array(""                =>0
                   );
 
 if ($_POST["upload"] && is_uploaded_file($_FILES["wages_file"]["tmp_name"])) {
-  $db = new db_alloc();
+    $db = new db_alloc();
 
-  $lines = file($_FILES["wages_file"]["tmp_name"]);
+    $lines = file($_FILES["wages_file"]["tmp_name"]);
 
-  reset($lines);
-  foreach ($lines as $line) {
-  
-    // Read field values from the line
-    $fields = explode("\t", $line);
-    $transactionDate = trim($fields[$field_map["transactionDate"]]);
-    $employeeNum = trim($fields[$field_map["employeeNum"]]);
-    $amount = trim($fields[$field_map["amount"]]);
-    $memo = trim($fields[$field_map["memo"]]);
-    $account = trim($fields[$field_map["account"]]);
-    $name = trim($fields[$field_map["name"]]);
+    reset($lines);
+    foreach ($lines as $line) {
+      // Read field values from the line
+        $fields = explode("\t", $line);
+        $transactionDate = trim($fields[$field_map["transactionDate"]]);
+        $employeeNum = trim($fields[$field_map["employeeNum"]]);
+        $amount = trim($fields[$field_map["amount"]]);
+        $memo = trim($fields[$field_map["memo"]]);
+        $account = trim($fields[$field_map["account"]]);
+        $name = trim($fields[$field_map["name"]]);
 
-    // Skip tax lines
-    if (stristr($account,"Payroll Liabilities")) {
-      continue;
-    }
+      // Skip tax lines
+        if (stristr($account, "Payroll Liabilities")) {
+            continue;
+        }
    
-    // Remove leading guff "789 - "
-    // The dash isn't an ASCII dash, hence non-greedy anything match
-    $account = preg_replace("/^\d+\s.*?\s/","",$account);
+      // Remove leading guff "789 - "
+      // The dash isn't an ASCII dash, hence non-greedy anything match
+        $account = preg_replace("/^\d+\s.*?\s/", "", $account);
 
-    // If there's a memo field then append it to account
-    $memo and $account.= " - ".$memo;
-
-
-    #echo "<br>";
-    #echo "<br>date: ".$transactionDate;
-    #echo "<br>memo: ".$memo;
-    #echo "<br>account: ".$account;
-    #echo "<br>amount: ".$amount;
-    #echo "<br>employeeNum: ".$employeeNum;
-
-    // Ignore heading row, dividing lines and total rows
-    if ($transactionDate == "Date" || !$transactionDate || strpos("_____", $transactionDate) !== FALSE || strpos("¯¯¯", $transactionDate) !== FALSE || stripos("total", $transactionDate) !== FALSE) {
-      continue;
-    }
-    // If the employeeNum field is blank use the previous employeeNum
-    #if (!$employeeNum) {
-     # $employeeNum = $prev_employeeNum;
-    #}
-    #$prev_employeeNum = $employeeNum;
-
-    // Find the TF for the wage
-    $query = prepare("SELECT * FROM tf WHERE qpEmployeeNum=%d", $employeeNum);
-    $db->query($query);
-    if (!$db->next_record()) {
-      $msg.= "<b>Warning: Could not find TF for employee number '$employeeNum' $name</b><br>";
-      continue;
-    }
-    $fromTfID = $db->f("tfID");
-
-    // Convert the date to yyyy-mm-dd
-    if (!preg_match("|^([0-9]{1,2})/([0-9]{1,2})/([0-9]{4})$|i", $transactionDate, $matches)) {
-      $msg.= "<b>Warning: Could not convert date '$transactionDate'</b><br>";
-      continue;
-    }
-    $transactionDate = sprintf("%04d-%02d-%02d", $matches[3], $matches[2], $matches[1]);
+      // If there's a memo field then append it to account
+        $memo and $account.= " - ".$memo;
 
 
-    // Strip $ and , from amount
-    $amount = str_replace(array('$',','), array(), $amount);
-    if (!preg_match("/^[-]?[0-9]+(\\.[0-9]+)?$/", $amount)) {
-      $msg.= "<b>Warning: Could not convert amount '$amount'</b><br>";
-      continue;
-    }
+      #echo "<br>";
+      #echo "<br>date: ".$transactionDate;
+      #echo "<br>memo: ".$memo;
+      #echo "<br>account: ".$account;
+      #echo "<br>amount: ".$amount;
+      #echo "<br>employeeNum: ".$employeeNum;
 
-    // Negate the amount - Wages are a debit from TF's
-    $amount = -$amount;
+      // Ignore heading row, dividing lines and total rows
+        if ($transactionDate == "Date" || !$transactionDate || strpos("_____", $transactionDate) !== false || strpos("¯¯¯", $transactionDate) !== false || stripos("total", $transactionDate) !== false) {
+            continue;
+        }
+      // If the employeeNum field is blank use the previous employeeNum
+      #if (!$employeeNum) {
+       # $employeeNum = $prev_employeeNum;
+      #}
+      #$prev_employeeNum = $employeeNum;
 
-    // Check for an existing transaction for this wage - note we have to use a range or amount because it is floating point
-    $query = prepare("SELECT transactionID
+      // Find the TF for the wage
+        $query = prepare("SELECT * FROM tf WHERE qpEmployeeNum=%d", $employeeNum);
+        $db->query($query);
+        if (!$db->next_record()) {
+            $msg.= "<b>Warning: Could not find TF for employee number '$employeeNum' $name</b><br>";
+            continue;
+        }
+        $fromTfID = $db->f("tfID");
+
+      // Convert the date to yyyy-mm-dd
+        if (!preg_match("|^([0-9]{1,2})/([0-9]{1,2})/([0-9]{4})$|i", $transactionDate, $matches)) {
+            $msg.= "<b>Warning: Could not convert date '$transactionDate'</b><br>";
+            continue;
+        }
+        $transactionDate = sprintf("%04d-%02d-%02d", $matches[3], $matches[2], $matches[1]);
+
+
+      // Strip $ and , from amount
+        $amount = str_replace(array('$',','), array(), $amount);
+        if (!preg_match("/^[-]?[0-9]+(\\.[0-9]+)?$/", $amount)) {
+            $msg.= "<b>Warning: Could not convert amount '$amount'</b><br>";
+            continue;
+        }
+
+      // Negate the amount - Wages are a debit from TF's
+        $amount = -$amount;
+
+      // Check for an existing transaction for this wage - note we have to use a range or amount because it is floating point
+        $query = prepare("SELECT transactionID
                         FROM transaction
-                        WHERE fromTfID=%d AND transactionDate='%s' AND amount=%d", $fromTfID, $transactionDate, page::money(config::get_config_item("currency"),$amount,"%mi"));
-    $db->query($query);
-    if ($db->next_record()) {
-      $msg.= "Warning: Salary for employee #$employeeNum $name on $transactionDate already exists as transaction #".$db->f("transactionID")."<br>";
-      continue;
+                        WHERE fromTfID=%d AND transactionDate='%s' AND amount=%d", $fromTfID, $transactionDate, page::money(config::get_config_item("currency"), $amount, "%mi"));
+        $db->query($query);
+        if ($db->next_record()) {
+            $msg.= "Warning: Salary for employee #$employeeNum $name on $transactionDate already exists as transaction #".$db->f("transactionID")."<br>";
+            continue;
+        }
+
+      // Create a transaction object and then save it
+        $transaction = new transaction();
+        $transaction->set_value("currencyTypeID", config::get_config_item("currency"));
+        $transaction->set_value("fromTfID", $fromTfID);
+        $transaction->set_value("tfID", config::get_config_item("outTfID"));
+        $transaction->set_value("transactionDate", $transactionDate);
+        $transaction->set_value("amount", $amount);
+        $transaction->set_value("companyDetails", "");
+        $transaction->set_value("product", $account);
+        $transaction->set_value("status", "approved");
+        $transaction->set_value("quantity", 1);
+        $transaction->set_value("transactionType", "salary");
+        $transaction->save();
+
+        $msg.= "\$$amount for employee $employeeNum $name on $transactionDate saved<br>";
     }
-
-    // Create a transaction object and then save it
-    $transaction = new transaction();
-    $transaction->set_value("currencyTypeID",config::get_config_item("currency"));
-    $transaction->set_value("fromTfID", $fromTfID);
-    $transaction->set_value("tfID", config::get_config_item("outTfID"));
-    $transaction->set_value("transactionDate", $transactionDate);
-    $transaction->set_value("amount", $amount);
-    $transaction->set_value("companyDetails", "");
-    $transaction->set_value("product", $account);
-    $transaction->set_value("status", "approved");
-    $transaction->set_value("quantity", 1);
-    $transaction->set_value("transactionType", "salary");
-    $transaction->save();
-
-    $msg.= "\$$amount for employee $employeeNum $name on $transactionDate saved<br>";
-  }
-  $TPL["msg"] = $msg;
+    $TPL["msg"] = $msg;
 }
 
 $TPL["main_alloc_title"] = "Upload Wages File - ".APPLICATION_NAME;
 include_template("templates/wagesUploadM.tpl");
-
-
-?>

--- a/help/getHelp.php
+++ b/help/getHelp.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,14 +23,10 @@
 require_once("../alloc.php");
 
 if ($_GET["topic"]) {
-  $topic = $_GET["topic"];
-  $TPL["str"] = @file_get_contents($TPL["url_alloc_help"].$topic.".html");
-
+    $topic = $_GET["topic"];
+    $TPL["str"] = @file_get_contents($TPL["url_alloc_help"].$topic.".html");
 } else {
-  $TPL["str"] = "No valid help topic specified.";
+    $TPL["str"] = "No valid help topic specified.";
 }
 
 include_template("templates/getHelpM.tpl");
-
-
-?>

--- a/help/help.php
+++ b/help/help.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -26,5 +26,3 @@ $TPL["alloc_version"] = get_alloc_version();
 $TPL["main_alloc_title"] = "Help - ".APPLICATION_NAME;
 
 include_template("templates/helpM.tpl");
-
-?>

--- a/home/config_top_ten_tasks.php
+++ b/home/config_top_ten_tasks.php
@@ -3,24 +3,24 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 $defaults = array("showHeader"=>true
@@ -33,8 +33,6 @@ $defaults = array("showHeader"=>true
 
 $_FORM = task::load_form_data($defaults);
 $arr = task::load_task_filter($_FORM);
-is_array($arr) and $TPL = array_merge($TPL,$arr);
+is_array($arr) and $TPL = array_merge($TPL, $arr);
 $TPL["showCancel"] = true;
 include_template("../task/templates/taskFilterS.tpl");
-
-?>

--- a/home/history.php
+++ b/home/history.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -28,21 +28,11 @@ global $TPL;
 $historyID = $_POST["historyID"] or $historyID = $_GET["historyID"];
 
 if ($historyID) {
-  if (is_numeric($historyID)) {
-    $db = new db_alloc();
-    $query = prepare("SELECT * FROM history WHERE historyID = %d", $historyID);
-    $db->query($query);
-    $db->next_record();
-    alloc_redirect($sess->url($TPL[$db->f("the_place")]."historyID=".$historyID).$db->f("the_args"));
-  }
+    if (is_numeric($historyID)) {
+        $db = new db_alloc();
+        $query = prepare("SELECT * FROM history WHERE historyID = %d", $historyID);
+        $db->query($query);
+        $db->next_record();
+        alloc_redirect($sess->url($TPL[$db->f("the_place")]."historyID=".$historyID).$db->f("the_args"));
+    }
 }
-
-
-
-
-
-
-
-
-
-?>

--- a/home/home.php
+++ b/home/home.php
@@ -3,76 +3,76 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function sort_home_items($a, $b) {
-  return $a->seq > $b->seq;
+function sort_home_items($a, $b)
+{
+    return $a->seq > $b->seq;
 }
 
-function show_home_items($width,$home_items) {
-  global $TPL;
-  $items = array();
+function show_home_items($width, $home_items)
+{
+    global $TPL;
+    $items = array();
 
-  foreach ($home_items as $item) {
-    $i = new $item();
-    $items[] = $i;
-  }
-
-  uasort($items,"sort_home_items");
-
-  foreach ((array)$items as $item) {
-    if ($item->width == $width && $item->visible()) {
-      $TPL["item"] = $item;
-      if ($item->render()) {
-        include_template("templates/homeItemS.tpl");
-      }
+    foreach ($home_items as $item) {
+        $i = new $item();
+        $items[] = $i;
     }
-  }
+
+    uasort($items, "sort_home_items");
+
+    foreach ((array)$items as $item) {
+        if ($item->width == $width && $item->visible()) {
+            $TPL["item"] = $item;
+            if ($item->render()) {
+                include_template("templates/homeItemS.tpl");
+            }
+        }
+    }
 }
 
 global $modules;
 $current_user = &singleton("current_user");
 foreach ($modules as $module_name => $module) {
-  if ($module->home_items) {
-    $home_items = array_merge((array)$home_items,$module->home_items);
-  }
+    if ($module->home_items) {
+        $home_items = array_merge((array)$home_items, $module->home_items);
+    }
 }
 $TPL["home_items"] = $home_items;
 
 if (isset($_POST["tsiHint_item"])) {
-  $t = tsiHint::parse_tsiHint_string($_POST["tsiHint_item"]);
-  if (is_numeric($t["duration"]) && $current_user->get_id()) {
-    $tsiHint = new tsiHint();
-    $tsi_row = $tsiHint->add_tsiHint($t);
-    alloc_redirect($TPL["url_alloc_home"]);
-  } else {
-    alloc_error("Time hint not added. No duration set.");
-    alloc_error(print_r($t,1));
-  }
+    $t = tsiHint::parse_tsiHint_string($_POST["tsiHint_item"]);
+    if (is_numeric($t["duration"]) && $current_user->get_id()) {
+        $tsiHint = new tsiHint();
+        $tsi_row = $tsiHint->add_tsiHint($t);
+        alloc_redirect($TPL["url_alloc_home"]);
+    } else {
+        alloc_error("Time hint not added. No duration set.");
+        alloc_error(print_r($t, 1));
+    }
 }
 
 $TPL["main_alloc_title"]="Home Page - ".APPLICATION_NAME;
 if ($_GET["media"] == "print") {
-	include_template("templates/homePrintableM.tpl");
+    include_template("templates/homePrintableM.tpl");
 } else {
-	include_template("templates/homeM.tpl");
+    include_template("templates/homeM.tpl");
 }
-
-?>

--- a/home/lib/home_item.inc.php
+++ b/home/lib/home_item.inc.php
@@ -3,86 +3,95 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class home_item {
-  var $name;
-  var $label;
-  var $module;
-  var $template;
-  var $library;
-  var $width = "standard";
-  var $help_topic;
-  var $seq;
-  var $print;
+class home_item
+{
+    var $name;
+    var $label;
+    var $module;
+    var $template;
+    var $library;
+    var $width = "standard";
+    var $help_topic;
+    var $seq;
+    var $print;
 
-  function __construct($name, $label, $module, $template, $width="standard",$seq=0, $print=true) {
-    $this->name = $name;
-    $this->label = $label;
-    $this->module = $module;
-    $this->template = $template;
-    $this->width = $width;
-    $this->seq = $seq;
-    $this->print = $print;
-  }
-
-  function get_template_dir() {
-    return ALLOC_MOD_DIR.$this->module."/templates/";
-  }
-
-  function get_seq() {
-    return $this->seq;
-  }
-
-  function show() {
-    global $TPL;
-    if ($this->template) {
-      //$TPL["this"] = $this;
-      $TPL[$this->module] = $this;
-      include_template($this->get_template_dir().$this->template);
-    }  
-  }
-
-  function visible() {
-    return true;
-  }
-
-  function render() {
-    return false;
-  }
-
-  function get_label() {
-    return $this->label;
-  }
-
-  function get_title() {
-    return $this->get_label();
-  }
-
-  function get_width() {
-    return $this->width;
-  }
-
-  function get_help() {
-    if ($this->help_topic) {
-      page::help($this->help_topic);
+    function __construct($name, $label, $module, $template, $width = "standard", $seq = 0, $print = true)
+    {
+        $this->name = $name;
+        $this->label = $label;
+        $this->module = $module;
+        $this->template = $template;
+        $this->width = $width;
+        $this->seq = $seq;
+        $this->print = $print;
     }
-  }
-}
 
-?>
+    function get_template_dir()
+    {
+        return ALLOC_MOD_DIR.$this->module."/templates/";
+    }
+
+    function get_seq()
+    {
+        return $this->seq;
+    }
+
+    function show()
+    {
+        global $TPL;
+        if ($this->template) {
+          //$TPL["this"] = $this;
+            $TPL[$this->module] = $this;
+            include_template($this->get_template_dir().$this->template);
+        }
+    }
+
+    function visible()
+    {
+        return true;
+    }
+
+    function render()
+    {
+        return false;
+    }
+
+    function get_label()
+    {
+        return $this->label;
+    }
+
+    function get_title()
+    {
+        return $this->get_label();
+    }
+
+    function get_width()
+    {
+        return $this->width;
+    }
+
+    function get_help()
+    {
+        if ($this->help_topic) {
+            page::help($this->help_topic);
+        }
+    }
+}

--- a/home/lib/init.php
+++ b/home/lib/init.php
@@ -3,26 +3,26 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class home_module extends module {
-  var $module = "home";
-  var $db_entities = array("history");
+class home_module extends module
+{
+    var $module = "home";
+    var $db_entities = array("history");
 }
-?>

--- a/index.php
+++ b/index.php
@@ -3,24 +3,22 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("./alloc.php");
 alloc_redirect($TPL["url_alloc_home"]);
-
-?>

--- a/installation/install.php
+++ b/installation/install.php
@@ -20,24 +20,26 @@
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("IN_INSTALL_RIGHT_NOW",1);
+define("IN_INSTALL_RIGHT_NOW", 1);
 require_once("../alloc.php");
 
-function errors_on() {
-  singleton("errors_fatal",true);
-  singleton("errors_format","text");
-  singleton("errors_logged",true);
-  singleton("errors_thrown",false);
-  singleton("errors_haltdb",true);
-  ini_set('display_errors',1);
+function errors_on()
+{
+    singleton("errors_fatal", true);
+    singleton("errors_format", "text");
+    singleton("errors_logged", true);
+    singleton("errors_thrown", false);
+    singleton("errors_haltdb", true);
+    ini_set('display_errors', 1);
 }
-function errors_off() {
-  singleton("errors_fatal",false);
-  singleton("errors_format","text");
-  singleton("errors_logged",false);
-  singleton("errors_thrown",false);
-  singleton("errors_haltdb",false);
-  ini_set("display_errors",0);
+function errors_off()
+{
+    singleton("errors_fatal", false);
+    singleton("errors_format", "text");
+    singleton("errors_logged", false);
+    singleton("errors_thrown", false);
+    singleton("errors_haltdb", false);
+    ini_set("display_errors", 0);
 }
 
 errors_on();
@@ -45,29 +47,34 @@ errors_on();
 $timeZone = @date_default_timezone_get();
 date_default_timezone_set($timeZone);
 
-define("IMG_TICK","<img src=\"".$TPL["url_alloc_images"]."tick.gif\" alt=\"Good\">");
-define("IMG_CROSS","<img src=\"".$TPL["url_alloc_images"]."cross.gif\" alt=\"Bad\">");
+define("IMG_TICK", "<img src=\"".$TPL["url_alloc_images"]."tick.gif\" alt=\"Good\">");
+define("IMG_CROSS", "<img src=\"".$TPL["url_alloc_images"]."cross.gif\" alt=\"Bad\">");
 $TPL["IMG_TICK"] = IMG_TICK;
 $TPL["IMG_CROSS"] = IMG_CROSS;
 
-function show_tab_1() {
-  $tab = $_GET["tab"] or $tab = $_POST["tab"];
-  return $tab == 1 || !$tab;
+function show_tab_1()
+{
+    $tab = $_GET["tab"] or $tab = $_POST["tab"];
+    return $tab == 1 || !$tab;
 }
-function show_tab_2() {
-  $tab = $_GET["tab"] or $tab = $_POST["tab"];
-  return $tab == 2 || $_POST["submit_stage_1"];
+function show_tab_2()
+{
+    $tab = $_GET["tab"] or $tab = $_POST["tab"];
+    return $tab == 2 || $_POST["submit_stage_1"];
 }
-function show_tab_3() {
-  $tab = $_GET["tab"] or $tab = $_POST["tab"];
-  return $tab == 3;
+function show_tab_3()
+{
+    $tab = $_GET["tab"] or $tab = $_POST["tab"];
+    return $tab == 3;
 }
-function show_tab_3b() {
-  return $_POST["test_db"];
+function show_tab_3b()
+{
+    return $_POST["test_db"];
 }
-function show_tab_4() {
-  $tab = $_GET["tab"] or $tab = $_POST["tab"];
-  return $tab == 4 && !$_POST["test_db"];
+function show_tab_4()
+{
+    $tab = $_GET["tab"] or $tab = $_POST["tab"];
+    return $tab == 4 && !$_POST["test_db"];
 }
 
 $server_user = getenv("APACHE_RUN_USER") or $server_user = "apache";
@@ -85,281 +92,278 @@ $config_vars = array("ALLOC_DB_NAME"     => array("default"=>"alloc",           
                     );
 
 
-foreach($config_vars as $name => $arr) {
-  $val = $_POST[$name] or $val = $_GET[$name];
-  $val == "" && !isset($_GET[$name]) && !isset($_POST[$name]) and $val = $arr["default"];
-  $name == "ATTACHMENTS_DIR" && $val and $val = rtrim($val,DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
-  $name == "allocURL" && $val and $val = rtrim($val,"/")."/";
-  $name == "currency" and $val = trim(strtoupper($val));
-  $_FORM[$name] = $val;
-  $get[] = $name."=".urlencode($val);
-  $hidden[] = "<input type='hidden' name='".$name."' value='".$val."'>";
-  $TPL[$name] = $val;
+foreach ($config_vars as $name => $arr) {
+    $val = $_POST[$name] or $val = $_GET[$name];
+    $val == "" && !isset($_GET[$name]) && !isset($_POST[$name]) and $val = $arr["default"];
+    $name == "ATTACHMENTS_DIR" && $val and $val = rtrim($val, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+    $name == "allocURL" && $val and $val = rtrim($val, "/")."/";
+    $name == "currency" and $val = trim(strtoupper($val));
+    $_FORM[$name] = $val;
+    $get[] = $name."=".urlencode($val);
+    $hidden[] = "<input type='hidden' name='".$name."' value='".$val."'>";
+    $TPL[$name] = $val;
 }
 $TPL["config_vars"] = $config_vars;
 $TPL["_FORM"] = $_FORM;
-$TPL["get"] = "&".implode("&",$get);
-$TPL["hidden"] = implode("\n",$hidden);
+$TPL["get"] = "&".implode("&", $get);
+$TPL["hidden"] = implode("\n", $hidden);
 
 
 if ($_POST["submit_stage_2"]) {
-
-  foreach($config_vars as $name => $arr) {
-    $val = $_POST[$name] or $val = $_GET[$name];
-    if (!$val) {
-      $text_tab_2a[] = "Missing a value for ".$arr["info"];
-      $failed = 1;
+    foreach ($config_vars as $name => $arr) {
+        $val = $_POST[$name] or $val = $_GET[$name];
+        if (!$val) {
+            $text_tab_2a[] = "Missing a value for ".$arr["info"];
+            $failed = 1;
+        }
     }
-  }
 
-  if (!is_dir($_FORM["ATTACHMENTS_DIR"])) {
-    $text_tab_2a[] = "This directory does not exist, please create it: ".$_FORM["ATTACHMENTS_DIR"];
-    $failed = 1;
-  }
-
-  if (!$failed && !is_writeable($_FORM["ATTACHMENTS_DIR"])) {
-    $text_tab_2a[] = "This directory is not writeable by the webserver: ".$_FORM["ATTACHMENTS_DIR"];
-    $failed = 1;
-  } else if (!$failed) {
-
-    // Create directories under attachment dir and chmod them
-    $dirs = $external_storage_directories; // something like array("task","client","project","invoice","comment","backups");
-    foreach ($dirs as $dir) {
-      $d = $_FORM["ATTACHMENTS_DIR"].$dir;
-      @mkdir($d,0777);
-      if (!is_dir($d)) {
-        $text_tab_2a[] = "<b>Unable to create directory: ".$d."</b>";
+    if (!is_dir($_FORM["ATTACHMENTS_DIR"])) {
+        $text_tab_2a[] = "This directory does not exist, please create it: ".$_FORM["ATTACHMENTS_DIR"];
         $failed = 1;
-      } else if (!is_writeable($d)) {
-        $text_tab_2a[] = "This directory is not writeable by the webserver: ".$d;
+    }
+
+    if (!$failed && !is_writeable($_FORM["ATTACHMENTS_DIR"])) {
+        $text_tab_2a[] = "This directory is not writeable by the webserver: ".$_FORM["ATTACHMENTS_DIR"];
         $failed = 1;
-      }
+    } else if (!$failed) {
+      // Create directories under attachment dir and chmod them
+        $dirs = $external_storage_directories; // something like array("task","client","project","invoice","comment","backups");
+        foreach ($dirs as $dir) {
+            $d = $_FORM["ATTACHMENTS_DIR"].$dir;
+            @mkdir($d, 0777);
+            if (!is_dir($d)) {
+                $text_tab_2a[] = "<b>Unable to create directory: ".$d."</b>";
+                $failed = 1;
+            } else if (!is_writeable($d)) {
+                $text_tab_2a[] = "This directory is not writeable by the webserver: ".$d;
+                $failed = 1;
+            }
+        }
     }
-  }
 
-  if (!$failed) {
-    // Create search indexes
-    $search_item_indexes = array("client", "comment", "item", "project", "task", "timeSheet", "wiki");
-    foreach ($search_item_indexes as $i) {
-      $index = Zend_Search_Lucene::create($_FORM["ATTACHMENTS_DIR"].'search'.DIRECTORY_SEPARATOR.$i);
-      $index->commit();
+    if (!$failed) {
+      // Create search indexes
+        $search_item_indexes = array("client", "comment", "item", "project", "task", "timeSheet", "wiki");
+        foreach ($search_item_indexes as $i) {
+            $index = Zend_Search_Lucene::create($_FORM["ATTACHMENTS_DIR"].'search'.DIRECTORY_SEPARATOR.$i);
+            $index->commit();
+        }
+
+        $query[] = sprintf("UPDATE config SET value = '%s' WHERE name = 'currency';", $_FORM["currency"]);
+        $query[] = sprintf("UPDATE currencyType SET currencyTypeActive = true, currencyTypeSeq = 1 WHERE currencyTypeID = '%s';", $_FORM["currency"]);
+        $query[] = sprintf("DELETE FROM exchangeRate;");
+        $query[] = sprintf("INSERT INTO exchangeRate (exchangeRateCreatedDate,exchangeRateCreatedTime,fromCurrency,toCurrency,exchangeRate) VALUES ('%s','%s','%s','%s',%d);", date("Y-m-d"), date("Y-m-d H:i:s"), $_FORM["currency"], $_FORM["currency"], 1);
+        $query[] = sprintf("UPDATE config SET value = '%s' WHERE name = 'allocURL';", $_FORM["allocURL"]);
+        $query[] = sprintf("UPDATE person SET password = '%s' WHERE personID = 1;", password_hash("alloc", PASSWORD_BCRYPT));
+        $query[] = sprintf("UPDATE config SET value = '%s' WHERE name = 'allocTimezone';", $timeZone);
+
+        file_put_contents($_FORM["ATTACHMENTS_DIR"]."db_config.sql", implode("\n", $query));
     }
 
-    $query[] = sprintf("UPDATE config SET value = '%s' WHERE name = 'currency';",$_FORM["currency"]);
-    $query[] = sprintf("UPDATE currencyType SET currencyTypeActive = true, currencyTypeSeq = 1 WHERE currencyTypeID = '%s';",$_FORM["currency"]);
-    $query[] = sprintf("DELETE FROM exchangeRate;");
-    $query[] = sprintf("INSERT INTO exchangeRate (exchangeRateCreatedDate,exchangeRateCreatedTime,fromCurrency,toCurrency,exchangeRate) VALUES ('%s','%s','%s','%s',%d);",date("Y-m-d"),date("Y-m-d H:i:s"),$_FORM["currency"],$_FORM["currency"],1);
-    $query[] = sprintf("UPDATE config SET value = '%s' WHERE name = 'allocURL';",$_FORM["allocURL"]);
-    $query[] = sprintf("UPDATE person SET password = '%s' WHERE personID = 1;",password_hash("alloc", PASSWORD_BCRYPT));
-    $query[] = sprintf("UPDATE config SET value = '%s' WHERE name = 'allocTimezone';",$timeZone);
-
-    file_put_contents($_FORM["ATTACHMENTS_DIR"]."db_config.sql",implode("\n",$query));
-  }
 
 
-
-  if ($failed) {
-    $TPL["img_install_result"] = IMG_CROSS;
-    $TPL["msg_install_result"] = "The allocPSA installation has encountered errors.";
-    $_GET["tab"] = 2;
-  } else {
-    define("INSTALL_SUCCESS",1);
-    $TPL["img_install_result"] = IMG_TICK;
-    $_GET["tab"] = 3;
-  }
-
+    if ($failed) {
+        $TPL["img_install_result"] = IMG_CROSS;
+        $TPL["msg_install_result"] = "The allocPSA installation has encountered errors.";
+        $_GET["tab"] = 2;
+    } else {
+        define("INSTALL_SUCCESS", 1);
+        $TPL["img_install_result"] = IMG_TICK;
+        $_GET["tab"] = 3;
+    }
 }
 
 
 if ($_POST["test_db"]) {
-  errors_off();
-  $db = new db($_FORM["ALLOC_DB_USER"],$_FORM["ALLOC_DB_PASS"],$_FORM["ALLOC_DB_HOST"],$_FORM["ALLOC_DB_NAME"]);
-  singleton("db",$db); // this makes db_esc() work as expected
+    errors_off();
+    $db = new db($_FORM["ALLOC_DB_USER"], $_FORM["ALLOC_DB_PASS"], $_FORM["ALLOC_DB_HOST"], $_FORM["ALLOC_DB_NAME"]);
+    singleton("db", $db); // this makes db_esc() work as expected
 
   // Test supplied credentials
-  if ($db->connect()) {
-    $text_tab_3b[] = "Connected to MySQL database server as user '".$_FORM["ALLOC_DB_USER"]."'.";
-  } else {
-    $text_tab_3b[] = "<b>Unable to connect to MySQL database server! (".$db->get_error().").</b>";
-    $failed = 1;
-  }
-
-  if (!$failed) {
-    if ($db->select_db($_FORM["ALLOC_DB_NAME"])) {
-      $text_tab_3b[] = "Connected to database '".$_FORM["ALLOC_DB_NAME"]."'.";
+    if ($db->connect()) {
+        $text_tab_3b[] = "Connected to MySQL database server as user '".$_FORM["ALLOC_DB_USER"]."'.";
     } else {
-      $text_tab_3b[] = "<b>Unable to select database '".$_FORM["ALLOC_DB_NAME"]."'. (".$db->get_error().").</b>";
-      $failed = 1;
+        $text_tab_3b[] = "<b>Unable to connect to MySQL database server! (".$db->get_error().").</b>";
+        $failed = 1;
     }
-  }
 
-  if (!$failed) {
-    $query = "CREATE TABLE IF NOT EXISTS test ( hey int );";
-    if ($db->query($query)) {
-      $text_tab_3b[] = "Created table 'test'.";
+    if (!$failed) {
+        if ($db->select_db($_FORM["ALLOC_DB_NAME"])) {
+            $text_tab_3b[] = "Connected to database '".$_FORM["ALLOC_DB_NAME"]."'.";
+        } else {
+            $text_tab_3b[] = "<b>Unable to select database '".$_FORM["ALLOC_DB_NAME"]."'. (".$db->get_error().").</b>";
+            $failed = 1;
+        }
+    }
+
+    if (!$failed) {
+        $query = "CREATE TABLE IF NOT EXISTS test ( hey int );";
+        if ($db->query($query)) {
+            $text_tab_3b[] = "Created table 'test'.";
+        } else {
+            $text_tab_3b[] = "<b>Unable to create table 'test'! (".$db->get_error().").</b>";
+            $failed = 1;
+        }
+    }
+
+    if (!$failed) {
+        $query = "DROP TABLE test;";
+        if ($db->query($query)) {
+            $text_tab_3b[] = "Deleted table 'test'.";
+        } else {
+            $text_tab_3b[] = "<b>Unable to delete table 'test'! (".$db->get_error().").</b>";
+            $failed = 1;
+        }
+    }
+
+    if (!$failed) {
+        $db->query("SHOW TABLES LIKE 'config'");
+        if ($db->row()) {
+            $text_tab_3b[] = "Config table exists.";
+        } else {
+            $text_tab_3b[] = "<b>Unable to find config table! Have you imported db_structure.sql as directed above?.</b>";
+            $failed = 1;
+        }
+    }
+
+    if (!$failed) {
+        $query = "SHOW TABLES";
+        if ($db->query($query)) {
+            $num_tables = $db->num_rows();
+        }
+    }
+
+    if (!$failed) {
+        $query = "SELECT * FROM config WHERE name='install_data'";
+        $db->query($query);
+        if ($row = $db->row()) {
+            $install_data = unserialize($row["value"]);
+        } else {
+            $text_tab_3b[] = "<b>Can't get install_data from config table. Have you imported db_patches.sql as directed above?</b>";
+            $failed = 1;
+        }
+    }
+
+    if (!$failed) {
+        if ($install_data["num_tables"] == $num_tables) {
+            $text_tab_3b[] = "Checked db_structure.sql (".$num_tables." out of ".$install_data["num_tables"]." tables).";
+        } else {
+            $text_tab_3b[] = "<b>Not all tables imported (".$num_tables." out of ".$install_data["num_tables"]."). Try re-importing db_structure.sql.</b>";
+            $failed = 1;
+        }
+    }
+
+    if (!$failed) {
+        $query = "SELECT * FROM announcement;";
+        $db->query($query);
+        if ($row = $db->row()) {
+            $text_tab_3b[] = "Checked db_data.sql.";
+        } else {
+            $text_tab_3b[] = "<b>Missing the final INSERT from db_data.sql. Have you imported db_data.sql as directed above?</b>";
+            $failed = 1;
+        }
+    }
+
+    if (!$failed) {
+        $query = "SELECT * FROM patchLog;";
+        $db->query($query);
+        if ($row = $db->row()) {
+            $text_tab_3b[] = "Checked db_patches.sql.";
+        } else {
+            $text_tab_3b[] = "<b>Missing the patchLog patches. Have you imported db_patches.sql as directed above?</b>";
+            $failed = 1;
+        }
+    }
+
+    if (!$failed) {
+      // one way to test the constraints is by trying to break them
+        $query = "DELETE FROM tfPerson WHERE tfID = 321321 AND personID = 374921;";
+        $db->query($query);
+        $query = "INSERT INTO tfPerson (tfID,personID) VALUES (321321,374921);";
+        if ($db->query($query)) {
+            $text_tab_3b[] = "<b>Missing constraints. Have you imported db_constraints.sql as directed above?</b>";
+            $failed = 1;
+        } else {
+            $text_tab_3b[] = "Checked db_constraints.sql.";
+        }
+        $query = "DELETE FROM tfPerson WHERE tfID = 321321 AND personID = 374921;";
+        $db->query($query);
+    }
+
+
+    if (!$failed) {
+        $db->query("SHOW FUNCTION STATUS where Db = '%s' AND Name = 'neq'", $_FORM["ALLOC_DB_NAME"]);
+        if ($db->row()) {
+            $text_tab_3b[] = "Checked db_triggers.sql.";
+        } else {
+            $text_tab_3b[] = "<b>Can't use a UDF. Have you imported db_triggers.sql as the db admin/root user, as directed above?</b>";
+            $failed = 1;
+        }
+    }
+
+    if (!$failed) {
+        $query = "SELECT password FROM person WHERE personID = 1;";
+        $row = $db->qr($query);
+        if ($row["password"]) {
+            $text_tab_3b[] = "Checked db_config.sql.";
+        } else {
+            $text_tab_3b[] = "<b>No user password in person table. Have you imported db_config.sql as directed above?</b>";
+            $failed = 1;
+        }
+    }
+
+
+    if ($failed) {
+        $TPL["img_test_db_result"] = IMG_CROSS;
+        $TPL["msg_test_db_result"] = "Database test unsuccessful!";
     } else {
-      $text_tab_3b[] = "<b>Unable to create table 'test'! (".$db->get_error().").</b>";
-      $failed = 1;
+        $TPL["img_test_db_result"] = IMG_TICK;
+        $TPL["msg_test_db_result"] = "Database test successful.";
     }
-  }
 
-  if (!$failed) {
-    $query = "DROP TABLE test;";
-    if ($db->query($query)) {
-      $text_tab_3b[] = "Deleted table 'test'.";
-    } else {
-      $text_tab_3b[] = "<b>Unable to delete table 'test'! (".$db->get_error().").</b>";
-      $failed = 1;
-    }
-  }
-
-  if (!$failed) {
-    $db->query("SHOW TABLES LIKE 'config'");
-    if ($db->row()) {
-      $text_tab_3b[] = "Config table exists.";
-    } else {
-      $text_tab_3b[] = "<b>Unable to find config table! Have you imported db_structure.sql as directed above?.</b>";
-      $failed = 1;
-    }
-  }
-
-  if (!$failed) {
-    $query = "SHOW TABLES";
-    if ($db->query($query)) {
-      $num_tables = $db->num_rows();
-    }
-  }
-
-  if (!$failed) {
-    $query = "SELECT * FROM config WHERE name='install_data'";
-    $db->query($query);
-    if ($row = $db->row()) {
-      $install_data = unserialize($row["value"]);
-    } else {
-      $text_tab_3b[] = "<b>Can't get install_data from config table. Have you imported db_patches.sql as directed above?</b>";
-      $failed = 1;
-    }
-  }
-
-  if (!$failed) {
-    if ($install_data["num_tables"] == $num_tables) {
-      $text_tab_3b[] = "Checked db_structure.sql (".$num_tables." out of ".$install_data["num_tables"]." tables).";
-    } else {
-      $text_tab_3b[] = "<b>Not all tables imported (".$num_tables." out of ".$install_data["num_tables"]."). Try re-importing db_structure.sql.</b>";
-      $failed = 1;
-    }
-  }
-
-  if (!$failed) {
-    $query = "SELECT * FROM announcement;";
-    $db->query($query);
-    if ($row = $db->row()) {
-      $text_tab_3b[] = "Checked db_data.sql.";
-    } else {
-      $text_tab_3b[] = "<b>Missing the final INSERT from db_data.sql. Have you imported db_data.sql as directed above?</b>";
-      $failed = 1;
-    }
-  }
-
-  if (!$failed) {
-    $query = "SELECT * FROM patchLog;";
-    $db->query($query);
-    if ($row = $db->row()) {
-      $text_tab_3b[] = "Checked db_patches.sql.";
-    } else {
-      $text_tab_3b[] = "<b>Missing the patchLog patches. Have you imported db_patches.sql as directed above?</b>";
-      $failed = 1;
-    }
-  }
-
-  if (!$failed) {
-    // one way to test the constraints is by trying to break them
-    $query = "DELETE FROM tfPerson WHERE tfID = 321321 AND personID = 374921;";
-    $db->query($query);
-    $query = "INSERT INTO tfPerson (tfID,personID) VALUES (321321,374921);";
-    if ($db->query($query)) {
-      $text_tab_3b[] = "<b>Missing constraints. Have you imported db_constraints.sql as directed above?</b>";
-      $failed = 1;
-    } else {
-      $text_tab_3b[] = "Checked db_constraints.sql.";
-    }
-    $query = "DELETE FROM tfPerson WHERE tfID = 321321 AND personID = 374921;";
-    $db->query($query);
-  }
-
-
-  if (!$failed) {
-    $db->query("SHOW FUNCTION STATUS where Db = '%s' AND Name = 'neq'",$_FORM["ALLOC_DB_NAME"]);
-    if ($db->row()) {
-      $text_tab_3b[] = "Checked db_triggers.sql.";
-    } else {
-      $text_tab_3b[] = "<b>Can't use a UDF. Have you imported db_triggers.sql as the db admin/root user, as directed above?</b>";
-      $failed = 1;
-    }
-  }
-
-  if (!$failed) {
-    $query = "SELECT password FROM person WHERE personID = 1;";
-    $row = $db->qr($query);
-    if ($row["password"]) {
-      $text_tab_3b[] = "Checked db_config.sql.";
-    } else {
-      $text_tab_3b[] = "<b>No user password in person table. Have you imported db_config.sql as directed above?</b>";
-      $failed = 1;
-    }
-  }
-
-
-  if ($failed) {
-    $TPL["img_test_db_result"] = IMG_CROSS;
-    $TPL["msg_test_db_result"] = "Database test unsuccessful!";
-  } else {
-    $TPL["img_test_db_result"] = IMG_TICK;
-    $TPL["msg_test_db_result"] = "Database test successful.";
-  }
-
-  $_GET["tab"] = 3;
+    $_GET["tab"] = 3;
 }
 
 // Tab 2 Text
 if ($_FORM["ALLOC_DB_NAME"] && $_FORM["ALLOC_DB_USER"]) {
-  $text_tab_3[] = "&nbsp;";
-  $text_tab_3[] = "DROP DATABASE IF EXISTS ".$_FORM["ALLOC_DB_NAME"].";";
-  $text_tab_3[] = "CREATE DATABASE ".$_FORM["ALLOC_DB_NAME"].";";
+    $text_tab_3[] = "&nbsp;";
+    $text_tab_3[] = "DROP DATABASE IF EXISTS ".$_FORM["ALLOC_DB_NAME"].";";
+    $text_tab_3[] = "CREATE DATABASE ".$_FORM["ALLOC_DB_NAME"].";";
 
-  if ($_FORM["ALLOC_DB_USER"] != 'root') {
-    // grant all on alloc14.* to 'heydiddle'@'localhost' IDENTIFIED BY 'hey';
+    if ($_FORM["ALLOC_DB_USER"] != 'root') {
+      // grant all on alloc14.* to 'heydiddle'@'localhost' IDENTIFIED BY 'hey';
+        $text_tab_3[] = "";
+        $text_tab_3[] = "GRANT ALL ON ".$_FORM["ALLOC_DB_NAME"].".* TO '".$_FORM["ALLOC_DB_USER"]."'@'".$_FORM["ALLOC_DB_HOST"]."' IDENTIFIED BY '".$_FORM["ALLOC_DB_PASS"]."';";
+    }
+
+    $text_tab_3[] = "FLUSH PRIVILEGES;";
     $text_tab_3[] = "";
-    $text_tab_3[] = "GRANT ALL ON ".$_FORM["ALLOC_DB_NAME"].".* TO '".$_FORM["ALLOC_DB_USER"]."'@'".$_FORM["ALLOC_DB_HOST"]."' IDENTIFIED BY '".$_FORM["ALLOC_DB_PASS"]."';";
-  }
-
-  $text_tab_3[] = "FLUSH PRIVILEGES;";
-  $text_tab_3[] = "";
-  $text_tab_3[] = "USE ".$_FORM["ALLOC_DB_NAME"].";";
-  $text_tab_3[] = "";
-  $text_tab_3[] = "SOURCE ".dirname(__FILE__).DIRECTORY_SEPARATOR."db_structure.sql;";
-  $text_tab_3[] = "SOURCE ".dirname(__FILE__).DIRECTORY_SEPARATOR."db_patches.sql;";
-  $text_tab_3[] = "SOURCE ".dirname(__FILE__).DIRECTORY_SEPARATOR."db_data.sql;";
-  $text_tab_3[] = "SOURCE ".dirname(__FILE__).DIRECTORY_SEPARATOR."db_constraints.sql;";
-  $text_tab_3[] = "SOURCE ".dirname(__FILE__).DIRECTORY_SEPARATOR."db_triggers.sql;";
-  $text_tab_3[] = "";
-  $text_tab_3[] = "SOURCE ".$_FORM["ATTACHMENTS_DIR"]."db_config.sql;";
-  $text_tab_3[] = "&nbsp;";
+    $text_tab_3[] = "USE ".$_FORM["ALLOC_DB_NAME"].";";
+    $text_tab_3[] = "";
+    $text_tab_3[] = "SOURCE ".dirname(__FILE__).DIRECTORY_SEPARATOR."db_structure.sql;";
+    $text_tab_3[] = "SOURCE ".dirname(__FILE__).DIRECTORY_SEPARATOR."db_patches.sql;";
+    $text_tab_3[] = "SOURCE ".dirname(__FILE__).DIRECTORY_SEPARATOR."db_data.sql;";
+    $text_tab_3[] = "SOURCE ".dirname(__FILE__).DIRECTORY_SEPARATOR."db_constraints.sql;";
+    $text_tab_3[] = "SOURCE ".dirname(__FILE__).DIRECTORY_SEPARATOR."db_triggers.sql;";
+    $text_tab_3[] = "";
+    $text_tab_3[] = "SOURCE ".$_FORM["ATTACHMENTS_DIR"]."db_config.sql;";
+    $text_tab_3[] = "&nbsp;";
 }
 
 
 // Tab 1 Text
 foreach ($config_vars as $name => $arr) {
-  $text_tab_1[] = "<tr><td>".$arr["info"]."</td><td><input type='text' name='".$name."' size='30' value='".$_FORM[$name]."'></td></tr>";
+    $text_tab_1[] = "<tr><td>".$arr["info"]."</td><td><input type='text' name='".$name."' size='30' value='".$_FORM[$name]."'></td></tr>";
 }
 
 
-is_array($text_tab_1) and $TPL["text_tab_1"] = implode("\n",$text_tab_1);
-is_array($text_tab_2a) and $TPL["text_tab_2a"] = implode("<br>",$text_tab_2a);
-is_array($text_tab_2b) and $TPL["text_tab_2b"] = implode("<br>",$text_tab_2b);
-is_array($text_tab_3) and $TPL["text_tab_3"] = implode("\n",$text_tab_3);
-is_array($text_tab_3b) and $TPL["text_tab_3b"] = implode("<br>",$text_tab_3b);
-is_array($text_tab_4) and $TPL["text_tab_4"] = implode("<br>",$text_tab_4);
+is_array($text_tab_1) and $TPL["text_tab_1"] = implode("\n", $text_tab_1);
+is_array($text_tab_2a) and $TPL["text_tab_2a"] = implode("<br>", $text_tab_2a);
+is_array($text_tab_2b) and $TPL["text_tab_2b"] = implode("<br>", $text_tab_2b);
+is_array($text_tab_3) and $TPL["text_tab_3"] = implode("\n", $text_tab_3);
+is_array($text_tab_3b) and $TPL["text_tab_3b"] = implode("<br>", $text_tab_3b);
+is_array($text_tab_4) and $TPL["text_tab_4"] = implode("<br>", $text_tab_4);
 
 
 $tab = $_GET["tab"] or $tab = $_POST["tab"] or $tab = $_FORM["tab"];
@@ -370,5 +374,3 @@ $tab == 4 and $TPL["tab4"] = " active";
 
 
 include_template("templates/install.tpl");
-
-?>

--- a/installation/lib/init.php
+++ b/installation/lib/init.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -24,127 +24,117 @@
 // Path to alloc_config.php
 $ALLOC_CONFIG_PATH = $_POST["ALLOC_CONFIG_PATH"] or $ALLOC_CONFIG_PATH = $_GET["ALLOC_CONFIG_PATH"];
 if ($ALLOC_CONFIG_PATH) {
-  define("ALLOC_CONFIG_PATH",$ALLOC_CONFIG_PATH);
+    define("ALLOC_CONFIG_PATH", $ALLOC_CONFIG_PATH);
 } else {
-  define("ALLOC_CONFIG_PATH", realpath(dirname(__FILE__)."/../..")."/alloc_config.php");
-} 
+    define("ALLOC_CONFIG_PATH", realpath(dirname(__FILE__)."/../..")."/alloc_config.php");
+}
 unset($ALLOC_CONFIG_PATH);
 
 
 
-class installation_module extends module {
-  var $module = "installation";
+class installation_module extends module
+{
+    var $module = "installation";
 }
 
-function get_patch_file_list() {
-  $dir = ALLOC_MOD_DIR."patches/";
-  $files = array();
-  if (is_dir($dir)) {
-    $dh = opendir($dir);
-    if ($dh) {
-      while (($file = readdir($dh)) !== false) {
-        if (filetype($dir.$file) == "file" && substr($file,0,1) != ".") {
-          $files[] = $file;
+function get_patch_file_list()
+{
+    $dir = ALLOC_MOD_DIR."patches/";
+    $files = array();
+    if (is_dir($dir)) {
+        $dh = opendir($dir);
+        if ($dh) {
+            while (($file = readdir($dh)) !== false) {
+                if (filetype($dir.$file) == "file" && substr($file, 0, 1) != ".") {
+                    $files[] = $file;
+                }
+            }
+            closedir($dh);
         }
-      }
-      closedir($dh);
+
+      #// Sort files in natural counting order file8 fil9 fil10
+      #natsort($files);
+      // filenames no longer require natsort
+        sort($files);
+      // Order the indexes too
+        $files = array_values($files);
+    }
+    return $files;
+}
+
+function get_applied_patches()
+{
+    $rows = array();
+    $db = new db_alloc();
+    $db->query("SELECT patchName FROM patchLog ORDER BY patchDate DESC,patchName DESC");
+    while ($row = $db->row()) {
+        $rows[] = $row["patchName"];
+    }
+    return $rows;
+}
+
+function perform_test($test)
+{
+    global $_FORM;
+    $arr = array();
+    $extensions = get_loaded_extensions();
+
+    switch ($test) {
+        case "php_mbstring":
+            $arr["value"] = defined("MB_OVERLOAD_MAIL") ? "Enabled" : "";
+            $arr["value"] or $arr["remedy"] = "Your installation of PHP does not have the mbstring extension.";
+            break;
+        case "php_version":
+            $arr["value"] = phpversion();
+            if (!version_compare(phpversion(), "5.4", ">=")) {
+                $arr["remedy"] = "Some functionality may not work correctly with your version of PHP. It is recommended that you upgrade.";
+            }
+            break;
+        case "php_memory":
+            $arr["value"] = get_cfg_var("memory_limit");
+            if (str_replace(array("m","M"), "", $arr["value"]) < 32) {
+                $arr["remedy"] = "Your installation of PHP may not have enough memory enabled. It is recommended to change the memory limit in the PHP config file: ".get_cfg_var("cfg_file_path");
+            }
+            break;
+        case "php_gd":
+            if (function_exists("gd_info")) {
+                $gd_info = gd_info();
+            } else {
+                $gd_info = array();
+            }
+            $arr["value"] = $gd_info["GD Version"];
+            if (!in_array("gd", $extensions)) {
+                $arr["remedy"] = "Your installation of PHP does not have the GD extension. It is recommended to install GD.";
+            }
+            break;
+        case "php_pdo":
+            $arr["value"] = "Enabled";
+            if (!extension_loaded('pdo')) {
+                $arr["value"] = "";
+                $arr["remedy"] = "Your installation of PHP does not have the PDO database extension.";
+            }
+            break;
+        case "mail_exists":
+            $arr["value"] = "mail()";
+            if (!function_exists("mail")) {
+                $arr["remedy"] = "Your installation of PHP does not have the mail() function. allocPSA may not be able to send out emails.";
+            }
+            break;
+
+        case "attachments_dir":
+            $arr["value"] = $_FORM["ATTACHMENTS_DIR"];
+            if ($_FORM["ATTACHMENTS_DIR"] == "" || !is_dir($_FORM["ATTACHMENTS_DIR"]) || !is_writeable($_FORM["ATTACHMENTS_DIR"])) {
+                $arr["remedy"] = "The directory specified for file uploads is either not defined or not writeable by the webserver process. Run:";
+                $arr["remedy"].= "<br>mkdir ".$_FORM["ATTACHMENTS_DIR"];
+                $arr["remedy"].= "<br>chmod a+w ".$_FORM["ATTACHMENTS_DIR"];
+            }
+            break;
     }
 
-    #// Sort files in natural counting order file8 fil9 fil10
-    #natsort($files);
-    // filenames no longer require natsort
-    sort($files);
-    // Order the indexes too
-    $files = array_values($files);
-  }
-  return $files;
+    $arr["status"] = IMG_TICK;
+    $arr["remedy"] and $arr["status"] = IMG_CROSS;
+    $arr["remedy"] or $arr["remedy"] = "Ok.";
+
+
+    return $arr;
 }
-
-function get_applied_patches() {
-  $rows = array();
-  $db = new db_alloc();
-  $db->query("SELECT patchName FROM patchLog ORDER BY patchDate DESC,patchName DESC");
-  while ($row = $db->row()) {
-    $rows[] = $row["patchName"];
-  }
-  return $rows;
-}
-
-function perform_test($test) {
-  global $_FORM;
-  $arr = array();
-  $extensions = get_loaded_extensions();
-
-  switch ($test) {
-    case "php_mbstring":
-      $arr["value"] = defined("MB_OVERLOAD_MAIL") ? "Enabled" : "";
-      $arr["value"] or $arr["remedy"] = "Your installation of PHP does not have the mbstring extension.";
-    break;
-    case "php_version":
-      $arr["value"] = phpversion();
-      if (!version_compare(phpversion(), "5.4", ">=")) {
-        $arr["remedy"] = "Some functionality may not work correctly with your version of PHP. It is recommended that you upgrade.";
-      }
-    break;
-    case "php_memory":
-      $arr["value"] = get_cfg_var("memory_limit");
-      if (str_replace(array("m","M"),"",$arr["value"]) < 32) {
-        $arr["remedy"] = "Your installation of PHP may not have enough memory enabled. It is recommended to change the memory limit in the PHP config file: ".get_cfg_var("cfg_file_path");
-      }
-    break;
-    case "php_gd":
-      if (function_exists("gd_info")) {
-        $gd_info = gd_info();
-      } else {
-        $gd_info = array();
-      }
-      $arr["value"] = $gd_info["GD Version"];
-      if (!in_array("gd",$extensions)) {
-        $arr["remedy"] = "Your installation of PHP does not have the GD extension. It is recommended to install GD.";
-      }
-    break;
-    case "php_pdo":
-      $arr["value"] = "Enabled";
-      if (!extension_loaded('pdo')) {
-        $arr["value"] = "";
-        $arr["remedy"] = "Your installation of PHP does not have the PDO database extension.";
-      }
-    break;
-    case "mail_exists":
-      $arr["value"] = "mail()";
-      if (!function_exists("mail")) {
-        $arr["remedy"] = "Your installation of PHP does not have the mail() function. allocPSA may not be able to send out emails.";
-      }
-    break;
-
-    case "attachments_dir":
-      $arr["value"] = $_FORM["ATTACHMENTS_DIR"];
-      if ($_FORM["ATTACHMENTS_DIR"] == "" || !is_dir($_FORM["ATTACHMENTS_DIR"]) || !is_writeable($_FORM["ATTACHMENTS_DIR"])) {
-        $arr["remedy"] = "The directory specified for file uploads is either not defined or not writeable by the webserver process. Run:";
-        $arr["remedy"].= "<br>mkdir ".$_FORM["ATTACHMENTS_DIR"];
-        $arr["remedy"].= "<br>chmod a+w ".$_FORM["ATTACHMENTS_DIR"];
-      }
-    break;
-  }
-
-  $arr["status"] = IMG_TICK;
-  $arr["remedy"] and $arr["status"] = IMG_CROSS;
-  $arr["remedy"] or $arr["remedy"] = "Ok.";
-
-
-  return $arr;
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-?>

--- a/installation/patch.php
+++ b/installation/patch.php
@@ -3,83 +3,83 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_AUTH",1);
-define("IS_GOD",true);
+define("NO_AUTH", 1);
+define("IS_GOD", true);
 require_once("../alloc.php");
 
-function apply_patch($f) {
-  global $TPL;
-  static $files;
-  // Should never attempt to apply the same patch twice.. in case 
+function apply_patch($f)
+{
+    global $TPL;
+    static $files;
+  // Should never attempt to apply the same patch twice.. in case
   // there are function declarations in the .php patches.
-  if ($files[$f]) {
-    return;
-  }
-  $files[$f] = true;
-  $db = new db_alloc();
-  $file = basename($f);
-  $failed = false;
-  $comments = array();
+    if ($files[$f]) {
+        return;
+    }
+    $files[$f] = true;
+    $db = new db_alloc();
+    $file = basename($f);
+    $failed = false;
+    $comments = array();
 
 
   // This is an important patch that converts money from 120.34 to 12034.
   // We MUST ensure that the user has a currency set before applying this patch.
-  if ($file == "patch-00188-alla.sql") {
-    if (!config::get_config_item('currency')) {
-      alloc_error("No default currency is set! Login to alloc (ignore any errors, you may need to manually change the url to config/config.php after logging in) go to Setup -> Finance and select a Main Currency. And then click the 'Update Transactions That Have No Currency' button. Then return here and apply this patch (patch-188). IT IS REALLY IMPORTANT THAT YOU FOLLOW THESE INSTRUCTIONS as the storage format for monetary amounts has changed.",true);
+    if ($file == "patch-00188-alla.sql") {
+        if (!config::get_config_item('currency')) {
+            alloc_error("No default currency is set! Login to alloc (ignore any errors, you may need to manually change the url to config/config.php after logging in) go to Setup -> Finance and select a Main Currency. And then click the 'Update Transactions That Have No Currency' button. Then return here and apply this patch (patch-188). IT IS REALLY IMPORTANT THAT YOU FOLLOW THESE INSTRUCTIONS as the storage format for monetary amounts has changed.", true);
+        }
     }
-  }
 
 
   // Try for sql file
-  if (strtolower(substr($file,-4)) == ".sql") {
+    if (strtolower(substr($file, -4)) == ".sql") {
+        list($sql,$comments) = parse_sql_file($f);
+        foreach ($sql as $query) {
+            if (!$db->query($query)) {
+                #$TPL["message"][] = "<b style=\"color:red\">Error:</b> ".$f."<br>".$db->get_error();
+                $failed = true;
+                alloc_error("<b style=\"color:red\">Error:</b> ".$f."<br>".$db->get_error());
+            }
+        }
+        if (!$failed) {
+            $TPL["message_good"][] = "Successfully Applied: ".$f;
+        }
 
-    list($sql,$comments) = parse_sql_file($f);
-    foreach ($sql as $query) {
-      if (!$db->query($query)) {
-        #$TPL["message"][] = "<b style=\"color:red\">Error:</b> ".$f."<br>".$db->get_error();
-        $failed = true;
-        alloc_error("<b style=\"color:red\">Error:</b> ".$f."<br>".$db->get_error());
-      }
+    // Try for php file
+    } else if (strtolower(substr($file, -4)) == ".php") {
+        $str = execute_php_file("../patches/".$file);
+        if ($str && !defined("FORCE_PATCH_SUCCEED_".$file)) {
+          #$TPL["message"][] = "<b style=\"color:red\">Error:</b> ".$f."<br>".$str;
+            $failed = true;
+            ob_end_clean();
+            alloc_error("<b style=\"color:red\">Error:</b> ".$f."<br>".$str);
+        } else {
+            $TPL["message_good"][] = "Successfully Applied: ".$f;
+        }
     }
     if (!$failed) {
-      $TPL["message_good"][] = "Successfully Applied: ".$f;
+        $q = prepare("INSERT INTO patchLog (patchName, patchDesc, patchDate) 
+                  VALUES ('%s','%s','%s')", $file, implode(" ", $comments), date("Y-m-d H:i:s"));
+        $db->query($q);
     }
-
-  // Try for php file
-  } else if (strtolower(substr($file,-4)) == ".php") {
-    $str = execute_php_file("../patches/".$file);
-    if ($str && !defined("FORCE_PATCH_SUCCEED_".$file)) {
-      #$TPL["message"][] = "<b style=\"color:red\">Error:</b> ".$f."<br>".$str;
-      $failed = true;
-      ob_end_clean();
-      alloc_error("<b style=\"color:red\">Error:</b> ".$f."<br>".$str);
-    } else {
-      $TPL["message_good"][] = "Successfully Applied: ".$f;
-    }
-  }
-  if (!$failed) {
-    $q = prepare("INSERT INTO patchLog (patchName, patchDesc, patchDate) 
-                  VALUES ('%s','%s','%s')",$file, implode(" ",$comments), date("Y-m-d H:i:s"));
-    $db->query($q);
-  }
 }
 
 // Get list of patch files in order
@@ -90,49 +90,47 @@ $abc123_applied_patches = get_applied_patches();
 
 
 // Hack to update everyones patch tree
-if (!in_array("patch-00053-alla.php",$abc123_applied_patches)) {
-  apply_patch(ALLOC_MOD_DIR."patches/patch-00053-alla.php");
+if (!in_array("patch-00053-alla.php", $abc123_applied_patches)) {
+    apply_patch(ALLOC_MOD_DIR."patches/patch-00053-alla.php");
 }
 
 
 // Apply all patches
 if ($_REQUEST["apply_patches"]) {
-  foreach ($abc123_files as $abc123_file) {
-    $abc123_f = ALLOC_MOD_DIR."patches/".$abc123_file;
-    if (!in_array($abc123_file,$abc123_applied_patches)) {
-      apply_patch($abc123_f);
+    foreach ($abc123_files as $abc123_file) {
+        $abc123_f = ALLOC_MOD_DIR."patches/".$abc123_file;
+        if (!in_array($abc123_file, $abc123_applied_patches)) {
+            apply_patch($abc123_f);
+        }
     }
-  }
 
 // Apply a single patch
 } else if ($_REQUEST["apply_patch"] && $_REQUEST["patch_file"]) {
-  $abc123_f = ALLOC_MOD_DIR."patches/".$_REQUEST["patch_file"];
-  if (!in_array($abc123_file,$abc123_applied_patches)) {
-    apply_patch($abc123_f);
-  }
+    $abc123_f = ALLOC_MOD_DIR."patches/".$_REQUEST["patch_file"];
+    if (!in_array($abc123_file, $abc123_applied_patches)) {
+        apply_patch($abc123_f);
+    }
 } else if ($_REQUEST["remove_patch"] && $_REQUEST["patch_file"]) {
-  $abc123_f = ALLOC_MOD_DIR."patches/".$_REQUEST["patch_file"];
-  $q = prepare("INSERT INTO patchLog (patchName, patchDesc, patchDate) 
-                VALUES ('%s','%s','%s')",$_REQUEST["patch_file"], "Patch not applied.", date("Y-m-d H:i:s"));
-  $db = new db_alloc();
-  $db->query($q);
+    $abc123_f = ALLOC_MOD_DIR."patches/".$_REQUEST["patch_file"];
+    $q = prepare("INSERT INTO patchLog (patchName, patchDesc, patchDate) 
+                VALUES ('%s','%s','%s')", $_REQUEST["patch_file"], "Patch not applied.", date("Y-m-d H:i:s"));
+    $db = new db_alloc();
+    $db->query($q);
 }
 
 
 
 $abc123_applied_patches = get_applied_patches();
 foreach ($abc123_files as $abc123_file) {
-  if (!in_array($abc123_file,$abc123_applied_patches)) {
-    $abc123_incomplete = true;
-  }
+    if (!in_array($abc123_file, $abc123_applied_patches)) {
+        $abc123_incomplete = true;
+    }
 }
 
 
 if (!$abc123_incomplete) {
-  alloc_redirect($TPL["url_alloc_login"]);
-} 
+    alloc_redirect($TPL["url_alloc_login"]);
+}
 
 
 include_template("templates/patch.tpl");
-
-?>

--- a/installation/patch_1_2_256_to_1_3_497.php
+++ b/installation/patch_1_2_256_to_1_3_497.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -37,60 +37,59 @@ define("ALLOC_CONFIG_PATH", realpath(dirname(__FILE__)."/..")."/alloc_config.php
 
 
 // Use action flags to specify which actions should be taken.
-define("ACTION_RM_ALLOC_INC"                       ,1);
-define("ACTION_CREATE_ALLOC_CONFIG"                ,2);
-define("ACTION_MV_PROJECTS_DIR"                    ,3);
-define("ACTION_MV_CLIENTS_DIR"                     ,4);
-define("ACTION_MV_TASKS_DIR"                       ,5);
-define("ACTION_ERR_ATTACHMENTS_DIR_NOT_DEFINED"    ,6);
-define("ACTION_ERR_ATTACHMENTS_DIR_NOT_DIR"        ,7);
-define("ACTION_ERR_ATTACHMENTS_DIR_NOT_WRITEABLE"  ,8);
-define("ACTION_FIX_DB_USER_PERMS"                  ,9);
-define("ACTION_CREATE_TABLE_PATCHLOG"              ,10);
+define("ACTION_RM_ALLOC_INC", 1);
+define("ACTION_CREATE_ALLOC_CONFIG", 2);
+define("ACTION_MV_PROJECTS_DIR", 3);
+define("ACTION_MV_CLIENTS_DIR", 4);
+define("ACTION_MV_TASKS_DIR", 5);
+define("ACTION_ERR_ATTACHMENTS_DIR_NOT_DEFINED", 6);
+define("ACTION_ERR_ATTACHMENTS_DIR_NOT_DIR", 7);
+define("ACTION_ERR_ATTACHMENTS_DIR_NOT_WRITEABLE", 8);
+define("ACTION_FIX_DB_USER_PERMS", 9);
+define("ACTION_CREATE_TABLE_PATCHLOG", 10);
 
 
 // Get include_path. check for alloc.inc in include_path
 $include_path = ini_get("include_path");
 
 // Include path
-$dirs = explode(PATH_SEPARATOR,$include_path);
+$dirs = explode(PATH_SEPARATOR, $include_path);
 
 if (is_array($dirs)) {
-  foreach ($dirs as $d) {
-    if (file_exists($d.DIRECTORY_SEPARATOR."alloc.inc")) {
-      $old_alloc_inc = $d.DIRECTORY_SEPARATOR."alloc.inc";
+    foreach ($dirs as $d) {
+        if (file_exists($d.DIRECTORY_SEPARATOR."alloc.inc")) {
+            $old_alloc_inc = $d.DIRECTORY_SEPARATOR."alloc.inc";
+        }
     }
-  }
 }
 
 if ($old_alloc_inc) {
-  $file = $old_alloc_inc;
+    $file = $old_alloc_inc;
 } else if (file_exists(ALLOC_CONFIG_PATH)) {
-  $file = ALLOC_CONFIG_PATH;
+    $file = ALLOC_CONFIG_PATH;
 } else {
-  alloc_error("No config file found! Find the alloc.inc file and put it in the php include_path.",true);
+    alloc_error("No config file found! Find the alloc.inc file and put it in the php include_path.", true);
 }
   
 $patterns = array("ALLOC_DB_NAME","ALLOC_DB_USER","ALLOC_DB_PASS","ALLOC_DB_HOST","ATTACHMENTS_DIR");
 $lines = file($file);
 foreach ($lines as $line) {
-  foreach ($patterns as $pattern) {
-    if (preg_match("/".$pattern."/",$line)) {
-      preg_match("/^\s*define\(\"\w*\"\s*,\s*\"(.*)\"\)/",$line,$matches);
-      $oldfile[$pattern] = $matches[1];
-      !defined($pattern) && define($pattern,trim($matches[1]));
+    foreach ($patterns as $pattern) {
+        if (preg_match("/".$pattern."/", $line)) {
+            preg_match("/^\s*define\(\"\w*\"\s*,\s*\"(.*)\"\)/", $line, $matches);
+            $oldfile[$pattern] = $matches[1];
+            !defined($pattern) && define($pattern, trim($matches[1]));
+        }
     }
-  }
 }
 
 $newfile = array();
 
 
-// Previous checks for upgrading from 1.2.256 
+// Previous checks for upgrading from 1.2.256
 if (!file_exists(ALLOC_CONFIG_PATH) || filesize(ALLOC_CONFIG_PATH) <5) {
-  
     foreach ($patterns as $pattern) {
-      $newfile[] = "define(\"".$pattern."\",\"".$oldfile[$pattern]."\");";
+        $newfile[] = "define(\"".$pattern."\",\"".$oldfile[$pattern]."\");";
     }
     $actions[] = ACTION_CREATE_ALLOC_CONFIG;
     $actions[] = ACTION_RM_ALLOC_INC;
@@ -112,41 +111,41 @@ require_once("../shared/lib/db_alloc.inc.php");
 
 // Try and create a table to test if we have perm
 $db = new db_alloc();
-$db->verbose = 0; 
+$db->verbose = 0;
 $q = "CREATE TABLE testCreateTableABC (heyID int)";
 $db->query($q);
 $cant_create = $db->get_error();
 
 // Try and alter a table to test if we have perm
 $db = new db_alloc();
-$db->verbose = 0; 
+$db->verbose = 0;
 $q = "ALTER TABLE testCreateTableABC ADD bee int";
 $db->query($q);
 $cant_alter = $db->get_error();
 
 // Try and drop a table to test if we have perm
 $db = new db_alloc();
-$db->verbose = 0; 
+$db->verbose = 0;
 $q = "DROP TABLE testCreateTableABC";
 $db->query($q);
 $cant_drop = $db->get_error();
 
 // If we can't do all three, then update the users permissions
 if ($cant_create || $cant_drop || $cant_alter) {
-  $actions[] = ACTION_FIX_DB_USER_PERMS;
-} 
+    $actions[] = ACTION_FIX_DB_USER_PERMS;
+}
 $db->verbose = 1;
 
 
 // Create table patchLog if it doesn't exist
 if (!$db->table_exists("patchLog")) {
-  $actions[] = ACTION_CREATE_TABLE_PATCHLOG;
+    $actions[] = ACTION_CREATE_TABLE_PATCHLOG;
 }
 
 
 
 $commands[ACTION_RM_ALLOC_INC]                       = "rm -f ".$old_alloc_inc;
-$commands[ACTION_CREATE_ALLOC_CONFIG]                = "echo '<?php \n".implode("\n",$newfile)."\n?>' > ".ALLOC_CONFIG_PATH;
+$commands[ACTION_CREATE_ALLOC_CONFIG]                = "echo '<?php \n".implode("\n", $newfile)."\n?>' > ".ALLOC_CONFIG_PATH;
 $commands[ACTION_MV_PROJECTS_DIR]                    = "mv ".ATTACHMENTS_DIR."projects ".ATTACHMENTS_DIR."project";
 $commands[ACTION_MV_CLIENTS_DIR]                     = "mv ".ATTACHMENTS_DIR."clients ".ATTACHMENTS_DIR."client";
 $commands[ACTION_MV_TASKS_DIR]                       = "mkdir ".ATTACHMENTS_DIR."task; chmod 777 ".ATTACHMENTS_DIR."task";
@@ -173,7 +172,7 @@ $commands[ACTION_CREATE_TABLE_PATCHLOG]             .= "'";
 $messages[ACTION_RM_ALLOC_INC] = "Please remove old config file: <b>".$old_alloc_inc."</b>";
 $messages[ACTION_CREATE_ALLOC_CONFIG] = "Please create a file that is readable only by the webserver, here: <b>".ALLOC_CONFIG_PATH;
 $messages[ACTION_CREATE_ALLOC_CONFIG].= "</b><br>The contents of the file should be:<br>";
-$messages[ACTION_CREATE_ALLOC_CONFIG].= "<pre>&lt;?php <br>".implode("\n",$newfile)."\n?&gt;</pre>";
+$messages[ACTION_CREATE_ALLOC_CONFIG].= "<pre>&lt;?php <br>".implode("\n", $newfile)."\n?&gt;</pre>";
 $messages[ACTION_CREATE_ALLOC_CONFIG].= "Ensure that that less-than symbol &lt; on the first line is the very first character in the file, ";
 $messages[ACTION_CREATE_ALLOC_CONFIG].= "and that the greater-than symbol &gt; on the last line, is the absolute last character in the file.";
 $messages[ACTION_MV_PROJECTS_DIR] = "Please rename ".ATTACHMENTS_DIR."projects  to  ".ATTACHMENTS_DIR."project";
@@ -188,27 +187,18 @@ $messages[ACTION_CREATE_TABLE_PATCHLOG] = "The patchLog table needs to be create
 // If we're hitting this script with wget as part of the automatic livealloc upgrade process
 // we just want to return the commands, so that the util/patch.sh script will eval them
 if ($_GET["return_commands"] && is_array($actions) && count($actions)) {
-
-  foreach ($actions as $action) {
-    echo $commands[$action]."\n";
-  }
+    foreach ($actions as $action) {
+        echo $commands[$action]."\n";
+    }
 
 // Else hitting this script with a web browser, provide more verbose instructions
 } else if (is_array($actions) && count($actions)) {
-
-  foreach ($actions as $action) {
-    echo "<br><br> * ".$messages[$action];
-    echo "<pre>Try the shell command:<br>".page::htmlentities($commands[$action])."</pre>";
-  }
+    foreach ($actions as $action) {
+        echo "<br><br> * ".$messages[$action];
+        echo "<pre>Try the shell command:<br>".page::htmlentities($commands[$action])."</pre>";
+    }
 
 // Don't echo this for livealloc
 } else if (!$_GET["return_commands"]) {
-  echo "Please complete the upgrade by performing the <a href=\"patch.php\">database updates</a>.";
+    echo "Please complete the upgrade by performing the <a href=\"patch.php\">database updates</a>.";
 }
-
-
-
-
-
-
-?>

--- a/invoice/checkRepeat.php
+++ b/invoice/checkRepeat.php
@@ -3,30 +3,30 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_AUTH",true);
+define("NO_AUTH", true);
 require_once("../alloc.php");
-singleton("errors_fatal",true);
-singleton("errors_format","text");
-singleton("errors_logged",true);
-singleton("errors_thrown",true);
-singleton("errors_haltdb",false);
+singleton("errors_fatal", true);
+singleton("errors_format", "text");
+singleton("errors_logged", true);
+singleton("errors_thrown", true);
+singleton("errors_haltdb", false);
 
 
 #$today = $_REQUEST["today"] or $today = date("Y-m-d");
@@ -42,79 +42,76 @@ $q = prepare("SELECT invoiceRepeatDate.invoiceRepeatID
            LEFT JOIN invoice ON invoice.invoiceRepeatID = invoiceRepeatDate.invoiceRepeatID
                  AND invoice.invoiceRepeatDate = invoiceRepeatDate.invoiceDate
                WHERE invoice.invoiceID IS NULL
-                 AND invoiceRepeatDate.invoiceDate <= '%s'",$today);
+                 AND invoiceRepeatDate.invoiceDate <= '%s'", $today);
 
 $orig_current_user = &singleton("current_user");
 $db = new db_alloc();
 $id = $db->query($q);
 while ($row = $db->row($id)) {
-
-  if ($row["currentUser"]) {
-    $current_user = new person();
-    $current_user->load_current_user($row["currentUser"]);
-    singleton("current_user",$current_user);
-  } 
+    if ($row["currentUser"]) {
+        $current_user = new person();
+        $current_user->load_current_user($row["currentUser"]);
+        singleton("current_user", $current_user);
+    }
 
   #echo "<br>Checking row: ".print_r($row,1);
 
-  $invoice = new invoice();
-  $invoice->set_id($row["templateInvoiceID"]);
-  $invoice->select();
+    $invoice = new invoice();
+    $invoice->set_id($row["templateInvoiceID"]);
+    $invoice->select();
 
-  $i = new invoice();
-  $i->set_value("invoiceRepeatID",$row["invoiceRepeatID"]);
-  $i->set_value("invoiceRepeatDate",$row["invoiceDate"]);
-  $i->set_value("invoiceNum",invoice::get_next_invoiceNum());
-  $i->set_value("clientID",$invoice->get_value("clientID"));
-  $i->set_value("projectID",$invoice->get_value("projectID"));
-  $i->set_value("invoiceName",$invoice->get_value("invoiceName"));
-  $i->set_value("invoiceStatus","edit");
-  $i->set_value("invoiceDateTo",$row["invoiceDate"]);
-  $i->set_value("currencyTypeID",$invoice->get_value("currencyTypeID"));
-  $i->set_value("maxAmount",$invoice->get_value("maxAmount"));
-  $i->save();
+    $i = new invoice();
+    $i->set_value("invoiceRepeatID", $row["invoiceRepeatID"]);
+    $i->set_value("invoiceRepeatDate", $row["invoiceDate"]);
+    $i->set_value("invoiceNum", invoice::get_next_invoiceNum());
+    $i->set_value("clientID", $invoice->get_value("clientID"));
+    $i->set_value("projectID", $invoice->get_value("projectID"));
+    $i->set_value("invoiceName", $invoice->get_value("invoiceName"));
+    $i->set_value("invoiceStatus", "edit");
+    $i->set_value("invoiceDateTo", $row["invoiceDate"]);
+    $i->set_value("currencyTypeID", $invoice->get_value("currencyTypeID"));
+    $i->set_value("maxAmount", $invoice->get_value("maxAmount"));
+    $i->save();
 
   #echo "<br>Created invoice: ".$i->get_id();
 
-  $q = prepare("SELECT * FROM invoiceItem WHERE invoiceID = %d",$invoice->get_id());
-  $id2 = $db->query($q);
-  while ($item = $db->row($id2)) {
-    $ii = new invoiceItem();
-    $ii->currency = $i->get_value("currencyTypeID");
-    $ii->set_value("invoiceID",$i->get_id());
-    $ii->set_value("iiMemo",$item["iiMemo"]);
-    $ii->set_value("iiUnitPrice",page::money($ii->currency,$item["iiUnitPrice"],"%mo"));
-    $ii->set_value("iiAmount",page::money($ii->currency,$item["iiAmount"],"%mo"));
-    $ii->set_value("iiQuantity",$item["iiQuantity"]);
-    $ii->save();
-    #echo "<br>Created invoice item: ".$ii->get_id();
-  }
-
-
-  if ($row["message"]) {
-    $ips = interestedParty::get_interested_parties("invoiceRepeat",$row["invoiceRepeatID"]);
-
-    $recipients = array();
-    foreach ($ips as $email => $info) {
-      $recipients[$email] = $info;
-      $recipients[$email]["addIP"] = true;
+    $q = prepare("SELECT * FROM invoiceItem WHERE invoiceID = %d", $invoice->get_id());
+    $id2 = $db->query($q);
+    while ($item = $db->row($id2)) {
+        $ii = new invoiceItem();
+        $ii->currency = $i->get_value("currencyTypeID");
+        $ii->set_value("invoiceID", $i->get_id());
+        $ii->set_value("iiMemo", $item["iiMemo"]);
+        $ii->set_value("iiUnitPrice", page::money($ii->currency, $item["iiUnitPrice"], "%mo"));
+        $ii->set_value("iiAmount", page::money($ii->currency, $item["iiAmount"], "%mo"));
+        $ii->set_value("iiQuantity", $item["iiQuantity"]);
+        $ii->save();
+      #echo "<br>Created invoice item: ".$ii->get_id();
     }
 
-    $commentID = comment::add_comment("invoice", $i->get_id(), $row["message"], "invoice", $i->get_id());
-    if ($recipients) {
-      $emailRecipients = comment::add_interested_parties($commentID, null, $recipients);
-      comment::attach_invoice($commentID,$i->get_id(),$verbose=true);
 
-      // Re-email the comment out, including any attachments
-      if (!comment::send_comment($commentID,$emailRecipients)) {
-        alloc_error("Failed to email invoice: ".$i->get_id());
-      }
+    if ($row["message"]) {
+        $ips = interestedParty::get_interested_parties("invoiceRepeat", $row["invoiceRepeatID"]);
+
+        $recipients = array();
+        foreach ($ips as $email => $info) {
+            $recipients[$email] = $info;
+            $recipients[$email]["addIP"] = true;
+        }
+
+        $commentID = comment::add_comment("invoice", $i->get_id(), $row["message"], "invoice", $i->get_id());
+        if ($recipients) {
+            $emailRecipients = comment::add_interested_parties($commentID, null, $recipients);
+            comment::attach_invoice($commentID, $i->get_id(), $verbose = true);
+
+          // Re-email the comment out, including any attachments
+            if (!comment::send_comment($commentID, $emailRecipients)) {
+                alloc_error("Failed to email invoice: ".$i->get_id());
+            }
+        }
     }
-  }
 
   // Put current_user back to normal
-  $current_user = &$orig_current_user;
-  singleton("current_user",$current_user);
+    $current_user = &$orig_current_user;
+    singleton("current_user", $current_user);
 }
-
-?>

--- a/invoice/invoice.php
+++ b/invoice/invoice.php
@@ -3,205 +3,205 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function show_new_invoiceItem($template) {
-  global $TPL;
-  global $invoice;
-  global $invoiceID;
-  $current_user = &singleton("current_user");
+function show_new_invoiceItem($template)
+{
+    global $TPL;
+    global $invoice;
+    global $invoiceID;
+    $current_user = &singleton("current_user");
 
   // Don't show entry form if no ID
-  if (!$invoiceID) {
-    return;
-  }
+    if (!$invoiceID) {
+        return;
+    }
 
-  $TPL["div1"] = "";
-  $TPL["div2"] = " class=\"hidden\"";
-  $TPL["div3"] = " class=\"hidden\"";
-  $TPL["div4"] = " class=\"hidden\"";
+    $TPL["div1"] = "";
+    $TPL["div2"] = " class=\"hidden\"";
+    $TPL["div3"] = " class=\"hidden\"";
+    $TPL["div4"] = " class=\"hidden\"";
 
 
-  if (is_object($invoice) && $invoice->get_value("invoiceStatus") == 'edit' && $current_user->have_role('admin')) {
-
-    // If we are editing an existing invoiceItem
-    if (is_array($_POST["invoiceItem_edit"])) {
-      $invoiceItemID = key($_POST["invoiceItem_edit"]);
-      $invoiceItem = new invoiceItem();
-      $invoiceItem->currency = $invoice->get_value("currencyTypeID");
-      $invoiceItem->set_id($invoiceItemID);
-      $invoiceItem->select();
-      $invoiceItem->set_tpl_values("invoiceItem_");
-      $TPL["invoiceItem_buttons"] = '
+    if (is_object($invoice) && $invoice->get_value("invoiceStatus") == 'edit' && $current_user->have_role('admin')) {
+      // If we are editing an existing invoiceItem
+        if (is_array($_POST["invoiceItem_edit"])) {
+            $invoiceItemID = key($_POST["invoiceItem_edit"]);
+            $invoiceItem = new invoiceItem();
+            $invoiceItem->currency = $invoice->get_value("currencyTypeID");
+            $invoiceItem->set_id($invoiceItemID);
+            $invoiceItem->select();
+            $invoiceItem->set_tpl_values("invoiceItem_");
+            $TPL["invoiceItem_buttons"] = '
         <button type="submit" name="invoiceItem_delete['.$invoiceItemID.']" value="1" class="delete_button">Delete<i class="icon-trash"></i></button>
         <button type="submit" name="invoiceItem_save['.$invoiceItemID.']" value="1" class="save_button">Save Item<i class="icon-edit"></i></button>
       ';
       
-      if ($invoiceItem->get_value("timeSheetID")) {
-        unset($TPL["div2"]);
-        $TPL["div1"] = " class=\"hidden\"";
-        $TPL["sbs_link"] = "timeSheet_ii";
+            if ($invoiceItem->get_value("timeSheetID")) {
+                unset($TPL["div2"]);
+                $TPL["div1"] = " class=\"hidden\"";
+                $TPL["sbs_link"] = "timeSheet_ii";
+            } else if ($invoiceItem->get_value("expenseFormID")) {
+                unset($TPL["div3"]);
+                $TPL["div1"] = " class=\"hidden\"";
+                $TPL["sbs_link"] = "expenseForm_ii";
+            } else if ($invoiceItem->get_value("productSaleID")) {
+                unset($TPL["div4"]);
+                $TPL["div1"] = " class=\"hidden\"";
+                $TPL["sbs_link"] = "productSale_ii";
+            }
 
-      } else if ($invoiceItem->get_value("expenseFormID")) {
-        unset($TPL["div3"]);
-        $TPL["div1"] = " class=\"hidden\"";
-        $TPL["sbs_link"] = "expenseForm_ii";
-
-      } else if ($invoiceItem->get_value("productSaleID")) {
-        unset($TPL["div4"]);
-        $TPL["div1"] = " class=\"hidden\"";
-        $TPL["sbs_link"] = "productSale_ii";
-      }
-
-    // Else default values for creating a new invoiceItem
-    } else {
-      $invoiceItem = new invoiceItem();
-      $invoiceItem->set_values("invoiceItem_");
-      $TPL["invoiceItem_buttons"] = '
+        // Else default values for creating a new invoiceItem
+        } else {
+            $invoiceItem = new invoiceItem();
+            $invoiceItem->set_values("invoiceItem_");
+            $TPL["invoiceItem_buttons"] = '
          <button type="submit" name="invoiceItem_save" value="1" class="save_button">Add Item<i class="icon-plus-sign"></i></button>
       ';
-    }
+        }
 
-    // Build dropdown lists for timeSheet and expenseForm options.
-    if ($invoice->get_value("clientID")) {
-
-      // Time Sheet dropdown
-      $db = new db_alloc();
-      $q = prepare("SELECT projectID FROM project WHERE clientID = %d",$invoice->get_value("clientID"));
-      $db->query($q);
-      $projectIDs = array();
-      while ($row = $db->row()) {
-        $projectIDs[] = $row["projectID"];
-      }
-      if ($projectIDs) {
-        $q = prepare("SELECT timeSheet.*, project.projectName 
+      // Build dropdown lists for timeSheet and expenseForm options.
+        if ($invoice->get_value("clientID")) {
+          // Time Sheet dropdown
+            $db = new db_alloc();
+            $q = prepare("SELECT projectID FROM project WHERE clientID = %d", $invoice->get_value("clientID"));
+            $db->query($q);
+            $projectIDs = array();
+            while ($row = $db->row()) {
+                $projectIDs[] = $row["projectID"];
+            }
+            if ($projectIDs) {
+                $q = prepare("SELECT timeSheet.*, project.projectName 
                         FROM timeSheet
                    LEFT JOIN project ON project.projectID = timeSheet.projectID 
                        WHERE timeSheet.projectID IN (%s) 
                          AND timeSheet.status != 'finished'
                     GROUP BY timeSheet.timeSheetID
                     ORDER BY timeSheetID
-                     ",$projectIDs);
-        $db->query($q);
+                     ", $projectIDs);
+                $db->query($q);
     
-        $timeSheetStatii = timeSheet::get_timeSheet_statii();
+                $timeSheetStatii = timeSheet::get_timeSheet_statii();
 
-        while ($row = $db->row()) {
-          $t = new timeSheet();
-          $t->read_db_record($db);
-          $t->load_pay_info();
-          $dollars = $t->pay_info["total_customerBilledDollars"] or $dollars = $t->pay_info["total_dollars"];
-          $timeSheetOptions[$row["timeSheetID"]] = "Time Sheet #".$t->get_id()." ".$row["dateFrom"]." ".$dollars." for ".person::get_fullname($row["personID"]).", Project: ".$row["projectName"]." [".$timeSheetStatii[$t->get_value("status")]."]";
-        }
+                while ($row = $db->row()) {
+                      $t = new timeSheet();
+                      $t->read_db_record($db);
+                      $t->load_pay_info();
+                      $dollars = $t->pay_info["total_customerBilledDollars"] or $dollars = $t->pay_info["total_dollars"];
+                      $timeSheetOptions[$row["timeSheetID"]] = "Time Sheet #".$t->get_id()." ".$row["dateFrom"]." ".$dollars." for ".person::get_fullname($row["personID"]).", Project: ".$row["projectName"]." [".$timeSheetStatii[$t->get_value("status")]."]";
+                }
 
-        $TPL["timeSheetOptions"] = page::select_options($timeSheetOptions,$invoiceItem->get_value("timeSheetID"),150);
-      }
+                $TPL["timeSheetOptions"] = page::select_options($timeSheetOptions, $invoiceItem->get_value("timeSheetID"), 150);
+            }
 
-      // Expense Form dropdown
-      $db = new db_alloc();
-      $q = prepare("SELECT expenseFormID, expenseFormCreatedUser
+          // Expense Form dropdown
+            $db = new db_alloc();
+            $q = prepare("SELECT expenseFormID, expenseFormCreatedUser
                       FROM expenseForm 
                      WHERE expenseFormFinalised = 1 
                        AND seekClientReimbursement = 1
                        AND clientID = %d
-                  ORDER BY expenseForm.expenseFormCreatedTime",$invoice->get_value("clientID"));
-      $db->query($q);
-      while ($row = $db->row()) {
-        $expenseFormOptions[$row["expenseFormID"]] = "Expense Form #".$row["expenseFormID"]." ".page::money(config::get_config_item("currency"),expenseForm::get_abs_sum_transactions($row["expenseFormID"]),"%s%m %c")." ".person::get_fullname($row["expenseFormCreatedUser"]);
-      }
+                  ORDER BY expenseForm.expenseFormCreatedTime", $invoice->get_value("clientID"));
+            $db->query($q);
+            while ($row = $db->row()) {
+                  $expenseFormOptions[$row["expenseFormID"]] = "Expense Form #".$row["expenseFormID"]." ".page::money(config::get_config_item("currency"), expenseForm::get_abs_sum_transactions($row["expenseFormID"]), "%s%m %c")." ".person::get_fullname($row["expenseFormCreatedUser"]);
+            }
 
-      if ($invoiceItem->get_value("expenseFormID")) {
-        $id = $invoiceItem->get_value("expenseFormID");
-      }
-      $TPL["expenseFormOptions"] = page::select_options($expenseFormOptions,$id,90);
+            if ($invoiceItem->get_value("expenseFormID")) {
+                $id = $invoiceItem->get_value("expenseFormID");
+            }
+            $TPL["expenseFormOptions"] = page::select_options($expenseFormOptions, $id, 90);
 
 
-      $q = prepare("SELECT *
+            $q = prepare("SELECT *
                       FROM productSale
                      WHERE clientID = %d
                        AND status = 'admin'
-                   ",$invoice->get_value("clientID"));
-      $invoice->get_value("projectID") and $q.= prepare(" AND projectID = %d",$invoice->get_value("projectID"));
-      $db->query($q);
-      while ($row = $db->row()) {
-        $productSale = new productSale();
-        $productSale->set_id($row["productSaleID"]);
-        $productSale->select();
-        $ps_row = $productSale->get_amounts();
-        $productSaleOptions[$row["productSaleID"]] = "Sale #".$row["productSaleID"]." ".$ps_row["total_sellPrice"]." ".person::get_fullname($row["personID"]);
-      }
-      if ($invoiceItem->get_value("productSaleID")) {
-        $id = $invoiceItem->get_value("productSaleID");
-      }
-      $TPL["productSaleOptions"] = page::select_options($productSaleOptions,$id,90);
+                   ", $invoice->get_value("clientID"));
+            $invoice->get_value("projectID") and $q.= prepare(" AND projectID = %d", $invoice->get_value("projectID"));
+            $db->query($q);
+            while ($row = $db->row()) {
+                  $productSale = new productSale();
+                  $productSale->set_id($row["productSaleID"]);
+                  $productSale->select();
+                  $ps_row = $productSale->get_amounts();
+                  $productSaleOptions[$row["productSaleID"]] = "Sale #".$row["productSaleID"]." ".$ps_row["total_sellPrice"]." ".person::get_fullname($row["personID"]);
+            }
+            if ($invoiceItem->get_value("productSaleID")) {
+                $id = $invoiceItem->get_value("productSaleID");
+            }
+            $TPL["productSaleOptions"] = page::select_options($productSaleOptions, $id, 90);
+        }
+
+        $TPL["invoiceItem_iiQuantity"] or $TPL["invoiceItem_iiQuantity"] = 1;
+        $TPL["invoiceItem_invoiceID"] = $invoice->get_id();
+
+        include_template($template);
     }
-
-    $TPL["invoiceItem_iiQuantity"] or $TPL["invoiceItem_iiQuantity"] = 1;
-    $TPL["invoiceItem_invoiceID"] = $invoice->get_id();
-
-    include_template($template);
-  }
 }
 
-function show_invoiceItem_list() {
-  global $invoiceID;
-  global $TPL;
-  global $invoice;
-  $current_user = &singleton("current_user");
+function show_invoiceItem_list()
+{
+    global $invoiceID;
+    global $TPL;
+    global $invoice;
+    $current_user = &singleton("current_user");
 
-  $template = "templates/invoiceItemListR.tpl";
+    $template = "templates/invoiceItemListR.tpl";
 
-  $db = new db_alloc();
-  $db2 = new db_alloc();
-  $q = prepare("SELECT *
+    $db = new db_alloc();
+    $db2 = new db_alloc();
+    $q = prepare(
+        "SELECT *
                   FROM invoiceItem 
                  WHERE invoiceItem.invoiceID = %d 
-              ORDER BY iiDate,invoiceItem.invoiceItemID"
-              ,$invoiceID);
-  $db->query($q);
-  while ($db->next_record()) {
-    $invoiceItem = new invoiceItem();
-    $invoiceItem->currency = $invoice->get_value("currencyTypeID");
+              ORDER BY iiDate,invoiceItem.invoiceItemID",
+        $invoiceID
+    );
+    $db->query($q);
+    while ($db->next_record()) {
+        $invoiceItem = new invoiceItem();
+        $invoiceItem->currency = $invoice->get_value("currencyTypeID");
   
-    if (!$invoiceItem->read_db_record($db)) {
-      continue;
-    }
-    $invoiceItem->set_tpl_values("invoiceItem_");
+        if (!$invoiceItem->read_db_record($db)) {
+            continue;
+        }
+        $invoiceItem->set_tpl_values("invoiceItem_");
 
-    unset($transaction_sum);
-    unset($transaction_info);
-    unset($transaction_statii);
-    unset($one_approved);
-    unset($one_rejected);
-    unset($one_pending);
-    unset($br);
-    unset($sel);
-    unset($amount);
-    unset($TPL["invoiceItem_buttons_top"],$TPL["invoiceItem_buttons"],$TPL["transaction_info"],$TPL["status_label"]);
+        unset($transaction_sum);
+        unset($transaction_info);
+        unset($transaction_statii);
+        unset($one_approved);
+        unset($one_rejected);
+        unset($one_pending);
+        unset($br);
+        unset($sel);
+        unset($amount);
+        unset($TPL["invoiceItem_buttons_top"], $TPL["invoiceItem_buttons"], $TPL["transaction_info"], $TPL["status_label"]);
 
-    // If editing a invoiceItem then don't display it in the list
-    if (is_array($_POST["invoiceItem_edit"]) && key($_POST["invoiceItem_edit"]) == $invoiceItem->get_id()) {
-      continue;
-    }
+      // If editing a invoiceItem then don't display it in the list
+        if (is_array($_POST["invoiceItem_edit"]) && key($_POST["invoiceItem_edit"]) == $invoiceItem->get_id()) {
+            continue;
+        }
     
-    $q = prepare("SELECT *
+        $q = prepare("SELECT *
                        , transaction.amount * pow(10,-currencyType.numberToBasic) AS transaction_amount
                        , transaction.tfID AS transaction_tfID
                        , transaction.fromTfID AS transaction_fromTfID
@@ -209,219 +209,209 @@ function show_invoiceItem_list() {
                        , transaction.currencyTypeID
                     FROM transaction 
                LEFT JOIN currencyType on transaction.currencyTypeID = currencyType.currencyTypeID
-                   WHERE transaction.invoiceItemID = %d",$invoiceItem->get_id());
-    $db2->query($q);
-    while ($db2->next_record()) {
-
-      $transaction = new transaction();
-      if (!$transaction->read_db_record($db2)) {
-        $other_peoples_transactions.= "<br>Tansaction access denied for transaction #".$db2->f("transactionID");
-        continue;
-      }
-
-
-      if ($db2->f("transaction_status") == "approved") {
-        $one_approved = true;
-      }
-      if ($db2->f("transaction_status") == "rejected") {
-        $one_rejected = true;
-      }
-      if ($db2->f("transaction_status") == "pending") {
-        $one_pending = true;
-      }
-
-      $amounts[$invoiceItem->get_id()]+= $db2->f("transaction_amount");
-
-      $db2->f("transaction_status") != "rejected" and $transaction_sum+= $db2->f("transaction_amount");
-      $transaction_info.= $br.ucwords($db2->f("transaction_status"))." Transaction ";
-      $transaction_info.= "<a href=\"".$TPL["url_alloc_transaction"]."transactionID=".$db2->f("transactionID")."\">#".$db2->f("transactionID")."</a>";
-      $transaction_info.= " from ";
-      $transaction_info.= "<a href=\"".$TPL["url_alloc_transactionList"]."tfID=".$db2->f("transaction_fromTfID")."\">".tf::get_name($db2->f("transaction_fromTfID"))."</a>";
-      $transaction_info.= " to <a href=\"".$TPL["url_alloc_transactionList"]."tfID=".$db2->f("transaction_tfID")."\">".tf::get_name($db2->f("transaction_tfID"))."</a>";
-      $transaction_info.= " for <b>".page::money($db2->f("currencyTypeID"),$db2->f("transaction_amount"),"%s%m")."</b>";
-      $br = "<br>";
-    }
+                   WHERE transaction.invoiceItemID = %d", $invoiceItem->get_id());
+        $db2->query($q);
+        while ($db2->next_record()) {
+            $transaction = new transaction();
+            if (!$transaction->read_db_record($db2)) {
+                $other_peoples_transactions.= "<br>Tansaction access denied for transaction #".$db2->f("transactionID");
+                continue;
+            }
 
 
-    $TPL["transaction_info"] = $transaction_info;
-    $TPL["transaction_info"].= $other_peoples_transactions;
+            if ($db2->f("transaction_status") == "approved") {
+                $one_approved = true;
+            }
+            if ($db2->f("transaction_status") == "rejected") {
+                $one_rejected = true;
+            }
+            if ($db2->f("transaction_status") == "pending") {
+                    $one_pending = true;
+            }
+
+            $amounts[$invoiceItem->get_id()]+= $db2->f("transaction_amount");
+
+            $db2->f("transaction_status") != "rejected" and $transaction_sum+= $db2->f("transaction_amount");
+            $transaction_info.= $br.ucwords($db2->f("transaction_status"))." Transaction ";
+            $transaction_info.= "<a href=\"".$TPL["url_alloc_transaction"]."transactionID=".$db2->f("transactionID")."\">#".$db2->f("transactionID")."</a>";
+            $transaction_info.= " from ";
+            $transaction_info.= "<a href=\"".$TPL["url_alloc_transactionList"]."tfID=".$db2->f("transaction_fromTfID")."\">".tf::get_name($db2->f("transaction_fromTfID"))."</a>";
+            $transaction_info.= " to <a href=\"".$TPL["url_alloc_transactionList"]."tfID=".$db2->f("transaction_tfID")."\">".tf::get_name($db2->f("transaction_tfID"))."</a>";
+            $transaction_info.= " for <b>".page::money($db2->f("currencyTypeID"), $db2->f("transaction_amount"), "%s%m")."</b>";
+            $br = "<br>";
+        }
+
+
+        $TPL["transaction_info"] = $transaction_info;
+        $TPL["transaction_info"].= $other_peoples_transactions;
 
     
-    // Sets the background colour of the invoice item boxes based on transaction.status
-    if (!$one_rejected && !$one_pending && $one_approved) {
-      $TPL["box_class"] = " approved";
-      $transaction_status = "approved";
-    } else if ($one_rejected) {
-      $TPL["box_class"] = " rejected";
-      $transaction_status = "rejected";
-    } else if ($one_pending) {
-      $transaction_status = "pending";
-      $TPL["box_class"] = " warn";
-    } else {
-      $TPL["box_class"] = " pending";
-      $transaction_status = "";
-    }
-
-    $sel[$transaction_status] = " checked";
-
-    if ($sel["rejected"]) {
-      $TPL["status_label"] = "<b>[Not Going To Be Paid]</b>";
-
-    } else if ($sel["pending"]) {
-      $TPL["status_label"] = "<b>[Pending]</b>";
-
-    } else if ($sel["approved"]) {
-      $TPL["status_label"] = "<b>[Paid]</b>";
-    }
-
-    if ($transaction_sum > 0 && $transaction_sum < $invoiceItem->get_value("iiAmount",DST_HTML_DISPLAY)) {
-      $TPL["status_label"] = "<b>[Paid in part]</b>";
-      $TPL["box_class"] = " warn";
-
-    } else if ($transaction_sum > $invoiceItem->get_value("iiAmount")) {
-      $TPL["status_label"] = "<b>[Overpaid]</b>";
-    }
-
-    $TPL["status_label"] or $TPL["status_label"] = "<b>[No Transactions Created]</b>";
-
-
-
-    if ($invoice->get_value("invoiceStatus") == "reconcile") {
-      
-      if ($amounts[$invoiceItem->get_id()] === null) {
-        $amount = $invoiceItem->get_value("iiAmount",DST_HTML_DISPLAY);
-        if (config::get_config_item("taxPercent") && $invoiceItem->get_value("iiTax") == 0) {
-          $amount = page::money($invoice->get_value("currencyTypeID"),$amount * (config::get_config_item("taxPercent") / 100 + 1),"%m");
+      // Sets the background colour of the invoice item boxes based on transaction.status
+        if (!$one_rejected && !$one_pending && $one_approved) {
+            $TPL["box_class"] = " approved";
+            $transaction_status = "approved";
+        } else if ($one_rejected) {
+            $TPL["box_class"] = " rejected";
+            $transaction_status = "rejected";
+        } else if ($one_pending) {
+            $transaction_status = "pending";
+            $TPL["box_class"] = " warn";
+        } else {
+            $TPL["box_class"] = " pending";
+            $transaction_status = "";
         }
-      } else {
-        $amount = page::money($invoice->get_value("currencyTypeID"),$amounts[$invoiceItem->get_id()],"%m");
-      }
+
+        $sel[$transaction_status] = " checked";
+
+        if ($sel["rejected"]) {
+            $TPL["status_label"] = "<b>[Not Going To Be Paid]</b>";
+        } else if ($sel["pending"]) {
+            $TPL["status_label"] = "<b>[Pending]</b>";
+        } else if ($sel["approved"]) {
+            $TPL["status_label"] = "<b>[Paid]</b>";
+        }
+
+        if ($transaction_sum > 0 && $transaction_sum < $invoiceItem->get_value("iiAmount", DST_HTML_DISPLAY)) {
+            $TPL["status_label"] = "<b>[Paid in part]</b>";
+            $TPL["box_class"] = " warn";
+        } else if ($transaction_sum > $invoiceItem->get_value("iiAmount")) {
+            $TPL["status_label"] = "<b>[Overpaid]</b>";
+        }
+
+        $TPL["status_label"] or $TPL["status_label"] = "<b>[No Transactions Created]</b>";
+
+
+
+        if ($invoice->get_value("invoiceStatus") == "reconcile") {
+            if ($amounts[$invoiceItem->get_id()] === null) {
+                $amount = $invoiceItem->get_value("iiAmount", DST_HTML_DISPLAY);
+                if (config::get_config_item("taxPercent") && $invoiceItem->get_value("iiTax") == 0) {
+                    $amount = page::money($invoice->get_value("currencyTypeID"), $amount * (config::get_config_item("taxPercent") / 100 + 1), "%m");
+                }
+            } else {
+                $amount = page::money($invoice->get_value("currencyTypeID"), $amounts[$invoiceItem->get_id()], "%m");
+            }
       
-      $selected_tfID = $db2->f("transaction_tfID");
-      if (!$selected_tfID && $invoiceItem->get_value("timeSheetID")) {
-        $timeSheet = $invoiceItem->get_foreign_object("timeSheet");
-        $project = $timeSheet->get_foreign_object("project");
-        $selected_tfID = $project->get_value("cost_centre_tfID");
-      
-      } else if (!$selected_tfID && $invoiceItem->get_value("transactionID")) {
-        $transaction = $invoiceItem->get_foreign_object("transaction");
-        $project = $transaction->get_foreign_object("project");
-        $selected_tfID = $project->get_value("cost_centre_tfID");
-        $selected_tfID or $selected_tfID = $transaction->get_value("tfID");
-      }
-      $selected_tfID or $selected_tfID = config::get_config_item("mainTfID");
+            $selected_tfID = $db2->f("transaction_tfID");
+            if (!$selected_tfID && $invoiceItem->get_value("timeSheetID")) {
+                $timeSheet = $invoiceItem->get_foreign_object("timeSheet");
+                $project = $timeSheet->get_foreign_object("project");
+                $selected_tfID = $project->get_value("cost_centre_tfID");
+            } else if (!$selected_tfID && $invoiceItem->get_value("transactionID")) {
+                $transaction = $invoiceItem->get_foreign_object("transaction");
+                $project = $transaction->get_foreign_object("project");
+                $selected_tfID = $project->get_value("cost_centre_tfID");
+                $selected_tfID or $selected_tfID = $transaction->get_value("tfID");
+            }
+            $selected_tfID or $selected_tfID = config::get_config_item("mainTfID");
 
 
-      #$tf_options = page::select_options($tf_array, $selected_tfID);
-      #$tf_options = "<select name=\"invoiceItemAmountPaidTfID[".$invoiceItem->get_id()."]\">".$tf_options."</select>";
-      #$TPL["invoiceItem_buttons"] = "<input size=\"8\" type=\"text\" id=\"ap_".$invoiceItem->get_id()."\" name=\"invoiceItemAmountPaid[".$invoiceItem->get_id()."]\" value=\"".$amount."\">";
-      #$TPL["invoiceItem_buttons"].= $tf_options;
+          #$tf_options = page::select_options($tf_array, $selected_tfID);
+          #$tf_options = "<select name=\"invoiceItemAmountPaidTfID[".$invoiceItem->get_id()."]\">".$tf_options."</select>";
+          #$TPL["invoiceItem_buttons"] = "<input size=\"8\" type=\"text\" id=\"ap_".$invoiceItem->get_id()."\" name=\"invoiceItemAmountPaid[".$invoiceItem->get_id()."]\" value=\"".$amount."\">";
+          #$TPL["invoiceItem_buttons"].= $tf_options;
 
 
-      unset($radio_buttons);
-      if ($current_user->have_role('admin')) {
-      $radio_buttons = "<label class='radio corner' for=\"invoiceItemStatus_rejected_".$invoiceItem->get_id()."\">Not Going To Be Paid";
-      $radio_buttons.= "<input type=\"radio\" id=\"invoiceItemStatus_rejected_".$invoiceItem->get_id()."\" name=\"invoiceItemStatus[".$invoiceItem->get_id()."]\"";
-      $radio_buttons.= " value=\"rejected\"".$sel["rejected"].">";
-      $radio_buttons.= "</label>";
+            unset($radio_buttons);
+            if ($current_user->have_role('admin')) {
+                $radio_buttons = "<label class='radio corner' for=\"invoiceItemStatus_rejected_".$invoiceItem->get_id()."\">Not Going To Be Paid";
+                $radio_buttons.= "<input type=\"radio\" id=\"invoiceItemStatus_rejected_".$invoiceItem->get_id()."\" name=\"invoiceItemStatus[".$invoiceItem->get_id()."]\"";
+                $radio_buttons.= " value=\"rejected\"".$sel["rejected"].">";
+                $radio_buttons.= "</label>";
 
-      $radio_buttons.= "&nbsp;&nbsp;";
-      $radio_buttons.= "<label class='radio corner' for=\"invoiceItemStatus_pending_".$invoiceItem->get_id()."\">Pending";
-      $radio_buttons.= "<input type=\"radio\" id=\"invoiceItemStatus_pending_".$invoiceItem->get_id()."\" name=\"invoiceItemStatus[".$invoiceItem->get_id()."]\"";
-      $radio_buttons.= " value=\"pending\"".$sel["pending"].">";
-      $radio_buttons.= "</label>";
+                $radio_buttons.= "&nbsp;&nbsp;";
+                $radio_buttons.= "<label class='radio corner' for=\"invoiceItemStatus_pending_".$invoiceItem->get_id()."\">Pending";
+                $radio_buttons.= "<input type=\"radio\" id=\"invoiceItemStatus_pending_".$invoiceItem->get_id()."\" name=\"invoiceItemStatus[".$invoiceItem->get_id()."]\"";
+                $radio_buttons.= " value=\"pending\"".$sel["pending"].">";
+                $radio_buttons.= "</label>";
 
-      $radio_buttons.= "&nbsp;&nbsp;";
-      $radio_buttons.= "<label class='radio corner' for=\"invoiceItemStatus_approved_".$invoiceItem->get_id()."\">Paid"; 
-      $radio_buttons.= "<input type=\"radio\" id=\"invoiceItemStatus_approved_".$invoiceItem->get_id()."\" name=\"invoiceItemStatus[".$invoiceItem->get_id()."]\"";
-      $radio_buttons.= " value=\"approved\"".$sel["approved"].">";
-      $radio_buttons.= "</label>";
-
-
-      $TPL["invoiceItem_buttons_top"] = $radio_buttons;
-      $TPL["invoiceItem_buttons_top"].= "&nbsp;&nbsp;&nbsp;&nbsp;<input type=\"text\" size=\"7\" name=\"invoiceItemAmountPaid[".$invoiceItem->get_id()."]\" value=\"".$amount."\">";
-      $TPL["invoiceItem_buttons_top"].= "<input type=\"hidden\" name=\"invoiceItemAmountPaidTfID[".$invoiceItem->get_id()."]\" value=\"".$selected_tfID."\">";
-      }
+                $radio_buttons.= "&nbsp;&nbsp;";
+                $radio_buttons.= "<label class='radio corner' for=\"invoiceItemStatus_approved_".$invoiceItem->get_id()."\">Paid";
+                $radio_buttons.= "<input type=\"radio\" id=\"invoiceItemStatus_approved_".$invoiceItem->get_id()."\" name=\"invoiceItemStatus[".$invoiceItem->get_id()."]\"";
+                $radio_buttons.= " value=\"approved\"".$sel["approved"].">";
+                $radio_buttons.= "</label>";
 
 
-      unset($TPL["invoiceItem_buttons"]);
-        
-    } else if ($invoice->get_value("invoiceStatus") == "finished") {
+                $TPL["invoiceItem_buttons_top"] = $radio_buttons;
+                $TPL["invoiceItem_buttons_top"].= "&nbsp;&nbsp;&nbsp;&nbsp;<input type=\"text\" size=\"7\" name=\"invoiceItemAmountPaid[".$invoiceItem->get_id()."]\" value=\"".$amount."\">";
+                $TPL["invoiceItem_buttons_top"].= "<input type=\"hidden\" name=\"invoiceItemAmountPaidTfID[".$invoiceItem->get_id()."]\" value=\"".$selected_tfID."\">";
+            }
 
 
-      
-
-    } else if (is_object($invoice) && $invoice->get_value("invoiceStatus") == "edit") {
-      $TPL["invoiceItem_buttons"] = '
+            unset($TPL["invoiceItem_buttons"]);
+        } else if ($invoice->get_value("invoiceStatus") == "finished") {
+        } else if (is_object($invoice) && $invoice->get_value("invoiceStatus") == "edit") {
+            $TPL["invoiceItem_buttons"] = '
         <button type="submit" name="invoiceItem_delete['.$invoiceItem->get_id().']" value="1" class="delete_button">Delete<i class="icon-trash"></i></button>
         <button type="submit" name="invoiceItem_edit['.$invoiceItem->get_id().']" value="1">Edit<i class="icon-edit"></i></button>
       ';
+        }
+
+        if ($invoiceItem->get_value("timeSheetID")) {
+            $t = new timeSheet();
+            $t->set_id($invoiceItem->get_value("timeSheetID"));
+            $t->select();
+            $t->load_pay_info();
+            $amount = $t->pay_info["total_customerBilledDollars"] or $amount = $t->pay_info["total_dollars"];
+
+            $TPL["invoiceItem_iiMemo"] = "<a href=\"".$TPL["url_alloc_timeSheet"]."timeSheetID=".$invoiceItem->get_value("timeSheetID")."\">".$invoiceItem->get_value("iiMemo")." (Currently: $".$amount.", Status: ".$t->get_timeSheet_status().")</a>";
+        } else if ($invoiceItem->get_value("expenseFormID")) {
+            $ep = $invoiceItem->get_foreign_object("expenseForm");
+            $total = $ep->get_abs_sum_transactions();
+            $TPL["invoiceItem_iiMemo"] = "<a href=\"".$TPL["url_alloc_expenseForm"]."expenseFormID=".$invoiceItem->get_value("expenseFormID")."\">".$invoiceItem->get_value("iiMemo")." (Currently: ".page::money(config::get_config_item("currency"), $total, "%s%m %c").", Status: ".$ep->get_status().")</a>";
+        }
+
+        $TPL["currency"] = $invoice->get_value("currencyTypeID");
+        include_template($template);
     }
-
-    if ($invoiceItem->get_value("timeSheetID")) {
-      $t = new timeSheet();
-      $t->set_id($invoiceItem->get_value("timeSheetID"));
-      $t->select();
-      $t->load_pay_info();
-      $amount = $t->pay_info["total_customerBilledDollars"] or $amount = $t->pay_info["total_dollars"];
-
-      $TPL["invoiceItem_iiMemo"] = "<a href=\"".$TPL["url_alloc_timeSheet"]."timeSheetID=".$invoiceItem->get_value("timeSheetID")."\">".$invoiceItem->get_value("iiMemo")." (Currently: $".$amount.", Status: ".$t->get_timeSheet_status().")</a>";
-
-
-    } else if ($invoiceItem->get_value("expenseFormID")) {
-      $ep = $invoiceItem->get_foreign_object("expenseForm");
-      $total = $ep->get_abs_sum_transactions();
-      $TPL["invoiceItem_iiMemo"] = "<a href=\"".$TPL["url_alloc_expenseForm"]."expenseFormID=".$invoiceItem->get_value("expenseFormID")."\">".$invoiceItem->get_value("iiMemo")." (Currently: ".page::money(config::get_config_item("currency"),$total,"%s%m %c").", Status: ".$ep->get_status().")</a>";
-    } 
-
-    $TPL["currency"] = $invoice->get_value("currencyTypeID");
-    include_template($template);
-  }
-
 }
 
-function show_attachments($invoiceID) {
-  global $TPL;
-  $options["hide_buttons"] = true;
-  util_show_attachments("invoice",$invoiceID, $options);
+function show_attachments($invoiceID)
+{
+    global $TPL;
+    $options["hide_buttons"] = true;
+    util_show_attachments("invoice", $invoiceID, $options);
 }
 
-function show_comments() {
-  global $invoiceID;
-  global $TPL;
-  global $invoice;
-  if ($invoiceID) {
-    $TPL["commentsR"] = comment::util_get_comments("invoice",$invoiceID);
-    $TPL["class_new_comment"] = "hidden";
+function show_comments()
+{
+    global $invoiceID;
+    global $TPL;
+    global $invoice;
+    if ($invoiceID) {
+        $TPL["commentsR"] = comment::util_get_comments("invoice", $invoiceID);
+        $TPL["class_new_comment"] = "hidden";
   
-    if ($invoice->get_value("projectID")) {
-      $project = $invoice->get_foreign_object("project");
-      $interestedPartyOptions = $project->get_all_parties($invoice->get_value("projectID"));
-      $client = $project->get_foreign_object("client");
-      $clientID = $client->get_id();
+        if ($invoice->get_value("projectID")) {
+            $project = $invoice->get_foreign_object("project");
+            $interestedPartyOptions = $project->get_all_parties($invoice->get_value("projectID"));
+            $client = $project->get_foreign_object("client");
+            $clientID = $client->get_id();
+        } else if ($invoice->get_value("clientID")) {
+            $client = $invoice->get_foreign_object("client");
+            $interestedPartyOptions = $client->get_all_parties($invoice->get_value("clientID"));
+            $clientID = $client->get_id();
+        }
 
-    } else if ($invoice->get_value("clientID")) {
-      $client = $invoice->get_foreign_object("client");
-      $interestedPartyOptions = $client->get_all_parties($invoice->get_value("clientID"));
-      $clientID = $client->get_id();
+        $interestedPartyOptions = interestedParty::get_interested_parties(
+            "invoice",
+            $invoice->get_id(),
+            $interestedPartyOptions
+        );
+        $TPL["allParties"] = $interestedPartyOptions or $TPL["allParties"] = array();
+        $TPL["entity"] = "invoice";
+        $TPL["entityID"] = $invoice->get_id();
+        $TPL["clientID"] = $clientID;
+        $commentTemplate = new commentTemplate();
+        $ops = $commentTemplate->get_assoc_array("commentTemplateID", "commentTemplateName", "", array("commentTemplateType"=>"invoice"));
+        $TPL["commentTemplateOptions"] = "<option value=\"\">Comment Templates</option>".page::select_options($ops);
+
+        $ops = array(""=>"Format as...","generate_pdf" => "PDF Invoice","generate_pdf_verbose"=>"PDF Invoice - verbose");
+        $TPL["attach_extra_files"] = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
+        $TPL["attach_extra_files"].= "Attach Invoice ";
+        $TPL["attach_extra_files"].= '<select name="attach_invoice">'.page::select_options($ops).'</select><br>';
+        include_template("../comment/templates/commentM.tpl");
     }
-
-    $interestedPartyOptions = interestedParty::get_interested_parties("invoice",$invoice->get_id()
-                                                                     ,$interestedPartyOptions);
-    $TPL["allParties"] = $interestedPartyOptions or $TPL["allParties"] = array();
-    $TPL["entity"] = "invoice";
-    $TPL["entityID"] = $invoice->get_id();
-    $TPL["clientID"] = $clientID;
-    $commentTemplate = new commentTemplate();
-    $ops = $commentTemplate->get_assoc_array("commentTemplateID","commentTemplateName","",array("commentTemplateType"=>"invoice"));
-    $TPL["commentTemplateOptions"] = "<option value=\"\">Comment Templates</option>".page::select_options($ops);
-
-    $ops = array(""=>"Format as...","generate_pdf" => "PDF Invoice","generate_pdf_verbose"=>"PDF Invoice - verbose");
-    $TPL["attach_extra_files"] = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
-    $TPL["attach_extra_files"].= "Attach Invoice ";
-    $TPL["attach_extra_files"].= '<select name="attach_invoice">'.page::select_options($ops).'</select><br>';
-    include_template("../comment/templates/commentM.tpl");
-  }
 }
 
 $invoiceID = $_POST["invoiceID"] or $invoiceID = $_GET["invoiceID"];
@@ -431,175 +421,162 @@ $invoice = new invoice();
 
 
 if ($invoiceID) {
-  $invoice->set_id($invoiceID);
-  $invoice->select();
-  $invoice->set_values();
-  $invoiceItemIDs = invoice::get_invoiceItems($invoiceID);
+    $invoice->set_id($invoiceID);
+    $invoice->select();
+    $invoice->set_values();
+    $invoiceItemIDs = invoice::get_invoiceItems($invoiceID);
 }
 
 
 // If creating a new invoice
 if ($_POST["save"] || $_POST["save_and_MoveForward"] || $_POST["save_and_MoveBack"]) {
-  $invoice->read_globals();
+    $invoice->read_globals();
 
   // Validation
-  if ($invoice->get_value("projectID")) {
-    $project = $invoice->get_foreign_object("project");
-    $currency = $project->get_value("currencyTypeID");
-    $invoice->set_value("clientID",$project->get_value("clientID"));
-  }
-
-  if (!$invoice->get_value("clientID")) {
-    alloc_error("Please select a Client.");
-  }
-
-  $currency or $currency = config::get_config_item("currency");
-  $invoice->set_value("currencyTypeID",$currency);
-
-
-  if (!$invoice->get_value("invoiceNum") || !is_numeric($invoice->get_value("invoiceNum"))) {
-    #alloc_error("Please enter a unique Invoice Number.");
-    $invoice->set_value("invoiceNum",invoice::get_next_invoiceNum());
-  } else {
-    $invoiceID and $invoiceID_sql = prepare(" AND invoiceID != %d",$invoiceID);
-    $q = prepare("SELECT * FROM invoice WHERE invoiceNum = '%s' ".$invoiceID_sql,$invoice->get_value("invoiceNum"));
-    $db->query($q);
-    if ($db->row()) {
-      alloc_error("Please enter a unique Invoice Number (that number is already taken).");
+    if ($invoice->get_value("projectID")) {
+        $project = $invoice->get_foreign_object("project");
+        $currency = $project->get_value("currencyTypeID");
+        $invoice->set_value("clientID", $project->get_value("clientID"));
     }
-  }
 
-  if (!$invoice->get_value("invoiceName") && $invoice->get_value("clientID")) {
-    $client = new client();
-    $client->set_id($invoice->get_value("clientID"));
-    $client->select();
-    $invoice->set_value("invoiceName", $client->get_value("clientName"));
-  } 
-  if ($_POST["save_and_MoveForward"]) {
-    $direction = "forwards";
-  } else if ($_POST["save_and_MoveBack"]) {
-    $direction = "backwards";
-  }
-
-  if (!$TPL["message"]) {
-
-    if (!$invoice->get_value("invoiceStatus")) {
-      $invoice->set_value("invoiceStatus","edit");
+    if (!$invoice->get_value("clientID")) {
+        alloc_error("Please select a Client.");
     }
-    // Save invoice Item approved/rejected info
-    $invoiceItemIDs = $invoice->get_invoiceItems();
-    foreach ($invoiceItemIDs as $iiID) {
-      $status = $_POST["invoiceItemStatus"][$iiID];
-      if ($status || $_POST["changeTransactionStatus"]) {
-        $_POST["changeTransactionStatus"] and $status = $_POST["changeTransactionStatus"];
-        if ($status) {
-          $ii = new invoiceItem();
-          $ii->set_id($iiID);
-          $ii->select();
-          $ii->create_transaction($_POST["invoiceItemAmountPaid"][$iiID],$invoice->get_value("tfID"),$status);
+
+    $currency or $currency = config::get_config_item("currency");
+    $invoice->set_value("currencyTypeID", $currency);
+
+
+    if (!$invoice->get_value("invoiceNum") || !is_numeric($invoice->get_value("invoiceNum"))) {
+      #alloc_error("Please enter a unique Invoice Number.");
+        $invoice->set_value("invoiceNum", invoice::get_next_invoiceNum());
+    } else {
+        $invoiceID and $invoiceID_sql = prepare(" AND invoiceID != %d", $invoiceID);
+        $q = prepare("SELECT * FROM invoice WHERE invoiceNum = '%s' ".$invoiceID_sql, $invoice->get_value("invoiceNum"));
+        $db->query($q);
+        if ($db->row()) {
+            alloc_error("Please enter a unique Invoice Number (that number is already taken).");
         }
-      }
+    }
+
+    if (!$invoice->get_value("invoiceName") && $invoice->get_value("clientID")) {
+        $client = new client();
+        $client->set_id($invoice->get_value("clientID"));
+        $client->select();
+        $invoice->set_value("invoiceName", $client->get_value("clientName"));
+    }
+    if ($_POST["save_and_MoveForward"]) {
+        $direction = "forwards";
+    } else if ($_POST["save_and_MoveBack"]) {
+        $direction = "backwards";
     }
 
     if (!$TPL["message"]) {
-      $invoice->change_status($direction);
+        if (!$invoice->get_value("invoiceStatus")) {
+            $invoice->set_value("invoiceStatus", "edit");
+        }
+      // Save invoice Item approved/rejected info
+        $invoiceItemIDs = $invoice->get_invoiceItems();
+        foreach ($invoiceItemIDs as $iiID) {
+            $status = $_POST["invoiceItemStatus"][$iiID];
+            if ($status || $_POST["changeTransactionStatus"]) {
+                $_POST["changeTransactionStatus"] and $status = $_POST["changeTransactionStatus"];
+                if ($status) {
+                    $ii = new invoiceItem();
+                    $ii->set_id($iiID);
+                    $ii->select();
+                    $ii->create_transaction($_POST["invoiceItemAmountPaid"][$iiID], $invoice->get_value("tfID"), $status);
+                }
+            }
+        }
+
+        if (!$TPL["message"]) {
+            $invoice->change_status($direction);
+        }
+
+        $invoice->save();
+        $invoiceID = $invoice->get_id();
+
+        $TPL["message_good"][] = "Invoice saved.";
+        alloc_redirect($TPL["url_alloc_invoice"]."invoiceID=".$invoiceID.$extra);
     }
-
-    $invoice->save();
-    $invoiceID = $invoice->get_id();
-
-    $TPL["message_good"][] = "Invoice saved.";
-    alloc_redirect($TPL["url_alloc_invoice"]."invoiceID=".$invoiceID.$extra);
-  }
-
 } else if ($_POST["delete"] && $invoice->get_value("invoiceStatus") == "edit") {
-  
-  if ($invoiceItemIDs) {
-    $db = new db_alloc();
-    $q = prepare("DELETE FROM transaction WHERE invoiceItemID in (%s)",$invoiceItemIDs);
-    $db->query($q);
-    $q = prepare("DELETE FROM invoiceItem WHERE invoiceItemID in (%s)",$invoiceItemIDs);
-    $db->query($q);
-  }
+    if ($invoiceItemIDs) {
+        $db = new db_alloc();
+        $q = prepare("DELETE FROM transaction WHERE invoiceItemID in (%s)", $invoiceItemIDs);
+        $db->query($q);
+        $q = prepare("DELETE FROM invoiceItem WHERE invoiceItemID in (%s)", $invoiceItemIDs);
+        $db->query($q);
+    }
 
   // should probablg delete/unlink the pdf docs
 
-  $invoice->delete();
-  $TPL["message_good"][] = "Invoice deleted.";
-  alloc_redirect($TPL["url_alloc_invoiceList"]);
+    $invoice->delete();
+    $TPL["message_good"][] = "Invoice deleted.";
+    alloc_redirect($TPL["url_alloc_invoiceList"]);
 
 
 // Saving editing individual invoiceItems
 } else if (($_POST["invoiceItem_save"] || $_POST["invoiceItem_edit"] || $_POST["invoiceItem_delete"]) && $invoice->get_value("invoiceStatus") == "edit") {
+    is_array($_POST["invoiceItem_edit"]) and $invoiceItemID = key($_POST["invoiceItem_edit"]);
+    is_array($_POST["invoiceItem_delete"]) and $invoiceItemID = key($_POST["invoiceItem_delete"]);
 
-  is_array($_POST["invoiceItem_edit"]) and $invoiceItemID = key($_POST["invoiceItem_edit"]);
-  is_array($_POST["invoiceItem_delete"]) and $invoiceItemID = key($_POST["invoiceItem_delete"]);
-
-  $invoiceItem = new invoiceItem();
-  $invoiceItem->currency = $invoice->get_value("currencyTypeID");
-  $invoiceItem->set_id($invoiceItemID);
+    $invoiceItem = new invoiceItem();
+    $invoiceItem->currency = $invoice->get_value("currencyTypeID");
+    $invoiceItem->set_id($invoiceItemID);
   #echo $invoiceItem->get_id();
-  $invoice->set_id($invoiceID);
-  $invoice->select();
+    $invoice->set_id($invoiceID);
+    $invoice->select();
 
   #echo "<pre>".print_r($_POST,1)."</pre>";
 
-  $_POST["iiTax"] or $_POST["iiTax"] = '';
+    $_POST["iiTax"] or $_POST["iiTax"] = '';
 
-  if ($_POST["invoiceItem_save"]) {
-    $invoiceItem->read_globals();
-    $invoiceItem->read_globals("invoiceItem_");
+    if ($_POST["invoiceItem_save"]) {
+        $invoiceItem->read_globals();
+        $invoiceItem->read_globals("invoiceItem_");
 
-    if ($_POST["timeSheetID"] && $_POST["split_timeSheet"]) {
-      invoiceEntity::create($invoiceItem->get_value("invoiceID"),"timeSheet",$_POST["timeSheetID"],1);
-      invoiceEntity::save_invoice_timeSheetItems($invoiceItem->get_value("invoiceID"),$_POST["timeSheetID"]);
+        if ($_POST["timeSheetID"] && $_POST["split_timeSheet"]) {
+            invoiceEntity::create($invoiceItem->get_value("invoiceID"), "timeSheet", $_POST["timeSheetID"], 1);
+            invoiceEntity::save_invoice_timeSheetItems($invoiceItem->get_value("invoiceID"), $_POST["timeSheetID"]);
+        } else if ($_POST["timeSheetID"]) {
+            invoiceEntity::create($invoiceItem->get_value("invoiceID"), "timeSheet", $_POST["timeSheetID"]);
+            invoiceEntity::save_invoice_timeSheet($invoiceItem->get_value("invoiceID"), $_POST["timeSheetID"]);
+        } else if ($_POST["expenseFormID"] && $_POST["split_expenseForm"]) {
+            invoiceEntity::create($invoiceItem->get_value("invoiceID"), "expenseForm", $_POST["expenseFormID"], 1);
+            invoiceEntity::save_invoice_expenseFormItems($invoiceItem->get_value("invoiceID"), $_POST["expenseFormID"]);
+        } else if ($_POST["expenseFormID"]) {
+            invoiceEntity::create($invoiceItem->get_value("invoiceID"), "expenseForm", $_POST["expenseFormID"]);
+            invoiceEntity::save_invoice_expenseForm($invoiceItem->get_value("invoiceID"), $_POST["expenseFormID"]);
+        } else if ($_POST["productSaleID"] && $_POST["split_productSale"]) {
+            invoiceEntity::create($invoiceItem->get_value("invoiceID"), "productSale", $_POST["productSaleID"], 1);
+            invoiceEntity::save_invoice_productSaleItems($invoiceItem->get_value("invoiceID"), $_POST["productSaleID"]);
+        } else if ($_POST["productSaleID"]) {
+            invoiceEntity::create($invoiceItem->get_value("invoiceID"), "productSale", $_POST["productSaleID"]);
+            invoiceEntity::save_invoice_productSale($invoiceItem->get_value("invoiceID"), $_POST["productSaleID"]);
+        } else {
+            $invoiceItem->save();
+        }
 
-    } else if ($_POST["timeSheetID"]) {
-      invoiceEntity::create($invoiceItem->get_value("invoiceID"),"timeSheet",$_POST["timeSheetID"]);
-      invoiceEntity::save_invoice_timeSheet($invoiceItem->get_value("invoiceID"),$_POST["timeSheetID"]);
-
-    } else if ($_POST["expenseFormID"] && $_POST["split_expenseForm"]) {
-      invoiceEntity::create($invoiceItem->get_value("invoiceID"),"expenseForm",$_POST["expenseFormID"],1);
-      invoiceEntity::save_invoice_expenseFormItems($invoiceItem->get_value("invoiceID"),$_POST["expenseFormID"]);
-
-    } else if ($_POST["expenseFormID"]) {
-      invoiceEntity::create($invoiceItem->get_value("invoiceID"),"expenseForm",$_POST["expenseFormID"]);
-      invoiceEntity::save_invoice_expenseForm($invoiceItem->get_value("invoiceID"),$_POST["expenseFormID"]);
-
-    } else if ($_POST["productSaleID"] && $_POST["split_productSale"]) {
-      invoiceEntity::create($invoiceItem->get_value("invoiceID"),"productSale",$_POST["productSaleID"],1);
-      invoiceEntity::save_invoice_productSaleItems($invoiceItem->get_value("invoiceID"),$_POST["productSaleID"]);
-
-    } else if ($_POST["productSaleID"]) {
-      invoiceEntity::create($invoiceItem->get_value("invoiceID"),"productSale",$_POST["productSaleID"]);
-      invoiceEntity::save_invoice_productSale($invoiceItem->get_value("invoiceID"),$_POST["productSaleID"]);
-
-    } else {
-      $invoiceItem->save();
+        $TPL["message_good"][] = "Invoice Item saved.";
+        alloc_redirect($TPL["url_alloc_invoice"]."invoiceID=".$invoiceItem->get_value("invoiceID"));
+    } else if ($_POST["invoiceItem_edit"]) {
+      // Hmph. Nothing needs to go here?
+    } else if ($_POST["invoiceItem_delete"]) {
+        $invoiceItem->select();
+        $invoiceItem->delete();
+        $TPL["message_good"][] = "Invoice Item deleted.";
+        alloc_redirect($TPL["url_alloc_invoice"]."invoiceID=".$invoiceID);
     }
-
-    $TPL["message_good"][] = "Invoice Item saved.";
-    alloc_redirect($TPL["url_alloc_invoice"]."invoiceID=".$invoiceItem->get_value("invoiceID"));
-
-  } else if ($_POST["invoiceItem_edit"]) {
-    // Hmph. Nothing needs to go here?
-
-  } else if ($_POST["invoiceItem_delete"]) {
-
-    $invoiceItem->select();
-    $invoiceItem->delete();
-    $TPL["message_good"][] = "Invoice Item deleted.";
-    alloc_redirect($TPL["url_alloc_invoice"]."invoiceID=".$invoiceID);
-  }
   // Displaying a record
-  $invoice->set_id($invoiceID);
-  $invoice->select();
+    $invoice->set_id($invoiceID);
+    $invoice->select();
 
-// if someone uploads an attachment                                                                                                                                      
+// if someone uploads an attachment
 } else if ($_POST["save_attachment"]) {
-  move_attachment("invoice",$invoiceID);
-  $TPL["message_good"][] = "Attachment saved.";
-  alloc_redirect($TPL["url_alloc_invoice"]."invoiceID=".$invoiceID);
+    move_attachment("invoice", $invoiceID);
+    $TPL["message_good"][] = "Attachment saved.";
+    alloc_redirect($TPL["url_alloc_invoice"]."invoiceID=".$invoiceID);
 }
 
 
@@ -608,8 +585,8 @@ if ($_POST["save"] || $_POST["save_and_MoveForward"] || $_POST["save_and_MoveBac
 
 
 if ($invoiceID && $invoiceItemIDs) {
-  $currency = $invoice->get_value("currencyTypeID");
-  $q = prepare("SELECT SUM(IF((iiTax IS NULL OR iiTax = 0) AND value,
+    $currency = $invoice->get_value("currencyTypeID");
+    $q = prepare("SELECT SUM(IF((iiTax IS NULL OR iiTax = 0) AND value,
                           (value/100+1) * iiAmount * pow(10,-currencyType.numberToBasic),
                           iiAmount * pow(10,-currencyType.numberToBasic)
                       )) as sum_iiAmount
@@ -617,17 +594,17 @@ if ($invoiceID && $invoiceItemIDs) {
              LEFT JOIN invoice on invoiceItem.invoiceID = invoice.invoiceID
              LEFT JOIN currencyType on invoice.currencyTypeID = currencyType.currencyTypeID
              LEFT JOIN config ON config.name = 'taxPercent'
-                 WHERE invoiceItem.invoiceID = %d",$invoiceID);
-  $db->query($q);
-  $db->next_record() and $TPL["invoiceTotal"] = page::money($currency,$db->f("sum_iiAmount"),"%S%m %c");
+                 WHERE invoiceItem.invoiceID = %d", $invoiceID);
+    $db->query($q);
+    $db->next_record() and $TPL["invoiceTotal"] = page::money($currency, $db->f("sum_iiAmount"), "%S%m %c");
 
-  $q = prepare("SELECT sum(amount * pow(10,-currencyType.numberToBasic)) as sum_transaction_amount
+    $q = prepare("SELECT sum(amount * pow(10,-currencyType.numberToBasic)) as sum_transaction_amount
                   FROM transaction 
              LEFT JOIN currencyType on transaction.currencyTypeID = currencyType.currencyTypeID
                  WHERE status = 'approved' 
-                   AND invoiceItemID in (%s)",$invoiceItemIDs);
-  $db->query($q);
-  $db->next_record() and $TPL["invoiceTotalPaid"] = page::money($currency,$db->f("sum_transaction_amount"),"%S%m %c");
+                   AND invoiceItemID in (%s)", $invoiceItemIDs);
+    $db->query($q);
+    $db->next_record() and $TPL["invoiceTotalPaid"] = page::money($currency, $db->f("sum_transaction_amount"), "%S%m %c");
 }
 
 
@@ -636,18 +613,18 @@ $invoice->set_values();
 $statii = invoice::get_invoice_statii();
 
 foreach ($statii as $s => $label) {
-  unset($pre,$suf);// prefix and suffix
-  $status = $invoice->get_value("invoiceStatus");
-  if (!$invoice->get_id()) {
-    $status = "create";
-  }
+    unset($pre, $suf);// prefix and suffix
+    $status = $invoice->get_value("invoiceStatus");
+    if (!$invoice->get_id()) {
+        $status = "create";
+    }
 
-  if ($s == $status) {
-    $pre = "<b>";
-    $suf = "</b>";
-  }
-  $TPL["invoice_status_label"].= $sep.$pre.$label.$suf;
-  $sep = "&nbsp;&nbsp;|&nbsp;&nbsp;";
+    if ($s == $status) {
+        $pre = "<b>";
+        $suf = "</b>";
+    }
+    $TPL["invoice_status_label"].= $sep.$pre.$label.$suf;
+    $sep = "&nbsp;&nbsp;|&nbsp;&nbsp;";
 }
 
 
@@ -666,154 +643,150 @@ foreach ($statii as $s => $label) {
 
 $TPL["field_invoiceNum"] = '<input type="text" name="invoiceNum" value="'.$TPL["invoiceNum"].'">';
 $TPL["field_invoiceName"] = '<input type="text" name="invoiceName" value="'.$TPL["invoiceName"].'">';
-$TPL["field_maxAmount"] = '<input type="text" name="maxAmount" size="10" value="'.$invoice->get_value("maxAmount",DST_HTML_DISPLAY).'"> ';
+$TPL["field_maxAmount"] = '<input type="text" name="maxAmount" size="10" value="'.$invoice->get_value("maxAmount", DST_HTML_DISPLAY).'"> ';
 $TPL["field_maxAmount"].= page::help('invoice_maxAmount');
-$TPL["field_invoiceDateFrom"] = page::calendar("invoiceDateFrom",$TPL["invoiceDateFrom"]);
-$TPL["field_invoiceDateTo"] = page::calendar("invoiceDateTo",$TPL["invoiceDateTo"]);
+$TPL["field_invoiceDateFrom"] = page::calendar("invoiceDateFrom", $TPL["invoiceDateFrom"]);
+$TPL["field_invoiceDateTo"] = page::calendar("invoiceDateTo", $TPL["invoiceDateTo"]);
 
 $clientID = $invoice->get_value("clientID") or $clientID = $_GET["clientID"];
 $projectID = $invoice->get_value("projectID") or $projectID = $_GET["projectID"];
 
-list($client_select, $client_link, $project_select, $project_link) 
+list($client_select, $client_link, $project_select, $project_link)
   = client::get_client_and_project_dropdowns_and_links($clientID, $projectID);
 
 $tf = new tf();
 if ($invoice->get_value("tfID")) {
-  $tf->set_id($invoice->get_value("tfID"));
-  $tf->select();
-  $tf_link = $tf->get_link();
-  $tf_sel = $invoice->get_value("tfID");
+    $tf->set_id($invoice->get_value("tfID"));
+    $tf->select();
+    $tf_link = $tf->get_link();
+    $tf_sel = $invoice->get_value("tfID");
 }
 $tf_sel or $tf_sel = config::get_config_item("mainTfID");
-$tf_select = "<select id='tfID' name='tfID'>".page::select_options($tf->get_assoc_array("tfID","tfName"),$tf_sel)."</select>";
+$tf_select = "<select id='tfID' name='tfID'>".page::select_options($tf->get_assoc_array("tfID", "tfName"), $tf_sel)."</select>";
 
 
 // Main invoice buttons
 if ($current_user->have_role('admin')) {
-
-  if (!$invoiceID) {
-    $_GET["clientID"] and $TPL["clientID"] = $_GET["clientID"];
-    $TPL["invoice_buttons"] = '
+    if (!$invoiceID) {
+        $_GET["clientID"] and $TPL["clientID"] = $_GET["clientID"];
+        $TPL["invoice_buttons"] = '
          <button type="submit" name="save" value="1" class="save_button">Create Invoice<i class="icon-ok-sign"></i></button>
     ';
-    $TPL["field_clientID"] = $client_select;
-    $TPL["field_projectID"] = $project_select;
-    $TPL["field_tfID"] = $tf_select;
-
-  } else if ($invoice->get_value("invoiceStatus") == "edit") {
-    $TPL["invoice_buttons"] = '
+        $TPL["field_clientID"] = $client_select;
+        $TPL["field_projectID"] = $project_select;
+        $TPL["field_tfID"] = $tf_select;
+    } else if ($invoice->get_value("invoiceStatus") == "edit") {
+        $TPL["invoice_buttons"] = '
         <button type="submit" name="delete" value="1" class="delete_button">Delete<i class="icon-trash"></i></button>
         <button type="submit" name="save" value="1" class="save_button">Save<i class="icon-ok-sign"></i></button>
         <button type="submit" name="save_and_MoveForward" value="1" class="save_button">'.$statii["reconcile"].'<i class="icon-arrow-right"></i></button>
     ';
+        $options["clientStatus"] = "Current";
+        $options["return"] = "dropdown_options";
+        $ops = client::get_list($options);
+        $TPL["field_clientID"] = $client_select;
+        $TPL["field_projectID"] = $project_select;
+        $TPL["field_tfID"] = $tf_select;
+    } else if ($invoice->get_value("invoiceStatus") == "reconcile") {
+        $TPL["invoice_buttons"] = '
+        <button type="submit" name="save_and_MoveBack" value="1" class="save_button"><i class="icon-arrow-left" style="margin:0px; margin-right:5px"></i>Back</button>
+        <button type="submit" name="save" value="1" class="save_button">Save<i class="icon-ok-sign"></i></button>
+        <button type="submit" name="save_and_MoveForward" value="1" class="save_button">Invoice to '.$statii["finished"].'<i class="icon-arrow-right"></i></button>
+        <select name="changeTransactionStatus"><option value="">Transaction Status<option value="approved">Approve<option value="rejected">Reject</select>';
+
+        $TPL["field_invoiceNum"] = $TPL["invoiceNum"];
+        $TPL["field_invoiceName"] = page::htmlentities($TPL["invoiceName"]);
+        $TPL["field_clientID"] = $client_link;
+        $TPL["field_projectID"] = $project_link;
+        $TPL["field_tfID"] = $tf_link;
+        $TPL["field_maxAmount"] = page::money($currency, $TPL["maxAmount"], "%s%mo %c");
+        $TPL["field_invoiceDateFrom"] = $TPL["invoiceDateFrom"];
+        $TPL["field_invoiceDateTo"] = $TPL["invoiceDateTo"];
+    } else if ($invoice->get_value("invoiceStatus") == "finished") {
+        $TPL["invoice_buttons"] = '
+        <button type="submit" name="save_and_MoveBack" value="1" class="save_button"><i class="icon-arrow-left" style="margin:0px; margin-right:5px"></i>Back</button>
+    ';
+        $TPL["field_invoiceNum"] = $TPL["invoiceNum"];
+        $TPL["field_invoiceName"] = page::htmlentities($TPL["invoiceName"]);
+        $TPL["field_clientID"] = $client_link;
+        $TPL["field_projectID"] = $project_link;
+        $TPL["field_tfID"] = $tf_link;
+        $TPL["field_maxAmount"] = page::money($currency, $TPL["maxAmount"], "%s%mo %c");
+        $TPL["field_invoiceDateFrom"] = $TPL["invoiceDateFrom"];
+        $TPL["field_invoiceDateTo"] = $TPL["invoiceDateTo"];
+    }
+} else {
+    $TPL["field_invoiceNum"] = $TPL["invoiceNum"];
+    $TPL["field_invoiceName"] = $TPL["invoiceName"];
+    $TPL["field_clientID"] = $client_link;
+    $TPL["field_projectID"] = $project_link;
+    $TPL["field_tfID"] = $tf_link;
+    $TPL["field_maxAmount"] = page::money($currency, $TPL["maxAmount"], "%s%mo %c");
+    $TPL["field_invoiceDateFrom"] = $TPL["invoiceDateFrom"];
+    $TPL["field_invoiceDateTo"] = $TPL["invoiceDateTo"];
+}
+
+if (!$invoice->get_value("clientID")) {
     $options["clientStatus"] = "Current";
     $options["return"] = "dropdown_options";
     $ops = client::get_list($options);
     $TPL["field_clientID"] = $client_select;
     $TPL["field_projectID"] = $project_select;
     $TPL["field_tfID"] = $tf_select;
-
-  } else if ($invoice->get_value("invoiceStatus") == "reconcile") {
-
-    $TPL["invoice_buttons"] = '
-        <button type="submit" name="save_and_MoveBack" value="1" class="save_button"><i class="icon-arrow-left" style="margin:0px; margin-right:5px"></i>Back</button>
-        <button type="submit" name="save" value="1" class="save_button">Save<i class="icon-ok-sign"></i></button>
-        <button type="submit" name="save_and_MoveForward" value="1" class="save_button">Invoice to '.$statii["finished"].'<i class="icon-arrow-right"></i></button>
-        <select name="changeTransactionStatus"><option value="">Transaction Status<option value="approved">Approve<option value="rejected">Reject</select>';
-
-    $TPL["field_invoiceNum"] = $TPL["invoiceNum"];
-    $TPL["field_invoiceName"] = page::htmlentities($TPL["invoiceName"]);
-    $TPL["field_clientID"] = $client_link;
-    $TPL["field_projectID"] = $project_link;
-    $TPL["field_tfID"] = $tf_link;
-    $TPL["field_maxAmount"] = page::money($currency,$TPL["maxAmount"],"%s%mo %c");
-    $TPL["field_invoiceDateFrom"] = $TPL["invoiceDateFrom"];
-    $TPL["field_invoiceDateTo"] = $TPL["invoiceDateTo"];
-
-  } else if ($invoice->get_value("invoiceStatus") == "finished") {
-    $TPL["invoice_buttons"] = '
-        <button type="submit" name="save_and_MoveBack" value="1" class="save_button"><i class="icon-arrow-left" style="margin:0px; margin-right:5px"></i>Back</button>
-    ';
-    $TPL["field_invoiceNum"] = $TPL["invoiceNum"];
-    $TPL["field_invoiceName"] = page::htmlentities($TPL["invoiceName"]);
-    $TPL["field_clientID"] = $client_link;
-    $TPL["field_projectID"] = $project_link;
-    $TPL["field_tfID"] = $tf_link;
-    $TPL["field_maxAmount"] = page::money($currency,$TPL["maxAmount"],"%s%mo %c");
-    $TPL["field_invoiceDateFrom"] = $TPL["invoiceDateFrom"];
-    $TPL["field_invoiceDateTo"] = $TPL["invoiceDateTo"];
-  }
-} else {
-  $TPL["field_invoiceNum"] = $TPL["invoiceNum"];
-  $TPL["field_invoiceName"] = $TPL["invoiceName"];
-  $TPL["field_clientID"] = $client_link;
-  $TPL["field_projectID"] = $project_link;
-  $TPL["field_tfID"] = $tf_link;
-  $TPL["field_maxAmount"] = page::money($currency,$TPL["maxAmount"],"%s%mo %c");
-  $TPL["field_invoiceDateFrom"] = $TPL["invoiceDateFrom"];
-  $TPL["field_invoiceDateTo"] = $TPL["invoiceDateTo"];
 }
 
-if (!$invoice->get_value("clientID")) {
-  $options["clientStatus"] = "Current";
-  $options["return"] = "dropdown_options";
-  $ops = client::get_list($options);
-  $TPL["field_clientID"] = $client_select;
-  $TPL["field_projectID"] = $project_select;
-  $TPL["field_tfID"] = $tf_select;
-} 
 
-
-if (is_object($invoice) && $invoice->get_id() 
+if (is_object($invoice) && $invoice->get_id()
 && ($invoice->get_value("invoiceStatus") == "reconcile" || $invoice->get_value("invoiceStatus") == "finished")
 && $invoice->has_attachment_permission($current_user)) {
-  define("SHOW_INVOICE_ATTACHMENTS",1);
+    define("SHOW_INVOICE_ATTACHMENTS", 1);
 }
 
 if ($invoiceID) {
-  $TPL["main_alloc_title"] = "Invoice " . $TPL["invoiceNum"] . " - ".APPLICATION_NAME;
+    $TPL["main_alloc_title"] = "Invoice " . $TPL["invoiceNum"] . " - ".APPLICATION_NAME;
 } else {
-  $TPL["main_alloc_title"] = "New Invoice - ".APPLICATION_NAME;
+    $TPL["main_alloc_title"] = "New Invoice - ".APPLICATION_NAME;
 }
 
 
 $invoiceRepeat = new invoiceRepeat();
 if (is_object($invoice) && $invoice->get_id()) {
-  $q = prepare("SELECT * FROM invoiceRepeat WHERE invoiceID = %d LIMIT 1",$invoice->get_id());
-  $qid1 = $db->query($q);
-  if ($db->row($qid1)) {
-    $invoiceRepeat->read_db_record($db);
-    $invoiceRepeat->set_values("invoiceRepeat_");
-    foreach (explode(" ",$TPL["invoiceRepeat_frequency"]) as $id) {
-      if ($id) {
-        $qid2 = $db->query("SELECT * FROM invoice WHERE invoiceRepeatID = %d AND invoiceRepeatDate = '%s'"
-                           ,$invoiceRepeat->get_id(),$id);
-        if ($idrow = $db->row($qid2)) {
-          $links[] = "<a href='".$TPL["url_alloc_invoice"]."invoiceID=".$idrow["invoiceID"]."'>".$id."</a>";
-        } else {
-          $links[] = $id;
+    $q = prepare("SELECT * FROM invoiceRepeat WHERE invoiceID = %d LIMIT 1", $invoice->get_id());
+    $qid1 = $db->query($q);
+    if ($db->row($qid1)) {
+        $invoiceRepeat->read_db_record($db);
+        $invoiceRepeat->set_values("invoiceRepeat_");
+        foreach (explode(" ", $TPL["invoiceRepeat_frequency"]) as $id) {
+            if ($id) {
+                $qid2 = $db->query(
+                    "SELECT * FROM invoice WHERE invoiceRepeatID = %d AND invoiceRepeatDate = '%s'",
+                    $invoiceRepeat->get_id(),
+                    $id
+                );
+                if ($idrow = $db->row($qid2)) {
+                      $links[] = "<a href='".$TPL["url_alloc_invoice"]."invoiceID=".$idrow["invoiceID"]."'>".$id."</a>";
+                } else {
+                    $links[] = $id;
+                }
+            }
         }
-      }
-    }
-    $TPL["message_help_no_esc"][] = "This invoice is also a template for the scheduled creation of new invoices on the following dates:
-                              <br>".implode("&nbsp;&nbsp;",(array)$links)."
+        $TPL["message_help_no_esc"][] = "This invoice is also a template for the scheduled creation of new invoices on the following dates:
+                              <br>".implode("&nbsp;&nbsp;", (array)$links)."
                               <br>Click the Repeating Invoice link for more information.";
-  }
+    }
 
 
-if ($invoice->get_value("invoiceRepeatID")) {
-  $ir = new invoiceRepeat();
-  $ir->set_id($invoice->get_value("invoiceRepeatID"));
-  $ir->select();
-  $i = new invoice();
-  $i->set_id($ir->get_value("invoiceID"));
-  $i->select();
-  $TPL["message_help_no_esc"][] = "This invoice was automatically generated by the
+    if ($invoice->get_value("invoiceRepeatID")) {
+        $ir = new invoiceRepeat();
+        $ir->set_id($invoice->get_value("invoiceRepeatID"));
+        $ir->select();
+        $i = new invoice();
+        $i->set_id($ir->get_value("invoiceID"));
+        $i->select();
+        $TPL["message_help_no_esc"][] = "This invoice was automatically generated by the
                                    <a href='".$TPL["url_alloc_invoice"]."invoiceID=".$ir->get_value("invoiceID")."'>
                                    repeating invoice ".$i->get_value("invoiceNum")."</a>";
-}
-
-
+    }
 }
 $TPL["invoice"] = $invoice;
 $TPL["invoiceRepeat"] = $invoiceRepeat;
@@ -821,6 +794,3 @@ $TPL["invoiceRepeat"] = $invoiceRepeat;
 
 
 include_template("templates/invoiceM.tpl");
-
-
-?>

--- a/invoice/invoiceList.php
+++ b/invoice/invoiceList.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -37,21 +37,22 @@ $defaults = array("showHeader"=>true
                  );
 
 
-function show_filter() {
-  global $TPL;
-  global $defaults;
-  $_FORM = invoice::load_form_data($defaults);
-  $arr = invoice::load_invoice_filter($_FORM);
-  is_array($arr) and $TPL = array_merge($TPL,$arr);
+function show_filter()
+{
+    global $TPL;
+    global $defaults;
+    $_FORM = invoice::load_form_data($defaults);
+    $arr = invoice::load_invoice_filter($_FORM);
+    is_array($arr) and $TPL = array_merge($TPL, $arr);
 
-  $payment_statii = invoice::get_invoice_statii_payment();
-  foreach($payment_statii as $payment_status => $label) {
-    $summary.= "\n".$nbsp.invoice::get_invoice_statii_payment_image($payment_status)." ".$label;
-    $nbsp = "&nbsp;&nbsp;";
-  }
-  $TPL["status_legend"] = $summary;
+    $payment_statii = invoice::get_invoice_statii_payment();
+    foreach ($payment_statii as $payment_status => $label) {
+        $summary.= "\n".$nbsp.invoice::get_invoice_statii_payment_image($payment_status)." ".$label;
+        $nbsp = "&nbsp;&nbsp;";
+    }
+    $TPL["status_legend"] = $summary;
 
-  include_template("templates/invoiceListFilterS.tpl");
+    include_template("templates/invoiceListFilterS.tpl");
 }
 
 
@@ -59,13 +60,13 @@ $_FORM = invoice::load_form_data($defaults);
 
 // Restrict non-admin users records
 if (!$current_user->have_role("admin")) {
-  $_FORM["personID"] = $current_user->get_id();
+    $_FORM["personID"] = $current_user->get_id();
 }
 $TPL["invoiceListRows"] = invoice::get_list($_FORM);
 $TPL["_FORM"] = $_FORM;
 
 if (!$current_user->prefs["invoiceList_filter"]) {
-  $TPL["message_help"][] = "
+    $TPL["message_help"][] = "
 
 allocPSA allows you to create Invoices for your Clients and record the
 payment status of those Invoices. This page allows you to view a list of
@@ -83,5 +84,3 @@ in the top-right hand corner of the box below.";
 
 $TPL["main_alloc_title"] = "Invoice List - ".APPLICATION_NAME;
 include_template("templates/invoiceListM.tpl");
-
-?>

--- a/invoice/invoicePrint.php
+++ b/invoice/invoicePrint.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,7 +23,7 @@
 require_once("../alloc.php");
 
 if (!$current_user->is_employee()) {
-  alloc_error("You do not have permission to access invoices",true);
+    alloc_error("You do not have permission to access invoices", true);
 }
 
 $invoiceID = $_POST["invoiceID"] or $invoiceID = $_GET["invoiceID"];
@@ -33,5 +33,3 @@ $invoice = new invoice();
 $invoice->set_id($invoiceID);
 $invoice->select();
 $invoice->generate_invoice_file($verbose);
-
-?>

--- a/invoice/invoiceRepeat.php
+++ b/invoice/invoiceRepeat.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -27,14 +27,12 @@ $db = new db_alloc();
 $invoiceRepeat = new invoiceRepeat($_REQUEST["invoiceRepeatID"]);
 
 if ($_POST["save"]) {
-  $invoiceRepeat->set_value("invoiceID",$_POST["invoiceID"]);
-  $invoiceRepeat->set_value("message",$_POST["message"]);
-  $invoiceRepeat->set_value("active",1);
-  $invoiceRepeat->set_value("personID",$current_user->get_id());
-  $invoiceRepeat->save($_POST["frequency"]);
-  interestedParty::make_interested_parties("invoiceRepeat",$invoiceRepeat->get_id(),$_POST["commentEmailRecipients"]);
+    $invoiceRepeat->set_value("invoiceID", $_POST["invoiceID"]);
+    $invoiceRepeat->set_value("message", $_POST["message"]);
+    $invoiceRepeat->set_value("active", 1);
+    $invoiceRepeat->set_value("personID", $current_user->get_id());
+    $invoiceRepeat->save($_POST["frequency"]);
+    interestedParty::make_interested_parties("invoiceRepeat", $invoiceRepeat->get_id(), $_POST["commentEmailRecipients"]);
 }
 
 alloc_redirect($TPL["url_alloc_invoice"]."invoiceID=".$_POST["invoiceID"]);
-
-?>

--- a/invoice/lib/init.php
+++ b/invoice/lib/init.php
@@ -3,26 +3,26 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class invoice_module extends module {
-  var $module = "invoice";
-  var $db_entities = array("invoice", "invoiceItem", "invoiceEntity");
+class invoice_module extends module
+{
+    var $module = "invoice";
+    var $db_entities = array("invoice", "invoiceItem", "invoiceEntity");
 }
-?>

--- a/invoice/lib/invoice.inc.php
+++ b/invoice/lib/invoice.inc.php
@@ -3,30 +3,31 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("DEFAULT_SEP","\n");
-class invoice extends db_entity {
-  public $classname = "invoice";
-  public $data_table = "invoice";
-  public $display_field_name = "invoiceName";
-  public $key_field = "invoiceID";
-  public $data_fields = array("invoiceName"
+define("DEFAULT_SEP", "\n");
+class invoice extends db_entity
+{
+    public $classname = "invoice";
+    public $data_table = "invoice";
+    public $display_field_name = "invoiceName";
+    public $key_field = "invoiceID";
+    public $data_fields = array("invoiceName"
                              ,"clientID"
                              ,"projectID"
                              ,"tfID"
@@ -45,459 +46,479 @@ class invoice extends db_entity {
                              ,"invoiceModifiedUser"
                              );
 
-  function save() {
-    if (!$this->get_value("currencyTypeID")) {
-      if ($this->get_value("projectID")) {
-        $project = $this->get_foreign_object("project");
-        $currencyTypeID = $project->get_value("currencyTypeID");
-      } else if (config::get_config_item("currency")) {
-        $currencyTypeID = config::get_config_item("currency");
-      }
+    function save()
+    {
+        if (!$this->get_value("currencyTypeID")) {
+            if ($this->get_value("projectID")) {
+                $project = $this->get_foreign_object("project");
+                $currencyTypeID = $project->get_value("currencyTypeID");
+            } else if (config::get_config_item("currency")) {
+                $currencyTypeID = config::get_config_item("currency");
+            }
 
-      if (!imp($this->get_value("maxAmount"))) {
-        $this->set_value("maxAmount",'');
-      }
-      if ($currencyTypeID) {
-        $this->set_value("currencyTypeID", $currencyTypeID);
-      } else {
-        alloc_error("Unable to save invoice. No currency is able to be determined. Either attach this invoice to a project, or set a Main Currency on the Setup -> Finance screen.");
-      } 
+            if (!imp($this->get_value("maxAmount"))) {
+                $this->set_value("maxAmount", '');
+            }
+            if ($currencyTypeID) {
+                $this->set_value("currencyTypeID", $currencyTypeID);
+            } else {
+                alloc_error("Unable to save invoice. No currency is able to be determined. Either attach this invoice to a project, or set a Main Currency on the Setup -> Finance screen.");
+            }
+        }
+        return parent::save();
     }
-    return parent::save();
-  }
 
-  function delete() {
-    $db = new db_alloc();
-    $q = prepare("DELETE FROM invoiceEntity WHERE invoiceID = %d",$this->get_id());
-    $db->query($q);
-    return parent::delete();
-  }
+    function delete()
+    {
+        $db = new db_alloc();
+        $q = prepare("DELETE FROM invoiceEntity WHERE invoiceID = %d", $this->get_id());
+        $db->query($q);
+        return parent::delete();
+    }
 
-  function get_invoice_statii() {
-    return array("create"=>"Create"
+    function get_invoice_statii()
+    {
+        return array("create"=>"Create"
                 ,"edit"=>"Add Items"
                 ,"reconcile"=>"Approve/Reject"
                 ,"finished"=>"Completed");
+    }
 
-  }
-
-  function get_invoice_statii_payment() {
-    return array("pending"=>"Not Paid In Full"
+    function get_invoice_statii_payment()
+    {
+        return array("pending"=>"Not Paid In Full"
                 // "partly_paid"=>"Waiting to be Paid"
                 ,"rejected"=>"Has Rejected Transactions"
                 ,"fully_paid"=>"Paid In Full"
                 ,"over_paid"=>"Overpaid/Pre-Paid"
                 );
-
-  }
-
-  function get_invoice_statii_payment_image($payment_status=false) {
-    global $TPL;
-    if ($payment_status) {
-      $payment_statii = invoice::get_invoice_statii_payment();
-      return "<img src=\"".$TPL["url_alloc_images"]."invoice_".$payment_status.".png\" alt=\"".$payment_statii[$payment_status]."\" title=\"".$payment_statii[$payment_status]."\">";
-    }
-  }
-
-  function is_owner($person = "") {
-    $current_user = &singleton("current_user");
-
-    if ($person == "") {
-      $person = $current_user;
     }
 
-    $db = new db_alloc();
-    $db->query("SELECT * FROM invoiceItem WHERE invoiceID=%d",$this->get_id());
-    while ($db->next_record()) {
-      $invoice_item = new invoiceItem();
-      if ($invoice_item->read_db_record($db)) {
-        if ($invoice_item->is_owner($person)) {
-          return true;
+    function get_invoice_statii_payment_image($payment_status = false)
+    {
+        global $TPL;
+        if ($payment_status) {
+            $payment_statii = invoice::get_invoice_statii_payment();
+            return "<img src=\"".$TPL["url_alloc_images"]."invoice_".$payment_status.".png\" alt=\"".$payment_statii[$payment_status]."\" title=\"".$payment_statii[$payment_status]."\">";
         }
-      }
     }
-    return false;
-  }
 
-  function get_invoiceItems($invoiceID="") {
-    $invoiceItemIDs = array();
-    $id = $invoiceID or $id = $this->get_id();
-    $q = prepare("SELECT invoiceItemID FROM invoiceItem WHERE invoiceID = %d",$id);
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $invoiceItemIDs[] = $row["invoiceItemID"];
-    }
-    return $invoiceItemIDs;
-  }
+    function is_owner($person = "")
+    {
+        $current_user = &singleton("current_user");
 
-  function get_transactions($invoiceID="") {
-    $transactionIDs = array();
-    $id = $invoiceID or $id = $this->get_id();
-    $q = prepare("SELECT transactionID FROM transaction WHERE invoiceID = %d",$id);
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $transactionIDs[] = $row["transactionID"];
-    }
-    return $transactionIDs;
-  }
-
-  function get_next_invoiceNum() {
-    $q = "SELECT coalesce(max(invoiceNum)+1,1) as newNum FROM invoice";
-    $db = new db_alloc();
-    $db->query($q);
-    $db->row();
-    return $db->f("newNum");
-  }
-
-  function get_invoiceItem_list_for_file($verbose=false) {
-    $currency = $this->get_value("currencyTypeID");
-
-    $q = prepare("SELECT * from invoiceItem WHERE invoiceID=%d ", $this->get_id());
-    $q.= prepare("ORDER BY iiDate,invoiceItemID");
-    $db = new db_alloc();
-    $db->query($q);
-
-    while ($db->next_record()) {
-      $invoiceItem = new invoiceItem();
-      $invoiceItem->read_db_record($db);
-
-      $taxPercent = $invoiceItem->get_value("iiTax");
-      $taxPercentDivisor = ($taxPercent/100) + 1;
-
-      $num = page::money($currency,$invoiceItem->get_value("iiAmount"),"%mo");
-
-      if ($taxPercent) {
-        $num_minus_gst = $num / $taxPercentDivisor;
-        $gst = $num - $num_minus_gst;
-
-        if (($num_minus_gst + $gst) != $num) {
-          $num_minus_gst += $num - ($num_minus_gst + $gst); // round it up.
+        if ($person == "") {
+            $person = $current_user;
         }
 
-        $rows[$invoiceItem->get_id()]["quantity"] = $invoiceItem->get_value("iiQuantity");
-        $rows[$invoiceItem->get_id()]["unit"] = page::money($currency,$invoiceItem->get_value("iiUnitPrice"),"%mo");
-        $rows[$invoiceItem->get_id()]["money"] = page::money($currency,$num_minus_gst,"%m");
-        $rows[$invoiceItem->get_id()]["gst"] = page::money($currency,$gst,"%m");
-        $info["total_gst"] += $gst;
-        $info["total"] += $num_minus_gst;
-      } else {
-
-        $taxPercent = config::get_config_item("taxPercent");
-        $taxPercentDivisor = ($taxPercent/100) + 1;
-
-        $num_plus_gst = $num * $taxPercentDivisor;
-        $gst = $num_plus_gst - $num;
-
-        $rows[$invoiceItem->get_id()]["quantity"] = $invoiceItem->get_value("iiQuantity");
-        $rows[$invoiceItem->get_id()]["unit"] = page::money($currency,$invoiceItem->get_value("iiUnitPrice"),"%mo");
-        $rows[$invoiceItem->get_id()]["money"] = page::money($currency,$num,"%m");
-        $rows[$invoiceItem->get_id()]["gst"] = page::money($currency,$gst,"%m");
-        $info["total_gst"] += $gst;
-        $info["total"] += $num;
-      }
-
-      unset($str);
-      $d = $invoiceItem->get_value('iiMemo');
-      $str[] = $d;
-
-      // Get task description
-      if ($invoiceItem->get_value("timeSheetID") && $verbose) {
-        $q = prepare("SELECT * FROM timeSheetItem WHERE timeSheetID = %d",$invoiceItem->get_value("timeSheetID"));
-        $db2 = new db_alloc();
-        $db2->query($q); 
-        unset($sep);
-        unset($task_info);
-        while ($db2->next_record()) {
-          if ($db2->f("taskID") && !$task_info[$db2->f("taskID")] && $db2->f("description")) {
-            $task_info[$db2->f("taskID")] = $db2->f("description");
-            $sep = DEFAULT_SEP;
-          } 
-          if (!$db2->f("commentPrivate") && $db2->f("comment")) {
-            $task_info[$db2->f("taskID")].= $sep."  <i>- ".$db2->f("comment")."</i>";
-          }
-          $sep = DEFAULT_SEP;
+        $db = new db_alloc();
+        $db->query("SELECT * FROM invoiceItem WHERE invoiceID=%d", $this->get_id());
+        while ($db->next_record()) {
+            $invoice_item = new invoiceItem();
+            if ($invoice_item->read_db_record($db)) {
+                if ($invoice_item->is_owner($person)) {
+                    return true;
+                }
+            }
         }
-        is_array($task_info) and $str[$invoiceItem->get_id()].= "* ".implode(DEFAULT_SEP."* ",$task_info);
-      }
-      is_array($str) and $rows[$invoiceItem->get_id()]["desc"].= trim(implode(DEFAULT_SEP,$str));
+        return false;
     }
-    $info["total_inc_gst"] = page::money($currency,$info["total"]+$info["total_gst"],"%s%m");
 
-    // If we are in dollar mode, then prefix the total with a dollar sign
-    $info["total"] =     page::money($currency,$info["total"],"%s%m");
-    $info["total_gst"] = page::money($currency,$info["total_gst"],"%s%m");
-    $rows or $rows = array();
-    $info or $info = array();
-    return array($rows,$info);
-  }
+    function get_invoiceItems($invoiceID = "")
+    {
+        $invoiceItemIDs = array();
+        $id = $invoiceID or $id = $this->get_id();
+        $q = prepare("SELECT invoiceItemID FROM invoiceItem WHERE invoiceID = %d", $id);
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $invoiceItemIDs[] = $row["invoiceItemID"];
+        }
+        return $invoiceItemIDs;
+    }
 
-  function generate_invoice_file($verbose=false, $getfile=false) {
-    // Build PDF document
-    $font1 = ALLOC_MOD_DIR."util/fonts/Helvetica.afm";
-    $font2 = ALLOC_MOD_DIR."util/fonts/Helvetica-Oblique.afm";
+    function get_transactions($invoiceID = "")
+    {
+        $transactionIDs = array();
+        $id = $invoiceID or $id = $this->get_id();
+        $q = prepare("SELECT transactionID FROM transaction WHERE invoiceID = %d", $id);
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $transactionIDs[] = $row["transactionID"];
+        }
+        return $transactionIDs;
+    }
+
+    function get_next_invoiceNum()
+    {
+        $q = "SELECT coalesce(max(invoiceNum)+1,1) as newNum FROM invoice";
+        $db = new db_alloc();
+        $db->query($q);
+        $db->row();
+        return $db->f("newNum");
+    }
+
+    function get_invoiceItem_list_for_file($verbose = false)
+    {
+        $currency = $this->get_value("currencyTypeID");
+
+        $q = prepare("SELECT * from invoiceItem WHERE invoiceID=%d ", $this->get_id());
+        $q.= prepare("ORDER BY iiDate,invoiceItemID");
+        $db = new db_alloc();
+        $db->query($q);
+
+        while ($db->next_record()) {
+            $invoiceItem = new invoiceItem();
+            $invoiceItem->read_db_record($db);
+
+            $taxPercent = $invoiceItem->get_value("iiTax");
+            $taxPercentDivisor = ($taxPercent/100) + 1;
+
+            $num = page::money($currency, $invoiceItem->get_value("iiAmount"), "%mo");
+
+            if ($taxPercent) {
+                $num_minus_gst = $num / $taxPercentDivisor;
+                $gst = $num - $num_minus_gst;
+
+                if (($num_minus_gst + $gst) != $num) {
+                    $num_minus_gst += $num - ($num_minus_gst + $gst); // round it up.
+                }
+
+                $rows[$invoiceItem->get_id()]["quantity"] = $invoiceItem->get_value("iiQuantity");
+                $rows[$invoiceItem->get_id()]["unit"] = page::money($currency, $invoiceItem->get_value("iiUnitPrice"), "%mo");
+                $rows[$invoiceItem->get_id()]["money"] = page::money($currency, $num_minus_gst, "%m");
+                $rows[$invoiceItem->get_id()]["gst"] = page::money($currency, $gst, "%m");
+                $info["total_gst"] += $gst;
+                $info["total"] += $num_minus_gst;
+            } else {
+                $taxPercent = config::get_config_item("taxPercent");
+                $taxPercentDivisor = ($taxPercent/100) + 1;
+
+                $num_plus_gst = $num * $taxPercentDivisor;
+                $gst = $num_plus_gst - $num;
+
+                $rows[$invoiceItem->get_id()]["quantity"] = $invoiceItem->get_value("iiQuantity");
+                $rows[$invoiceItem->get_id()]["unit"] = page::money($currency, $invoiceItem->get_value("iiUnitPrice"), "%mo");
+                $rows[$invoiceItem->get_id()]["money"] = page::money($currency, $num, "%m");
+                $rows[$invoiceItem->get_id()]["gst"] = page::money($currency, $gst, "%m");
+                $info["total_gst"] += $gst;
+                $info["total"] += $num;
+            }
+
+            unset($str);
+            $d = $invoiceItem->get_value('iiMemo');
+            $str[] = $d;
+
+          // Get task description
+            if ($invoiceItem->get_value("timeSheetID") && $verbose) {
+                $q = prepare("SELECT * FROM timeSheetItem WHERE timeSheetID = %d", $invoiceItem->get_value("timeSheetID"));
+                $db2 = new db_alloc();
+                $db2->query($q);
+                unset($sep);
+                unset($task_info);
+                while ($db2->next_record()) {
+                    if ($db2->f("taskID") && !$task_info[$db2->f("taskID")] && $db2->f("description")) {
+                        $task_info[$db2->f("taskID")] = $db2->f("description");
+                        $sep = DEFAULT_SEP;
+                    }
+                    if (!$db2->f("commentPrivate") && $db2->f("comment")) {
+                        $task_info[$db2->f("taskID")].= $sep."  <i>- ".$db2->f("comment")."</i>";
+                    }
+                    $sep = DEFAULT_SEP;
+                }
+                is_array($task_info) and $str[$invoiceItem->get_id()].= "* ".implode(DEFAULT_SEP."* ", $task_info);
+            }
+            is_array($str) and $rows[$invoiceItem->get_id()]["desc"].= trim(implode(DEFAULT_SEP, $str));
+        }
+        $info["total_inc_gst"] = page::money($currency, $info["total"]+$info["total_gst"], "%s%m");
+
+      // If we are in dollar mode, then prefix the total with a dollar sign
+        $info["total"] =     page::money($currency, $info["total"], "%s%m");
+        $info["total_gst"] = page::money($currency, $info["total_gst"], "%s%m");
+        $rows or $rows = array();
+        $info or $info = array();
+        return array($rows,$info);
+    }
+
+    function generate_invoice_file($verbose = false, $getfile = false)
+    {
+      // Build PDF document
+        $font1 = ALLOC_MOD_DIR."util/fonts/Helvetica.afm";
+        $font2 = ALLOC_MOD_DIR."util/fonts/Helvetica-Oblique.afm";
   
-    $db = new db_alloc();
+        $db = new db_alloc();
 
-    // Get client name
-    $client = $this->get_foreign_object("client");
-    $clientName = $client->get_value("clientName");
+      // Get client name
+        $client = $this->get_foreign_object("client");
+        $clientName = $client->get_value("clientName");
 
-    // Get cyber info
-    $companyName = config::get_config_item("companyName");
-    $companyNos1 = config::get_config_item("companyACN");
-    $companyNos2 = config::get_config_item("companyABN");
-    $phone = config::get_config_item("companyContactPhone");
-    $fax = config::get_config_item("companyContactFax");
-    $phone and $phone = "Ph: ".$phone;
-    $fax and $fax = "Fax: ".$fax;
-    $img = config::get_config_item("companyImage");
-    $companyContactAddress = config::get_config_item("companyContactAddress");
-    $companyContactAddress2 = config::get_config_item("companyContactAddress2");
-    $companyContactAddress3 = config::get_config_item("companyContactAddress3");
-    $email = config::get_config_item("companyContactEmail");
-    $email and $companyContactEmail = "Email: ".$email;
-    $web = config::get_config_item("companyContactHomePage");
-    $web and $companyContactHomePage = "Web: ".$web;
-    $footer = config::get_config_item("timeSheetPrintFooter");
-    $taxName = config::get_config_item("taxName");
+      // Get cyber info
+        $companyName = config::get_config_item("companyName");
+        $companyNos1 = config::get_config_item("companyACN");
+        $companyNos2 = config::get_config_item("companyABN");
+        $phone = config::get_config_item("companyContactPhone");
+        $fax = config::get_config_item("companyContactFax");
+        $phone and $phone = "Ph: ".$phone;
+        $fax and $fax = "Fax: ".$fax;
+        $img = config::get_config_item("companyImage");
+        $companyContactAddress = config::get_config_item("companyContactAddress");
+        $companyContactAddress2 = config::get_config_item("companyContactAddress2");
+        $companyContactAddress3 = config::get_config_item("companyContactAddress3");
+        $email = config::get_config_item("companyContactEmail");
+        $email and $companyContactEmail = "Email: ".$email;
+        $web = config::get_config_item("companyContactHomePage");
+        $web and $companyContactHomePage = "Web: ".$web;
+        $footer = config::get_config_item("timeSheetPrintFooter");
+        $taxName = config::get_config_item("taxName");
 
-    if ($this->get_value("invoiceDateFrom") && $this->get_value("invoiceDateTo")
-    && $this->get_value("invoiceDateFrom") != $this->get_value("invoiceDateTo")) {
-      $period = format_date(DATE_FORMAT,$this->get_value("invoiceDateFrom"))." to ".format_date(DATE_FORMAT,$this->get_value("invoiceDateTo"));
-    } else {
-      $period = format_date(DATE_FORMAT,$this->get_value("invoiceDateTo"));
-    }
-
-    $default_header = "Tax Invoice";
-    $default_id_label = "Invoice Number";
-
-
-    $pdf_table_options = array("showLines"=>0,"shaded"=>0,"showHeadings"=>0,"xPos"=>"left","xOrientation"=>"right","fontSize"=>10,"rowGap"=>0,"fontSize"=>10);
-
-    $cols = array("one"=>"","two"=>"","three"=>"","four"=>"");
-    $cols3 = array("one"=>"","two"=>"");
-    $cols_settings["one"] = array("justification"=>"right");
-    $cols_settings["three"] = array("justification"=>"right");
-    $pdf_table_options2 = array("showLines"=>0,"shaded"=>0,"showHeadings"=>0, "width"=>400, "fontSize"=>10, "xPos"=>"center", "xOrientation"=>"center", "cols"=>$cols_settings);
-    $cols_settings2["gst"] = array("justification"=>"right");
-    $cols_settings2["money"] = array("justification"=>"right");
-    $cols_settings2["unit"] = array("justification"=>"right");
-    $pdf_table_options3 = array("showLines"=>2,"shaded"=>0,"width"=>400, "xPos"=>"center","fontSize"=>10,"cols"=>$cols_settings2,"lineCol"=>array(0.8, 0.8, 0.8),"splitRows"=>1,"protectRows"=>0);
-    $cols_settings["two"] = array("justification"=>"right","width"=>80);
-    $pdf_table_options4 = array("showLines"=>2,"shaded"=>0,"width"=>400, "showHeadings"=>0, "fontSize"=>10, "xPos"=>"center", "cols"=>$cols_settings,"lineCol"=>array(0.8, 0.8, 0.8));
-
-    $pdf = new Cezpdf();
-    $pdf->ezSetMargins(90,90,90,90);
-
-    $pdf->selectFont($font1);
-    $pdf->ezStartPageNumbers(436,80,10,'right','Page {PAGENUM} of {TOTALPAGENUM}');
-    $pdf->ezStartPageNumbers(200,80,10,'left','<b>'.$default_id_label.': </b>'.$this->get_value("invoiceNum"));
-    $pdf->ezSetY(775);
-
-    $companyName            and $contact_info[] = array($companyName);
-    $companyContactAddress  and $contact_info[] = array($companyContactAddress);
-    $companyContactAddress2 and $contact_info[] = array($companyContactAddress2);
-    $companyContactAddress3 and $contact_info[] = array($companyContactAddress3);
-    $companyContactEmail    and $contact_info[] = array($companyContactEmail);
-    $companyContactHomePage and $contact_info[] = array($companyContactHomePage);
-    $phone                  and $contact_info[] = array($phone);
-    $fax                    and $contact_info[] = array($fax);
-
-    $pdf->selectFont($font2);
-    $y = $pdf->ezTable($contact_info,false,"",$pdf_table_options);
-    $pdf->selectFont($font1);
-
-    $line_y = $y-10;
-    $pdf->setLineStyle(1,"round");
-    $pdf->line(90,$line_y,510,$line_y);
-
-
-    $pdf->ezSetY(782);
-    $image_jpg = ALLOC_LOGO;
-    if (file_exists($image_jpg)) {
-      $pdf->ezImage($image_jpg,0,sprintf("%d",config::get_config_item("logoScaleX")),'none');
-      $y = 700;
-    } else {
-      $y = $pdf->ezText($companyName,27, array("justification"=>"right"));
-    }
-    $nos_y = $line_y + 22;
-    $companyNos2 and $nos_y = $line_y + 34;
-    $pdf->ezSetY($nos_y);
-    $companyNos1 and $y = $pdf->ezText($companyNos1,10, array("justification"=>"right"));
-    $companyNos2 and $y = $pdf->ezText($companyNos2,10, array("justification"=>"right"));
-
-
-    $pdf->ezSetY($line_y -20);
-    $y = $pdf->ezText($default_header,20, array("justification"=>"center"));
-    $pdf->ezSetY($y -20);
-
-    $ts_info[] = array("one"=>"<b>".$default_id_label.":</b>","two"=>$this->get_value("invoiceNum"),"three"=>"<b>Date Issued:</b>","four"=>date("d/m/Y"));
-    $ts_info[] = array("one"=>"<b>Client:</b>"        ,"two"=>$clientName,"three"=>"<b>Billing Period:</b>","four"=>$period);
-    $y = $pdf->ezTable($ts_info,$cols,"",$pdf_table_options2);
-
-    $pdf->ezSetY($y -20);
-
-    list($rows,$info) = $this->get_invoiceItem_list_for_file($verbose);
-    $cols2 = array("desc"=>"Description","quantity"=>"Qty","unit"=>"Unit Price","money"=>"Charges","gst"=>$taxName);
-    $taxPercent = config::get_config_item("taxPercent");
-    if ($taxPercent === '') unset($cols2["gst"]);
-    $rows[] = array("desc"=>"<b>TOTAL</b>","money"=>$info["total"],"gst"=>$info["total_gst"]);
-    $y = $pdf->ezTable($rows,$cols2,"",$pdf_table_options3);
-    $pdf->ezSetY($y -20);
-    if ($taxPercent !== '') $totals[] = array("one"=>"TOTAL ".$taxName,"two"=>$info["total_gst"]);
-    $totals[] = array("one"=>"TOTAL CHARGES","two"=>$info["total"]);
-    $totals[] = array("one"=>"<b>TOTAL AMOUNT PAYABLE</b>","two"=>"<b>".$info["total_inc_gst"]."</b>");
-    $y = $pdf->ezTable($totals,$cols3,"",$pdf_table_options4);
-
-    $pdf->ezSetY($y-20);
-    $pdf->ezText(str_replace(array("<br>","<br/>","<br />"),"\n",$footer),10);
-
-
-    // Add footer
-    #$all = $pdf->openObject();
-    #$pdf->saveState();
-    #$pdf->addText(415,80,12,"<b>".$default_id_label.":</b>".$this->get_value("invoiceNum"));
-    #$pdf->restoreState();
-    #$pdf->closeObject();
-    #$pdf->addObject($all,'all');
-
-    if ($getfile) {
-      return $pdf->ezOutput();
-    } else {
-      $pdf->ezStream(array("Content-Disposition"=>"invoice_".$this->get_id().".pdf"));
-    }
-  }
-
-  function has_attachment_permission($person) {
-    return $person->have_role("admin");
-  }
-
-  function has_attachment_permission_delete($person) {
-    return $person->have_role("admin");
-  }
-
-  function get_url() {
-    global $sess;
-    $sess or $sess = new session();
-
-    $url = "invoice/invoice.php?invoiceID=".$this->get_id();
-
-    if ($sess->Started()) {
-      $url = $sess->url(SCRIPT_PATH.$url);
-
-    // This for urls that are emailed
-    } else {
-      static $prefix;
-      $prefix or $prefix = config::get_config_item("allocURL");
-      $url = $prefix.$url;
-    }
-    return $url;
-  }
-
-  function get_name($_FORM=array()) {
-    return $this->get_value("invoiceNum");
-  }
-
-  function get_invoice_link($_FORM=array()) {
-    global $TPL;
-    return "<a href=\"".$TPL["url_alloc_invoice"]."invoiceID=".$this->get_id()."\">".$this->get_name($_FORM)."</a>";
-  }
-
-  function get_list_filter($filter=array()) {
-    $current_user = &singleton("current_user");
-    $sql = array();
-
-    // If they want starred, load up the invoiceID filter element
-    if ($filter["starred"]) {
-      foreach ((array)$current_user->prefs["stars"]["invoice"] as $k=>$v) {
-        $filter["invoiceID"][] = $k;
-      }
-      is_array($filter["invoiceID"]) or $filter["invoiceID"][] = -1;
-    }
-
-    // Filter invoiceID
-    $filter["invoiceID"] and $sql[] = sprintf_implode("invoice.invoiceID = %d",$filter["invoiceID"]);
-
-    // No point continuing if primary key specified, so return
-    if ($filter["invoiceID"] || $filter["starred"]) {
-      return $sql;
-    }
-
-    if ($filter["personID"]) {
-      $q = "SELECT DISTINCT project.clientID
-              FROM projectPerson LEFT JOIN project ON projectPerson.projectID = project.projectID
-             WHERE ".sprintf_implode("projectPerson.personID = %d",$filter["personID"])."
-               AND project.clientID IS NOT NULL";
-      $db = new db_alloc();
-      $db->query($q);
-      while ($row = $db->row()) {
-        $valid_clientIDs[] = $row["clientID"];
-      }
-      $filter["clientID"] && !is_array($filter["clientID"]) and $filter["clientID"] = array($filter["clientID"]);
-      foreach ((array)$filter["clientID"] as $clientID) {
-        if (in_array($clientID,(array)$valid_clientIDs)) {
-          $approved_clientIDs[] = $clientID;
+        if ($this->get_value("invoiceDateFrom") && $this->get_value("invoiceDateTo")
+        && $this->get_value("invoiceDateFrom") != $this->get_value("invoiceDateTo")) {
+            $period = format_date(DATE_FORMAT, $this->get_value("invoiceDateFrom"))." to ".format_date(DATE_FORMAT, $this->get_value("invoiceDateTo"));
+        } else {
+            $period = format_date(DATE_FORMAT, $this->get_value("invoiceDateTo"));
         }
-      }
-      $approved_clientIDs or $approved_clientIDs = (array)$valid_clientIDs;
-      if ($approved_clientIDs) {
-        $filter["clientID"] = $approved_clientIDs;
-      } else {
-        $filter["clientID"] = array(0);
-      }
+
+        $default_header = "Tax Invoice";
+        $default_id_label = "Invoice Number";
+
+
+        $pdf_table_options = array("showLines"=>0,"shaded"=>0,"showHeadings"=>0,"xPos"=>"left","xOrientation"=>"right","fontSize"=>10,"rowGap"=>0,"fontSize"=>10);
+
+        $cols = array("one"=>"","two"=>"","three"=>"","four"=>"");
+        $cols3 = array("one"=>"","two"=>"");
+        $cols_settings["one"] = array("justification"=>"right");
+        $cols_settings["three"] = array("justification"=>"right");
+        $pdf_table_options2 = array("showLines"=>0,"shaded"=>0,"showHeadings"=>0, "width"=>400, "fontSize"=>10, "xPos"=>"center", "xOrientation"=>"center", "cols"=>$cols_settings);
+        $cols_settings2["gst"] = array("justification"=>"right");
+        $cols_settings2["money"] = array("justification"=>"right");
+        $cols_settings2["unit"] = array("justification"=>"right");
+        $pdf_table_options3 = array("showLines"=>2,"shaded"=>0,"width"=>400, "xPos"=>"center","fontSize"=>10,"cols"=>$cols_settings2,"lineCol"=>array(0.8, 0.8, 0.8),"splitRows"=>1,"protectRows"=>0);
+        $cols_settings["two"] = array("justification"=>"right","width"=>80);
+        $pdf_table_options4 = array("showLines"=>2,"shaded"=>0,"width"=>400, "showHeadings"=>0, "fontSize"=>10, "xPos"=>"center", "cols"=>$cols_settings,"lineCol"=>array(0.8, 0.8, 0.8));
+
+        $pdf = new Cezpdf();
+        $pdf->ezSetMargins(90, 90, 90, 90);
+
+        $pdf->selectFont($font1);
+        $pdf->ezStartPageNumbers(436, 80, 10, 'right', 'Page {PAGENUM} of {TOTALPAGENUM}');
+        $pdf->ezStartPageNumbers(200, 80, 10, 'left', '<b>'.$default_id_label.': </b>'.$this->get_value("invoiceNum"));
+        $pdf->ezSetY(775);
+
+        $companyName            and $contact_info[] = array($companyName);
+        $companyContactAddress  and $contact_info[] = array($companyContactAddress);
+        $companyContactAddress2 and $contact_info[] = array($companyContactAddress2);
+        $companyContactAddress3 and $contact_info[] = array($companyContactAddress3);
+        $companyContactEmail    and $contact_info[] = array($companyContactEmail);
+        $companyContactHomePage and $contact_info[] = array($companyContactHomePage);
+        $phone                  and $contact_info[] = array($phone);
+        $fax                    and $contact_info[] = array($fax);
+
+        $pdf->selectFont($font2);
+        $y = $pdf->ezTable($contact_info, false, "", $pdf_table_options);
+        $pdf->selectFont($font1);
+
+        $line_y = $y-10;
+        $pdf->setLineStyle(1, "round");
+        $pdf->line(90, $line_y, 510, $line_y);
+
+
+        $pdf->ezSetY(782);
+        $image_jpg = ALLOC_LOGO;
+        if (file_exists($image_jpg)) {
+            $pdf->ezImage($image_jpg, 0, sprintf("%d", config::get_config_item("logoScaleX")), 'none');
+            $y = 700;
+        } else {
+            $y = $pdf->ezText($companyName, 27, array("justification"=>"right"));
+        }
+        $nos_y = $line_y + 22;
+        $companyNos2 and $nos_y = $line_y + 34;
+        $pdf->ezSetY($nos_y);
+        $companyNos1 and $y = $pdf->ezText($companyNos1, 10, array("justification"=>"right"));
+        $companyNos2 and $y = $pdf->ezText($companyNos2, 10, array("justification"=>"right"));
+
+
+        $pdf->ezSetY($line_y -20);
+        $y = $pdf->ezText($default_header, 20, array("justification"=>"center"));
+        $pdf->ezSetY($y -20);
+
+        $ts_info[] = array("one"=>"<b>".$default_id_label.":</b>","two"=>$this->get_value("invoiceNum"),"three"=>"<b>Date Issued:</b>","four"=>date("d/m/Y"));
+        $ts_info[] = array("one"=>"<b>Client:</b>"        ,"two"=>$clientName,"three"=>"<b>Billing Period:</b>","four"=>$period);
+        $y = $pdf->ezTable($ts_info, $cols, "", $pdf_table_options2);
+
+        $pdf->ezSetY($y -20);
+
+        list($rows,$info) = $this->get_invoiceItem_list_for_file($verbose);
+        $cols2 = array("desc"=>"Description","quantity"=>"Qty","unit"=>"Unit Price","money"=>"Charges","gst"=>$taxName);
+        $taxPercent = config::get_config_item("taxPercent");
+        if ($taxPercent === '') {
+            unset($cols2["gst"]);
+        }
+        $rows[] = array("desc"=>"<b>TOTAL</b>","money"=>$info["total"],"gst"=>$info["total_gst"]);
+        $y = $pdf->ezTable($rows, $cols2, "", $pdf_table_options3);
+        $pdf->ezSetY($y -20);
+        if ($taxPercent !== '') {
+            $totals[] = array("one"=>"TOTAL ".$taxName,"two"=>$info["total_gst"]);
+        }
+        $totals[] = array("one"=>"TOTAL CHARGES","two"=>$info["total"]);
+        $totals[] = array("one"=>"<b>TOTAL AMOUNT PAYABLE</b>","two"=>"<b>".$info["total_inc_gst"]."</b>");
+        $y = $pdf->ezTable($totals, $cols3, "", $pdf_table_options4);
+
+        $pdf->ezSetY($y-20);
+        $pdf->ezText(str_replace(array("<br>","<br/>","<br />"), "\n", $footer), 10);
+
+
+      // Add footer
+      #$all = $pdf->openObject();
+      #$pdf->saveState();
+      #$pdf->addText(415,80,12,"<b>".$default_id_label.":</b>".$this->get_value("invoiceNum"));
+      #$pdf->restoreState();
+      #$pdf->closeObject();
+      #$pdf->addObject($all,'all');
+
+        if ($getfile) {
+            return $pdf->ezOutput();
+        } else {
+            $pdf->ezStream(array("Content-Disposition"=>"invoice_".$this->get_id().".pdf"));
+        }
     }
 
-    $filter["invoiceNum"]    and $sql[] = sprintf_implode("invoice.invoiceNum = %d",$filter["invoiceNum"]);
-    $filter["dateOne"]       and $sql[] = sprintf_implode("invoice.invoiceDateFrom>='%s'",$filter["dateOne"]);
-    $filter["dateTwo"]       and $sql[] = sprintf_implode("invoice.invoiceDateTo<='%s'",$filter["dateTwo"]);
-    $filter["invoiceName"]   and $sql[] = sprintf_implode("invoice.invoiceName like '%%%s%%'",$filter["invoiceName"]);
-    $filter["invoiceStatus"] and $sql[] = sprintf_implode("invoice.invoiceStatus = '%s'",$filter["invoiceStatus"]);
-    $filter["clientID"]      and $sql[] = sprintf_implode("invoice.clientID = %d",$filter["clientID"]);
-    $filter["projectID"]     and $sql[] = sprintf_implode("invoice.projectID = %d",$filter["projectID"]);
-    return $sql;
-  }
-
-  function get_list_filter2($filter=array()) {
-    // Filter for the HAVING clause
-    $sql = array();
-    if ($filter["invoiceStatusPayment"] == "pending") {
-      $sql[] = "(COALESCE(amountPaidApproved,0) < iiAmountSum)";
-    #if ($filter["invoiceStatusPayment"] == "partly_paid") {
-     # $sql[] = "(amountPaidApproved < iiAmountSum)";
-    } else if ($filter["invoiceStatusPayment"] == "rejected") {
-      $sql[] = "(COALESCE(amountPaidRejected,0) > 0)";
-    } else if ($filter["invoiceStatusPayment"] == "fully_paid") {
-      $sql[] = "(COALESCE(amountPaidApproved,0) = iiAmountSum)";
-    } else if ($filter["invoiceStatusPayment"] == "over_paid") {
-      $sql[] = "(COALESCE(amountPaidApproved,0) > iiAmountSum)";
+    function has_attachment_permission($person)
+    {
+        return $person->have_role("admin");
     }
 
-    return $sql;
-  }
+    function has_attachment_permission_delete($person)
+    {
+        return $person->have_role("admin");
+    }
 
-  public static function get_list($_FORM) {
-    /*
-     * This is the definitive method of getting a list of invoices that need a sophisticated level of filtering
-     *
-     */
+    function get_url()
+    {
+        global $sess;
+        $sess or $sess = new session();
 
-    global $TPL;
-    $filter1_where = invoice::get_list_filter($_FORM);
-    $filter2_having = invoice::get_list_filter2($_FORM);
+        $url = "invoice/invoice.php?invoiceID=".$this->get_id();
 
-    $debug = $_FORM["debug"];
-    $debug and print "<pre>_FORM: ".print_r($_FORM,1)."</pre>";
-    $debug and print "<pre>filter1_where: ".print_r($filter1_where,1)."</pre>";
-    $debug and print "<pre>filter2_having: ".print_r($filter2_having,1)."</pre>";
+        if ($sess->Started()) {
+            $url = $sess->url(SCRIPT_PATH.$url);
 
-    $_FORM["return"] or $_FORM["return"] = "html";
+        // This for urls that are emailed
+        } else {
+            static $prefix;
+            $prefix or $prefix = config::get_config_item("allocURL");
+            $url = $prefix.$url;
+        }
+        return $url;
+    }
 
-    is_array($filter1_where) && count($filter1_where) and $f1_where = " WHERE ".implode(" AND ",$filter1_where);
-    is_array($filter2_having) && count($filter2_having) and $f2_having = " HAVING ".implode(" AND ",$filter2_having);
+    function get_name($_FORM = array())
+    {
+        return $this->get_value("invoiceNum");
+    }
+
+    function get_invoice_link($_FORM = array())
+    {
+        global $TPL;
+        return "<a href=\"".$TPL["url_alloc_invoice"]."invoiceID=".$this->get_id()."\">".$this->get_name($_FORM)."</a>";
+    }
+
+    function get_list_filter($filter = array())
+    {
+        $current_user = &singleton("current_user");
+        $sql = array();
+
+      // If they want starred, load up the invoiceID filter element
+        if ($filter["starred"]) {
+            foreach ((array)$current_user->prefs["stars"]["invoice"] as $k => $v) {
+                $filter["invoiceID"][] = $k;
+            }
+            is_array($filter["invoiceID"]) or $filter["invoiceID"][] = -1;
+        }
+
+      // Filter invoiceID
+        $filter["invoiceID"] and $sql[] = sprintf_implode("invoice.invoiceID = %d", $filter["invoiceID"]);
+
+      // No point continuing if primary key specified, so return
+        if ($filter["invoiceID"] || $filter["starred"]) {
+            return $sql;
+        }
+
+        if ($filter["personID"]) {
+            $q = "SELECT DISTINCT project.clientID
+              FROM projectPerson LEFT JOIN project ON projectPerson.projectID = project.projectID
+             WHERE ".sprintf_implode("projectPerson.personID = %d", $filter["personID"])."
+               AND project.clientID IS NOT NULL";
+            $db = new db_alloc();
+            $db->query($q);
+            while ($row = $db->row()) {
+                $valid_clientIDs[] = $row["clientID"];
+            }
+            $filter["clientID"] && !is_array($filter["clientID"]) and $filter["clientID"] = array($filter["clientID"]);
+            foreach ((array)$filter["clientID"] as $clientID) {
+                if (in_array($clientID, (array)$valid_clientIDs)) {
+                    $approved_clientIDs[] = $clientID;
+                }
+            }
+            $approved_clientIDs or $approved_clientIDs = (array)$valid_clientIDs;
+            if ($approved_clientIDs) {
+                $filter["clientID"] = $approved_clientIDs;
+            } else {
+                $filter["clientID"] = array(0);
+            }
+        }
+
+        $filter["invoiceNum"]    and $sql[] = sprintf_implode("invoice.invoiceNum = %d", $filter["invoiceNum"]);
+        $filter["dateOne"]       and $sql[] = sprintf_implode("invoice.invoiceDateFrom>='%s'", $filter["dateOne"]);
+        $filter["dateTwo"]       and $sql[] = sprintf_implode("invoice.invoiceDateTo<='%s'", $filter["dateTwo"]);
+        $filter["invoiceName"]   and $sql[] = sprintf_implode("invoice.invoiceName like '%%%s%%'", $filter["invoiceName"]);
+        $filter["invoiceStatus"] and $sql[] = sprintf_implode("invoice.invoiceStatus = '%s'", $filter["invoiceStatus"]);
+        $filter["clientID"]      and $sql[] = sprintf_implode("invoice.clientID = %d", $filter["clientID"]);
+        $filter["projectID"]     and $sql[] = sprintf_implode("invoice.projectID = %d", $filter["projectID"]);
+        return $sql;
+    }
+
+    function get_list_filter2($filter = array())
+    {
+      // Filter for the HAVING clause
+        $sql = array();
+        if ($filter["invoiceStatusPayment"] == "pending") {
+            $sql[] = "(COALESCE(amountPaidApproved,0) < iiAmountSum)";
+        #if ($filter["invoiceStatusPayment"] == "partly_paid") {
+         # $sql[] = "(amountPaidApproved < iiAmountSum)";
+        } else if ($filter["invoiceStatusPayment"] == "rejected") {
+            $sql[] = "(COALESCE(amountPaidRejected,0) > 0)";
+        } else if ($filter["invoiceStatusPayment"] == "fully_paid") {
+            $sql[] = "(COALESCE(amountPaidApproved,0) = iiAmountSum)";
+        } else if ($filter["invoiceStatusPayment"] == "over_paid") {
+            $sql[] = "(COALESCE(amountPaidApproved,0) > iiAmountSum)";
+        }
+
+        return $sql;
+    }
+
+    public static function get_list($_FORM)
+    {
+      /*
+       * This is the definitive method of getting a list of invoices that need a sophisticated level of filtering
+       *
+       */
+
+        global $TPL;
+        $filter1_where = invoice::get_list_filter($_FORM);
+        $filter2_having = invoice::get_list_filter2($_FORM);
+
+        $debug = $_FORM["debug"];
+        $debug and print "<pre>_FORM: ".print_r($_FORM, 1)."</pre>";
+        $debug and print "<pre>filter1_where: ".print_r($filter1_where, 1)."</pre>";
+        $debug and print "<pre>filter2_having: ".print_r($filter2_having, 1)."</pre>";
+
+        $_FORM["return"] or $_FORM["return"] = "html";
+
+        is_array($filter1_where) && count($filter1_where) and $f1_where = " WHERE ".implode(" AND ", $filter1_where);
+        is_array($filter2_having) && count($filter2_having) and $f2_having = " HAVING ".implode(" AND ", $filter2_having);
  
-    $q1= "CREATE TEMPORARY TABLE invoice_details
+        $q1= "CREATE TEMPORARY TABLE invoice_details
           SELECT SUM(invoiceItem.iiAmount * pow(10,-currencyType.numberToBasic)) as iiAmountSum
                , invoice.*
                , client.clientName
@@ -509,11 +530,11 @@ class invoice extends db_entity {
         GROUP BY invoice.invoiceID
         ORDER BY invoiceDateFrom";
 
-    $db = new db_alloc();
-    #$db->query("DROP TABLE IF EXISTS invoice_details");
-    $db->query($q1);
+        $db = new db_alloc();
+      #$db->query("DROP TABLE IF EXISTS invoice_details");
+        $db->query($q1);
 
-    $q2= "SELECT invoice_details.*
+        $q2= "SELECT invoice_details.*
                , SUM(transaction_approved.amount) as amountPaidApproved
                , SUM(transaction_pending.amount) as amountPaidPending
                , SUM(transaction_rejected.amount) as amountPaidRejected
@@ -525,48 +546,49 @@ class invoice extends db_entity {
         GROUP BY invoice_details.invoiceID
               $f2_having
         ORDER BY invoiceDateFrom";
-       // Don't do this! It doubles the totals!
-       //LEFT JOIN tfPerson ON tfPerson.tfID = transaction_approved.tfID OR tfPerson.tfID = transaction_pending.tfID OR tfPerson.tfID = transaction_rejected.tfID
+         // Don't do this! It doubles the totals!
+         //LEFT JOIN tfPerson ON tfPerson.tfID = transaction_approved.tfID OR tfPerson.tfID = transaction_pending.tfID OR tfPerson.tfID = transaction_rejected.tfID
 
-    $debug and print "<pre>Query1: ".$q1."</pre>";
-    $debug and print "<pre>Query2: ".$q2."</pre>";
-    $db->query($q2);
+        $debug and print "<pre>Query1: ".$q1."</pre>";
+        $debug and print "<pre>Query2: ".$q2."</pre>";
+        $db->query($q2);
 
-    while ($row = $db->next_record()) {
-      $print = true;
-      $i = new invoice();
-      $i->read_db_record($db);
-      $row["amountPaidApproved"] = page::money($row["currencyTypeID"],$row["amountPaidApproved"],"%mo");
-      $row["amountPaidPending"] = page::money($row["currencyTypeID"],$row["amountPaidPending"],"%mo");
-      $row["amountPaidRejected"] = page::money($row["currencyTypeID"],$row["amountPaidRejected"],"%mo");
-      $row["invoiceLink"] = $i->get_invoice_link();
+        while ($row = $db->next_record()) {
+            $print = true;
+            $i = new invoice();
+            $i->read_db_record($db);
+            $row["amountPaidApproved"] = page::money($row["currencyTypeID"], $row["amountPaidApproved"], "%mo");
+            $row["amountPaidPending"] = page::money($row["currencyTypeID"], $row["amountPaidPending"], "%mo");
+            $row["amountPaidRejected"] = page::money($row["currencyTypeID"], $row["amountPaidRejected"], "%mo");
+            $row["invoiceLink"] = $i->get_invoice_link();
 
-      $payment_status = array();
-      $row["statii"] = invoice::get_invoice_statii();
-      $row["payment_statii"] = invoice::get_invoice_statii_payment();
-      $row["amountPaidApproved"] == $row["iiAmountSum"] and $payment_status[] = "fully_paid";
-      $row["amountPaidApproved"] > $row["iiAmountSum"] and $payment_status[] = "over_paid";
-      $row["amountPaidRejected"] > 0 and $payment_status[] = "rejected";
-      #$row["amountPaidApproved"] > 0 && $row["amountPaidApproved"] < $row["iiAmountSum"] and $payment_status[] = "partly_paid";
-      $row["amountPaidApproved"] < $row["iiAmountSum"] and $payment_status[] = "pending";
+            $payment_status = array();
+            $row["statii"] = invoice::get_invoice_statii();
+            $row["payment_statii"] = invoice::get_invoice_statii_payment();
+            $row["amountPaidApproved"] == $row["iiAmountSum"] and $payment_status[] = "fully_paid";
+            $row["amountPaidApproved"] > $row["iiAmountSum"] and $payment_status[] = "over_paid";
+            $row["amountPaidRejected"] > 0 and $payment_status[] = "rejected";
+          #$row["amountPaidApproved"] > 0 && $row["amountPaidApproved"] < $row["iiAmountSum"] and $payment_status[] = "partly_paid";
+            $row["amountPaidApproved"] < $row["iiAmountSum"] and $payment_status[] = "pending";
 
-      foreach ((array)$payment_status as $ps) {
-        $row["image"].= invoice::get_invoice_statii_payment_image($ps);
-        $row["status_label"].= $ps;
-      }
+            foreach ((array)$payment_status as $ps) {
+                $row["image"].= invoice::get_invoice_statii_payment_image($ps);
+                $row["status_label"].= $ps;
+            }
 
-      $row["_FORM"] = $_FORM;
-      $row = array_merge($TPL,(array)$row);
+            $row["_FORM"] = $_FORM;
+            $row = array_merge($TPL, (array)$row);
 
-      $rows[$row["invoiceID"]] = $row;
+            $rows[$row["invoiceID"]] = $row;
+        }
+
+        return $rows;
     }
 
-    return $rows;
-  }
+    function get_list_vars()
+    {
 
-  function get_list_vars() {
-
-    return array("return"                   => "[MANDATORY] eg: array | html | dropdown_options"
+        return array("return"                   => "[MANDATORY] eg: array | html | dropdown_options"
                 ,"invoiceID"                => "Invoice by ID"
                 ,"clientID"                 => "Invoices for a particular Client"
                 ,"invoiceNum"               => "Invoice by invoice number"
@@ -591,226 +613,238 @@ class invoice extends db_entity {
                 ,"showInvoiceStatus"        => "Shows the invoices status"
                 ,"showInvoiceStatusPayment" => "Shows the invoices payment status"
                 );
-  }
-
-  function load_form_data($defaults=array()) {
-    $current_user = &singleton("current_user");
-
-    $page_vars = array_keys(invoice::get_list_vars());
-
-    $_FORM = get_all_form_data($page_vars,$defaults);
-
-    if (!$_FORM["applyFilter"]) {
-      $_FORM = $current_user->prefs[$_FORM["form_name"]];
-      if (!isset($current_user->prefs[$_FORM["form_name"]])) {
-        // defaults go here
-        $_FORM["invoiceStatus"] = "edit";
-      }
-
-    } else if ($_FORM["applyFilter"] && is_object($current_user) && !$_FORM["dontSave"]) {
-      $url = $_FORM["url_form_action"];
-      unset($_FORM["url_form_action"]);
-      $current_user->prefs[$_FORM["form_name"]] = $_FORM;
-      $_FORM["url_form_action"] = $url;
     }
 
-    return $_FORM;
-  }
+    function load_form_data($defaults = array())
+    {
+        $current_user = &singleton("current_user");
 
-  function load_invoice_filter($_FORM) {
-    global $TPL;
+        $page_vars = array_keys(invoice::get_list_vars());
 
-    // Load up the forms action url
-    $rtn["url_form_action"] = $_FORM["url_form_action"];
+        $_FORM = get_all_form_data($page_vars, $defaults);
 
-    $statii = invoice::get_invoice_statii();
-    unset($statii["create"]);
-    $rtn["statusOptions"] = page::select_options($statii,$_FORM["invoiceStatus"]);
-    $statii_payment = invoice::get_invoice_statii_payment();
-    $rtn["statusPaymentOptions"] = page::select_options($statii_payment,$_FORM["invoiceStatusPayment"]);
-    $rtn["status"] = $_FORM["status"];
-    $rtn["dateOne"] = $_FORM["dateOne"];
-    $rtn["dateTwo"] = $_FORM["dateTwo"];
-    $rtn["invoiceID"] = $_FORM["invoiceID"];
-    $rtn["invoiceName"] = $_FORM["invoiceName"];
-    $rtn["invoiceNum"] = $_FORM["invoiceNum"];
-    $rtn["invoiceItemID"] = $_FORM["invoiceItemID"];
+        if (!$_FORM["applyFilter"]) {
+            $_FORM = $current_user->prefs[$_FORM["form_name"]];
+            if (!isset($current_user->prefs[$_FORM["form_name"]])) {
+                // defaults go here
+                $_FORM["invoiceStatus"] = "edit";
+            }
+        } else if ($_FORM["applyFilter"] && is_object($current_user) && !$_FORM["dontSave"]) {
+            $url = $_FORM["url_form_action"];
+            unset($_FORM["url_form_action"]);
+            $current_user->prefs[$_FORM["form_name"]] = $_FORM;
+            $_FORM["url_form_action"] = $url;
+        }
 
-    $options["clientStatus"] = "Current";
-    $options["return"] = "dropdown_options";
-    $ops = client::get_list($options);
-    $ops = array_kv($ops,"clientID","clientName");
-    $rtn["clientOptions"] = page::select_options($ops,$_FORM["clientID"]);
+        return $_FORM;
+    }
 
-    // Get
-    $rtn["FORM"] = "FORM=".urlencode(serialize($_FORM));
+    function load_invoice_filter($_FORM)
+    {
+        global $TPL;
 
-    return $rtn;
-  }
+      // Load up the forms action url
+        $rtn["url_form_action"] = $_FORM["url_form_action"];
 
-  function update_invoice_dates($invoiceID) {
-    $db = new db_alloc();
-    $db->query(prepare("SELECT max(iiDate) AS maxDate, min(iiDate) AS minDate
+        $statii = invoice::get_invoice_statii();
+        unset($statii["create"]);
+        $rtn["statusOptions"] = page::select_options($statii, $_FORM["invoiceStatus"]);
+        $statii_payment = invoice::get_invoice_statii_payment();
+        $rtn["statusPaymentOptions"] = page::select_options($statii_payment, $_FORM["invoiceStatusPayment"]);
+        $rtn["status"] = $_FORM["status"];
+        $rtn["dateOne"] = $_FORM["dateOne"];
+        $rtn["dateTwo"] = $_FORM["dateTwo"];
+        $rtn["invoiceID"] = $_FORM["invoiceID"];
+        $rtn["invoiceName"] = $_FORM["invoiceName"];
+        $rtn["invoiceNum"] = $_FORM["invoiceNum"];
+        $rtn["invoiceItemID"] = $_FORM["invoiceItemID"];
+
+        $options["clientStatus"] = "Current";
+        $options["return"] = "dropdown_options";
+        $ops = client::get_list($options);
+        $ops = array_kv($ops, "clientID", "clientName");
+        $rtn["clientOptions"] = page::select_options($ops, $_FORM["clientID"]);
+
+      // Get
+        $rtn["FORM"] = "FORM=".urlencode(serialize($_FORM));
+
+        return $rtn;
+    }
+
+    function update_invoice_dates($invoiceID)
+    {
+        $db = new db_alloc();
+        $db->query(prepare(
+            "SELECT max(iiDate) AS maxDate, min(iiDate) AS minDate
                           FROM invoiceItem
-                         WHERE invoiceID=%d"
-                      ,$invoiceID));
-    $db->next_record();
-    $invoice = new invoice();
-    $invoice->set_id($invoiceID);
-    $invoice->select();
-    $invoice->set_value("invoiceDateFrom", $db->f("minDate"));
-    $invoice->set_value("invoiceDateTo", $db->f("maxDate"));
-    return $invoice->save();
-  }
+                         WHERE invoiceID=%d",
+            $invoiceID
+        ));
+        $db->next_record();
+        $invoice = new invoice();
+        $invoice->set_id($invoiceID);
+        $invoice->select();
+        $invoice->set_value("invoiceDateFrom", $db->f("minDate"));
+        $invoice->set_value("invoiceDateTo", $db->f("maxDate"));
+        return $invoice->save();
+    }
 
-  function close_related_entities() {
-    $db = new db_alloc();
-    $invoiceItemIDs = $this->get_invoiceItems();
-    foreach ($invoiceItemIDs as $invoiceItemID) {
-
-      $q = prepare("SELECT *
+    function close_related_entities()
+    {
+        $db = new db_alloc();
+        $invoiceItemIDs = $this->get_invoiceItems();
+        foreach ($invoiceItemIDs as $invoiceItemID) {
+            $q = prepare(
+                "SELECT *
                       FROM transaction
                      WHERE invoiceItemID = %d
-                       AND status = 'pending'"
-                  ,$invoiceItemID);
-      $db->query($q);
-      if (!$db->next_record()) {
-        $invoiceItem = new invoiceItem();
-        $invoiceItem->set_id($invoiceItemID);
-        $invoiceItem->select();
-        $invoiceItem->close_related_entity();
-      }
+                       AND status = 'pending'",
+                $invoiceItemID
+            );
+            $db->query($q);
+            if (!$db->next_record()) {
+                  $invoiceItem = new invoiceItem();
+                  $invoiceItem->set_id($invoiceItemID);
+                  $invoiceItem->select();
+                  $invoiceItem->close_related_entity();
+            }
+        }
     }
-  }
 
-  function next_status($direction) {
+    function next_status($direction)
+    {
  
-    $steps["forwards"][""] = "edit";
-    $steps["forwards"]["edit"] = "reconcile";
-    $steps["forwards"]["reconcile"] = "finished";
+        $steps["forwards"][""] = "edit";
+        $steps["forwards"]["edit"] = "reconcile";
+        $steps["forwards"]["reconcile"] = "finished";
 
-    $steps["backwards"]["finished"] = "reconcile";
-    $steps["backwards"]["reconcile"] = "edit";
-    $steps["backwards"]["edit"] = "";
+        $steps["backwards"]["finished"] = "reconcile";
+        $steps["backwards"]["reconcile"] = "edit";
+        $steps["backwards"]["edit"] = "";
 
-    $status = $this->get_value("invoiceStatus");
-    $newstatus = $steps[$direction][$status];
+        $status = $this->get_value("invoiceStatus");
+        $newstatus = $steps[$direction][$status];
 
-    return $newstatus;
-  }
+        return $newstatus;
+    }
  
-  function change_status($direction) {
-    $newstatus = $this->next_status($direction);
-    if ($newstatus) {
-      if ($this->can_move($direction, $newstatus)) {
-        $m = $this->{"move_status_to_".$newstatus}($direction);
-      }
-      if (is_array($m)) {
-        return implode("<br>",$m);
-      }
+    function change_status($direction)
+    {
+        $newstatus = $this->next_status($direction);
+        if ($newstatus) {
+            if ($this->can_move($direction, $newstatus)) {
+                $m = $this->{"move_status_to_".$newstatus}($direction);
+            }
+            if (is_array($m)) {
+                return implode("<br>", $m);
+            }
+        }
     }
 
-
-  }
-
-  function move_status_to_edit($direction) {
-    $this->set_value("invoiceStatus", "edit");
-  }
-
-  function move_status_to_reconcile($direction) {
-    $this->set_value("invoiceStatus", "reconcile");
-  }
-
-  function move_status_to_finished($direction) {
-    if ($direction == "forwards") {
-      $this->close_related_entities();
+    function move_status_to_edit($direction)
+    {
+        $this->set_value("invoiceStatus", "edit");
     }
-    $this->set_value("invoiceStatus", "finished");
-  }
 
-  function can_move($direction) {
-    $newstatus = $this->next_status($direction);
-    if ($direction == "forwards" && $newstatus == "finished") {
-      if ($this->has_pending_transactions()) {
-        alloc_error("There are still Invoice Items pending. This Invoice cannot be marked completed.");
-        return false;
-      }
+    function move_status_to_reconcile($direction)
+    {
+        $this->set_value("invoiceStatus", "reconcile");
     }
-    if ($direction == "forwards" && $newstatus == "reconcile") {
-      $db = new db_alloc();
-      $hasItems = $db->qr("SELECT * FROM invoiceItem WHERE invoiceID = %d",$this->get_id());
-      if (!$hasItems) {
-        alloc_error("Unable to submit invoice, no items have been added.");
-        return false;
-      }
+
+    function move_status_to_finished($direction)
+    {
+        if ($direction == "forwards") {
+            $this->close_related_entities();
+        }
+        $this->set_value("invoiceStatus", "finished");
     }
-    return true;
-  }
+
+    function can_move($direction)
+    {
+        $newstatus = $this->next_status($direction);
+        if ($direction == "forwards" && $newstatus == "finished") {
+            if ($this->has_pending_transactions()) {
+                alloc_error("There are still Invoice Items pending. This Invoice cannot be marked completed.");
+                return false;
+            }
+        }
+        if ($direction == "forwards" && $newstatus == "reconcile") {
+            $db = new db_alloc();
+            $hasItems = $db->qr("SELECT * FROM invoiceItem WHERE invoiceID = %d", $this->get_id());
+            if (!$hasItems) {
+                alloc_error("Unable to submit invoice, no items have been added.");
+                return false;
+            }
+        }
+        return true;
+    }
   
-  function has_pending_transactions() {
-    $q = prepare("SELECT * 
+    function has_pending_transactions()
+    {
+        $q = prepare("SELECT * 
                     FROM transaction
                LEFT JOIN invoiceItem on transaction.invoiceItemID = invoiceItem.invoiceItemID
                    WHERE invoiceItem.invoiceID = %d AND transaction.status = 'pending' 
-                   ",$this->get_id());
-    $db = new db_alloc();
-    $db->query($q);
-    return $db->next_record();
-  }
+                   ", $this->get_id());
+        $db = new db_alloc();
+        $db->query($q);
+        return $db->next_record();
+    }
 
-  function add_timeSheet($timeSheetID=false) {
-    if ($timeSheetID) {
-      $q = prepare("SELECT * 
+    function add_timeSheet($timeSheetID = false)
+    {
+        if ($timeSheetID) {
+            $q = prepare(
+                "SELECT * 
                       FROM invoiceItem 
                      WHERE invoiceID = %d 
-                       AND timeSheetID = %d"
-                  ,$this->get_id()
-                  ,$timeSheetID);
-      $db = new db_alloc();
-      $db->query($q);
-      // Add this time sheet to the invoice if the timeSheet hasn't already
-      // been added to this invoice
-      if (!$db->row()) {
-        invoiceEntity::save_invoice_timeSheet($this->get_id(),$timeSheetID);
-      }
-    }  
-  }
-
-  function get_all_parties($projectID="", $clientID="") {
-    $db = new db_alloc();
-    $interestedPartyOptions = array();
-
-    if (!$projectID && is_object($this)) {
-      $projectID = $this->get_value("projectID");
+                       AND timeSheetID = %d",
+                $this->get_id(),
+                $timeSheetID
+            );
+            $db = new db_alloc();
+            $db->query($q);
+          // Add this time sheet to the invoice if the timeSheet hasn't already
+          // been added to this invoice
+            if (!$db->row()) {
+                  invoiceEntity::save_invoice_timeSheet($this->get_id(), $timeSheetID);
+            }
+        }
     }
 
-    if ($projectID) {
-      $project = new project($projectID);
-      $interestedPartyOptions = $project->get_all_parties();
-    }
-    if ($clientID) {
-      $client = new client($clientID);
-      $interestedPartyOptions = array_merge((array)$interestedPartyOptions, (array)$client->get_all_parties());
-    }
+    function get_all_parties($projectID = "", $clientID = "")
+    {
+        $db = new db_alloc();
+        $interestedPartyOptions = array();
+
+        if (!$projectID && is_object($this)) {
+            $projectID = $this->get_value("projectID");
+        }
+
+        if ($projectID) {
+            $project = new project($projectID);
+            $interestedPartyOptions = $project->get_all_parties();
+        }
+        if ($clientID) {
+            $client = new client($clientID);
+            $interestedPartyOptions = array_merge((array)$interestedPartyOptions, (array)$client->get_all_parties());
+        }
   
-    $extra_interested_parties = config::get_config_item("defaultInterestedParties") or $extra_interested_parties=array();
-    foreach ($extra_interested_parties as $name => $email) {
-      $interestedPartyOptions[$email] = array("name"=>$name);
+        $extra_interested_parties = config::get_config_item("defaultInterestedParties") or $extra_interested_parties=array();
+        foreach ($extra_interested_parties as $name => $email) {
+            $interestedPartyOptions[$email] = array("name"=>$name);
+        }
+
+      // return an aggregation of the current task/proj/client parties + the existing interested parties
+        $interestedPartyOptions = interestedParty::get_interested_parties("invoice", $this->get_id(), $interestedPartyOptions);
+        return $interestedPartyOptions;
     }
 
-    // return an aggregation of the current task/proj/client parties + the existing interested parties
-    $interestedPartyOptions = interestedParty::get_interested_parties("invoice",$this->get_id(),$interestedPartyOptions);
-    return $interestedPartyOptions;
-  }
-
-  function get_list_html($rows=array(),$ops=array()) {
-    global $TPL;
-    $TPL["invoiceListRows"] = $rows;
-    $TPL["_FORM"] = $ops;
-    include_template(dirname(__FILE__)."/../templates/invoiceListS.tpl");
-  }
+    function get_list_html($rows = array(), $ops = array())
+    {
+        global $TPL;
+        $TPL["invoiceListRows"] = $rows;
+        $TPL["_FORM"] = $ops;
+        include_template(dirname(__FILE__)."/../templates/invoiceListS.tpl");
+    }
 }
-
-
-
-?>

--- a/invoice/lib/invoiceEntity.inc.php
+++ b/invoice/lib/invoiceEntity.inc.php
@@ -3,164 +3,169 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("DEFAULT_SEP","\n");
-class invoiceEntity extends db_entity {
-  public $classname = "invoiceEntity";
-  public $data_table = "invoiceEntity";
-  public $key_field = "invoiceEntityID";
-  public $data_fields = array("invoiceID"
+define("DEFAULT_SEP", "\n");
+class invoiceEntity extends db_entity
+{
+    public $classname = "invoiceEntity";
+    public $data_table = "invoiceEntity";
+    public $key_field = "invoiceEntityID";
+    public $data_fields = array("invoiceID"
                              ,"timeSheetID"
                              ,"expenseFormID"
                              ,"productSaleID"
                              ,"useItems"
                              );
 
-  function create($invoiceID,$entity,$entityID,$useItems=0) {
-    $q = prepare("SELECT * FROM invoiceEntity WHERE invoiceID = %d AND %sID = %d",$invoiceID,$entity,$entityID);
-    $db = new db_alloc();
-    $db->query($q);
-    $row = $db->row();
-    $ie = new invoiceEntity();
-    if ($row) {
-      $ie->set_id($row["invoiceEntityID"]);
+    function create($invoiceID, $entity, $entityID, $useItems = 0)
+    {
+        $q = prepare("SELECT * FROM invoiceEntity WHERE invoiceID = %d AND %sID = %d", $invoiceID, $entity, $entityID);
+        $db = new db_alloc();
+        $db->query($q);
+        $row = $db->row();
+        $ie = new invoiceEntity();
+        if ($row) {
+            $ie->set_id($row["invoiceEntityID"]);
+        }
+        $ie->set_value("invoiceID", $invoiceID);
+        $ie->set_value($entity."ID", $entityID);
+        $ie->set_value("useItems", sprintf("%d", $useItems));
+        $ie->save();
     }
-    $ie->set_value("invoiceID",$invoiceID);
-    $ie->set_value($entity."ID",$entityID);
-    $ie->set_value("useItems",sprintf("%d",$useItems));
-    $ie->save();
-  }
 
-  function get($entity,$entityID) {
-    $q = prepare("SELECT invoiceEntity.*,invoice.invoiceNum
+    function get($entity, $entityID)
+    {
+        $q = prepare("SELECT invoiceEntity.*,invoice.invoiceNum
                     FROM invoiceEntity
                LEFT JOIN invoice ON invoiceEntity.invoiceID = invoice.invoiceID
                    WHERE invoiceEntity.%sID = %d
-                ",$entity,$entityID);
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $rows[] = $row;
+                ", $entity, $entityID);
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $rows[] = $row;
+        }
+        return (array)$rows;
     }
-    return (array)$rows;
-  }
 
-  function get_links($invoiceID) {
-    $rows = invoiceEntity::get("invoice",$invoiceID); // cheating :)
-    foreach ($rows as $row) {
-      if ($row["timeSheetID"]) {
-        $timeSheet = new timeSheet($row["timeSheetID"]);
-        $timeSheet_links[] = $timeSheet->get_link();
-      }
+    function get_links($invoiceID)
+    {
+        $rows = invoiceEntity::get("invoice", $invoiceID); // cheating :)
+        foreach ($rows as $row) {
+            if ($row["timeSheetID"]) {
+                $timeSheet = new timeSheet($row["timeSheetID"]);
+                $timeSheet_links[] = $timeSheet->get_link();
+            }
       
-      if ($row["expenseFormID"]) {
-        $expenseForm = new expenseForm($row["expenseFormID"]);
-        $expenseForm_links[] = $expenseForm->get_link();
-      }
+            if ($row["expenseFormID"]) {
+                $expenseForm = new expenseForm($row["expenseFormID"]);
+                $expenseForm_links[] = $expenseForm->get_link();
+            }
 
-      if ($row["productSaleID"]) {
-        $productSale = new productSale($row["productSaleID"]);
-        $productSale_links[] = $productSale->get_link();
-      }
+            if ($row["productSaleID"]) {
+                $productSale = new productSale($row["productSaleID"]);
+                $productSale_links[] = $productSale->get_link();
+            }
+        }
+
+        $timeSheet_links and $rtn[] = "Time Sheet: ".implode(", ", (array)$timeSheet_links);
+        $expenseForm_links and $rtn[] = "Expense Form: ".implode(", ", (array)$expenseForm_links);
+        $productSale_links and $rtn[] = "Product Sale: ".implode(", ", (array)$productSale_links);
+        return implode(" / ", (array)$rtn);
     }
 
-    $timeSheet_links and $rtn[] = "Time Sheet: ".implode(", ",(array)$timeSheet_links);
-    $expenseForm_links and $rtn[] = "Expense Form: ".implode(", ",(array)$expenseForm_links);
-    $productSale_links and $rtn[] = "Product Sale: ".implode(", ",(array)$productSale_links);
-    return implode(" / ",(array)$rtn);
-  }
+    function save_invoice_timeSheet($invoiceID, $timeSheetID)
+    {
+        global $TPL;
+        $invoice = new invoice($invoiceID);
+        if ($invoice->get_value("invoiceStatus") != "finished") {
+            $timeSheet = new timeSheet();
+            $timeSheet->set_id($timeSheetID);
+            $timeSheet->select();
+            $timeSheet->load_pay_info();
+            $project = $timeSheet->get_foreign_object("project");
+            $date = $timeSheet->get_value("dateFrom") or $date = date("Y-m-d");
 
-  function save_invoice_timeSheet($invoiceID,$timeSheetID) {
-    global $TPL;
-    $invoice = new invoice($invoiceID);
-    if ($invoice->get_value("invoiceStatus") != "finished") {
-      $timeSheet = new timeSheet();
-      $timeSheet->set_id($timeSheetID);
-      $timeSheet->select();
-      $timeSheet->load_pay_info();
-      $project = $timeSheet->get_foreign_object("project");
-      $date = $timeSheet->get_value("dateFrom") or $date = date("Y-m-d");
-
-      // customerBilledDollars will not be set if the actual field is blank,
-      // and thus there won't be a usable total_customerBilledDollars.
-      if (isset($timeSheet->pay_info["customerBilledDollars"])) { 
-        $amount = $timeSheet->pay_info["total_customerBilledDollars"];
-        $iiUnitPrice = $timeSheet->pay_info["customerBilledDollars"];
-        $iiQuantity = $timeSheet->pay_info["total_duration"];
-      } else {
-        $amount = $timeSheet->pay_info["total_dollars"];
-        $iiUnitPrice = $amount; 
-        $iiQuantity = 1;
-      }
+          // customerBilledDollars will not be set if the actual field is blank,
+          // and thus there won't be a usable total_customerBilledDollars.
+            if (isset($timeSheet->pay_info["customerBilledDollars"])) {
+                $amount = $timeSheet->pay_info["total_customerBilledDollars"];
+                $iiUnitPrice = $timeSheet->pay_info["customerBilledDollars"];
+                $iiQuantity = $timeSheet->pay_info["total_duration"];
+            } else {
+                $amount = $timeSheet->pay_info["total_dollars"];
+                $iiUnitPrice = $amount;
+                $iiQuantity = 1;
+            }
       
-      $q = prepare("SELECT * FROM invoiceItem WHERE invoiceID = %d AND timeSheetID = %d AND timeSheetItemID IS NULL
-                   ",$invoiceID,$timeSheetID);
-      $db = new db_alloc();
-      $db->query($q);
-      $row = $db->row();
-      $ii = new invoiceItem();
-      if ($row) {
-        $ii->set_id($row["invoiceItemID"]);
-      }
-      $ii->set_value("invoiceID",$invoiceID);
-      $ii->set_value("timeSheetID",$timeSheet->get_id());
-      $ii->set_value("iiMemo","Time Sheet #".$timeSheet->get_id()." for ".person::get_fullname($timeSheet->get_value("personID")).", Project: ".$project->get_value("projectName"));
-      $ii->set_value("iiQuantity",$iiQuantity);
-      $ii->set_value("iiUnitPrice",$iiUnitPrice);
-      $ii->set_value("iiAmount",$amount);
-      $ii->set_value("iiDate",$date);
-      $ii->set_value("iiTax",config::get_config_item("taxPercent"));
-      $ii->currency = $timeSheet->get_value("currencyTypeID");
-      $ii->save();
-    } else {
-      alloc_error("Unable to update related Invoice (ID:".$invoiceID.").");
+            $q = prepare("SELECT * FROM invoiceItem WHERE invoiceID = %d AND timeSheetID = %d AND timeSheetItemID IS NULL
+                   ", $invoiceID, $timeSheetID);
+            $db = new db_alloc();
+            $db->query($q);
+            $row = $db->row();
+            $ii = new invoiceItem();
+            if ($row) {
+                  $ii->set_id($row["invoiceItemID"]);
+            }
+            $ii->set_value("invoiceID", $invoiceID);
+            $ii->set_value("timeSheetID", $timeSheet->get_id());
+            $ii->set_value("iiMemo", "Time Sheet #".$timeSheet->get_id()." for ".person::get_fullname($timeSheet->get_value("personID")).", Project: ".$project->get_value("projectName"));
+            $ii->set_value("iiQuantity", $iiQuantity);
+            $ii->set_value("iiUnitPrice", $iiUnitPrice);
+            $ii->set_value("iiAmount", $amount);
+            $ii->set_value("iiDate", $date);
+            $ii->set_value("iiTax", config::get_config_item("taxPercent"));
+            $ii->currency = $timeSheet->get_value("currencyTypeID");
+            $ii->save();
+        } else {
+            alloc_error("Unable to update related Invoice (ID:".$invoiceID.").");
+        }
     }
-  }
 
-  function save_invoice_timeSheetItems($invoiceID,$timeSheetID) {
-    $timeSheet = new timeSheet();
-    $timeSheet->set_id($timeSheetID);
-    $timeSheet->select();
-    $currency = $timeSheet->get_value("currencyTypeID");
-    $timeSheet->load_pay_info();
-    $amount = $timeSheet->pay_info["total_customerBilledDollars"] or $amount = $timeSheet->pay_info["total_dollars"];
+    function save_invoice_timeSheetItems($invoiceID, $timeSheetID)
+    {
+        $timeSheet = new timeSheet();
+        $timeSheet->set_id($timeSheetID);
+        $timeSheet->select();
+        $currency = $timeSheet->get_value("currencyTypeID");
+        $timeSheet->load_pay_info();
+        $amount = $timeSheet->pay_info["total_customerBilledDollars"] or $amount = $timeSheet->pay_info["total_dollars"];
 
-    $project = $timeSheet->get_foreign_object("project");
-    $client = $project->get_foreign_object("client");
+        $project = $timeSheet->get_foreign_object("project");
+        $client = $project->get_foreign_object("client");
 
-    $db = new db_alloc();
-    $q1 = $db->query(prepare("SELECT * FROM timeSheetItem WHERE timeSheetID = %d",$timeSheetID));
-    while ($row = $db->row($q1)) {
+        $db = new db_alloc();
+        $q1 = $db->query(prepare("SELECT * FROM timeSheetItem WHERE timeSheetID = %d", $timeSheetID));
+        while ($row = $db->row($q1)) {
+            if (imp($timeSheet->pay_info["customerBilledDollars"])) {
+                $iiUnitPrice = $timeSheet->pay_info["customerBilledDollars"];
+            } else {
+                $iiUnitPrice = page::money($currency, $row["rate"], "%mo");
+            }
 
-      if (imp($timeSheet->pay_info["customerBilledDollars"])) {
-        $iiUnitPrice = $timeSheet->pay_info["customerBilledDollars"];
-      } else {
-        $iiUnitPrice = page::money($currency,$row["rate"],"%mo");
-      }
+            unset($str);
+            if ($row["comment"] && !$row["commentPrivate"]) {
+                $str = $row["comment"];
+            }
 
-      unset($str);
-      if ($row["comment"] && !$row["commentPrivate"]) {
-        $str = $row["comment"];
-      }
-
-      // Look for an existing invoiceItem
-      $q = prepare("SELECT invoiceItem.invoiceItemID
+          // Look for an existing invoiceItem
+            $q = prepare("SELECT invoiceItem.invoiceItemID
                       FROM invoiceItem
                  LEFT JOIN invoice ON invoiceItem.invoiceID = invoice.invoiceID
                      WHERE invoiceItem.timeSheetID = %d
@@ -168,154 +173,152 @@ class invoiceEntity extends db_entity {
                        AND invoiceItem.invoiceID = %d
                        AND invoice.invoiceStatus != 'finished'
                   ORDER BY iiDate DESC LIMIT 1
-                   ",$timeSheet->get_id(),$row["timeSheetItemID"],$invoiceID);
-      $q2 = $db->query($q);
-      $r2 = $db->row($q2);
+                   ", $timeSheet->get_id(), $row["timeSheetItemID"], $invoiceID);
+            $q2 = $db->query($q);
+            $r2 = $db->row($q2);
 
-      $ii = new invoiceItem();
-      if ($r2["invoiceItemID"]) {
-        $ii->set_id($r2["invoiceItemID"]);
-      }
-      $ii->currency = $currency;
-      $ii->set_value("invoiceID",$invoiceID);
-      $ii->set_value("timeSheetID",$timeSheet->get_id());
-      $ii->set_value("timeSheetItemID",$row["timeSheetItemID"]);
-      $ii->set_value("iiMemo","Time Sheet for ".person::get_fullname($timeSheet->get_value("personID")).", Project: ".$project->get_value("projectName").", ".$row["description"]."\n".$str);
-      $ii->set_value("iiQuantity",$row["timeSheetItemDuration"] * $row["multiplier"]);
-      $ii->set_value("iiUnitPrice",$iiUnitPrice);
-      $ii->set_value("iiAmount",$iiUnitPrice * $row["timeSheetItemDuration"] * $row["multiplier"]);
-      $ii->set_value("iiDate",$row["dateTimeSheetItem"]);
-      $ii->set_value("iiTax",config::get_config_item("taxPercent"));
-      $ii->save();
+            $ii = new invoiceItem();
+            if ($r2["invoiceItemID"]) {
+                  $ii->set_id($r2["invoiceItemID"]);
+            }
+            $ii->currency = $currency;
+            $ii->set_value("invoiceID", $invoiceID);
+            $ii->set_value("timeSheetID", $timeSheet->get_id());
+            $ii->set_value("timeSheetItemID", $row["timeSheetItemID"]);
+            $ii->set_value("iiMemo", "Time Sheet for ".person::get_fullname($timeSheet->get_value("personID")).", Project: ".$project->get_value("projectName").", ".$row["description"]."\n".$str);
+            $ii->set_value("iiQuantity", $row["timeSheetItemDuration"] * $row["multiplier"]);
+            $ii->set_value("iiUnitPrice", $iiUnitPrice);
+            $ii->set_value("iiAmount", $iiUnitPrice * $row["timeSheetItemDuration"] * $row["multiplier"]);
+            $ii->set_value("iiDate", $row["dateTimeSheetItem"]);
+            $ii->set_value("iiTax", config::get_config_item("taxPercent"));
+            $ii->save();
+        }
     }
-  }
 
-  function save_invoice_expenseForm($invoiceID,$expenseFormID) {
-    $expenseForm = new expenseForm();
-    $expenseForm->set_id($expenseFormID);
-    $expenseForm->select();
-    $db = new db_alloc();
-    $db->query("SELECT max(transactionDate) as maxDate
+    function save_invoice_expenseForm($invoiceID, $expenseFormID)
+    {
+        $expenseForm = new expenseForm();
+        $expenseForm->set_id($expenseFormID);
+        $expenseForm->select();
+        $db = new db_alloc();
+        $db->query("SELECT max(transactionDate) as maxDate
                   FROM transaction
-                 WHERE expenseFormID = %d",$expenseFormID);
-    $row = $db->row();
-    $amount = $expenseForm->get_abs_sum_transactions();
+                 WHERE expenseFormID = %d", $expenseFormID);
+        $row = $db->row();
+        $amount = $expenseForm->get_abs_sum_transactions();
 
-    $q = prepare("SELECT * FROM invoiceItem WHERE expenseFormID = %d AND transactionID IS NULL",$expenseFormID);
-    $db = new db_alloc();
-    $q2 = $db->query($q);
-    $r2 = $db->row($q2);
-    $ii = new invoiceItem();
-    if ($r2) {
-      $ii->set_id($r2["invoiceItemID"]);
+        $q = prepare("SELECT * FROM invoiceItem WHERE expenseFormID = %d AND transactionID IS NULL", $expenseFormID);
+        $db = new db_alloc();
+        $q2 = $db->query($q);
+        $r2 = $db->row($q2);
+        $ii = new invoiceItem();
+        if ($r2) {
+            $ii->set_id($r2["invoiceItemID"]);
+        }
+        $ii->set_value("invoiceID", $invoiceID);
+        $ii->set_value("expenseFormID", $expenseForm->get_id());
+        $ii->set_value("iiMemo", "Expense Form #".$expenseForm->get_id()." for ".person::get_fullname($expenseForm->get_value("expenseFormCreatedUser")));
+        $ii->set_value("iiQuantity", 1);
+        $ii->set_value("iiUnitPrice", $amount);
+        $ii->set_value("iiAmount", $amount);
+        $ii->set_value("iiDate", $row["maxDate"]);
+        $ii->set_value("iiTax", config::get_config_item("taxPercent"));
+        $ii->save();
     }
-    $ii->set_value("invoiceID",$invoiceID);
-    $ii->set_value("expenseFormID",$expenseForm->get_id());
-    $ii->set_value("iiMemo","Expense Form #".$expenseForm->get_id()." for ".person::get_fullname($expenseForm->get_value("expenseFormCreatedUser")));
-    $ii->set_value("iiQuantity",1);
-    $ii->set_value("iiUnitPrice",$amount);
-    $ii->set_value("iiAmount",$amount);
-    $ii->set_value("iiDate",$row["maxDate"]);
-    $ii->set_value("iiTax",config::get_config_item("taxPercent"));
-    $ii->save();
-  }
 
-  function save_invoice_expenseFormItems($invoiceID,$expenseFormID) {
-    $expenseForm = new expenseForm();
-    $expenseForm->set_id($expenseFormID);
-    $expenseForm->select();
-    $db = new db_alloc();
-    $q1 = $db->query("SELECT * FROM transaction WHERE expenseFormID = %d",$expenseFormID);
-    while ($row = $db->row($q1)) {
-      $amount = page::money($row["currencyTypeID"],$row["amount"],"%mo");
+    function save_invoice_expenseFormItems($invoiceID, $expenseFormID)
+    {
+        $expenseForm = new expenseForm();
+        $expenseForm->set_id($expenseFormID);
+        $expenseForm->select();
+        $db = new db_alloc();
+        $q1 = $db->query("SELECT * FROM transaction WHERE expenseFormID = %d", $expenseFormID);
+        while ($row = $db->row($q1)) {
+            $amount = page::money($row["currencyTypeID"], $row["amount"], "%mo");
 
-      $q = prepare("SELECT * FROM invoiceItem WHERE expenseFormID = %d AND transactionID = %d",$expenseFormID,$row["transactionID"]);
-      $db = new db_alloc();
-      $q2 = $db->query($q);
-      $r2 = $db->row($q2);
-      $ii = new invoiceItem();
-      if ($r2) {
-        $ii->set_id($r2["invoiceItemID"]);
-      }
-      $ii->currency = $row["currencyTypeID"];
-      $ii->set_value("invoiceID",$invoiceID);
-      $ii->set_value("expenseFormID",$expenseForm->get_id());
-      $ii->set_value("transactionID",$row["transactionID"]);
-      $ii->set_value("iiMemo","Expenses for ".person::get_fullname($expenseForm->get_value("expenseFormCreatedUser")).", ".$row["product"]);
-      $ii->set_value("iiQuantity",$row["quantity"]);
-      $ii->set_value("iiUnitPrice",$amount/$row["quantity"]);
-      $ii->set_value("iiAmount",$amount);
-      $ii->set_value("iiDate",$row["transactionDate"]);
-      $ii->set_value("iiTax",config::get_config_item("taxPercent"));
-      $ii->save();
+            $q = prepare("SELECT * FROM invoiceItem WHERE expenseFormID = %d AND transactionID = %d", $expenseFormID, $row["transactionID"]);
+            $db = new db_alloc();
+            $q2 = $db->query($q);
+            $r2 = $db->row($q2);
+            $ii = new invoiceItem();
+            if ($r2) {
+                $ii->set_id($r2["invoiceItemID"]);
+            }
+            $ii->currency = $row["currencyTypeID"];
+            $ii->set_value("invoiceID", $invoiceID);
+            $ii->set_value("expenseFormID", $expenseForm->get_id());
+            $ii->set_value("transactionID", $row["transactionID"]);
+            $ii->set_value("iiMemo", "Expenses for ".person::get_fullname($expenseForm->get_value("expenseFormCreatedUser")).", ".$row["product"]);
+            $ii->set_value("iiQuantity", $row["quantity"]);
+            $ii->set_value("iiUnitPrice", $amount/$row["quantity"]);
+            $ii->set_value("iiAmount", $amount);
+            $ii->set_value("iiDate", $row["transactionDate"]);
+            $ii->set_value("iiTax", config::get_config_item("taxPercent"));
+            $ii->save();
+        }
     }
-  }
 
-  function save_invoice_productSale($invoiceID,$productSaleID) {
-    $productSale = new productSale();
-    $productSale->set_id($productSaleID);
-    $productSale->select();
-    $db = new db_alloc();
-    $db->query("SELECT max(transactionDate) as maxDate
+    function save_invoice_productSale($invoiceID, $productSaleID)
+    {
+        $productSale = new productSale();
+        $productSale->set_id($productSaleID);
+        $productSale->select();
+        $db = new db_alloc();
+        $db->query("SELECT max(transactionDate) as maxDate
                   FROM transaction
-                 WHERE productSaleID = %d",$productSaleID);
-    $row = $db->row();
-    $amounts = $productSale->get_amounts();
+                 WHERE productSaleID = %d", $productSaleID);
+        $row = $db->row();
+        $amounts = $productSale->get_amounts();
 
-    $q = prepare("SELECT * FROM invoiceItem WHERE productSaleID = %d AND productSaleItemID IS NULL",$productSaleID);
-    $db = new db_alloc();
-    $q2 = $db->query($q);
-    $r2 = $db->row($q2);
-    $ii = new invoiceItem();
-    if ($r2) {
-      $ii->set_id($r2["invoiceItemID"]);
+        $q = prepare("SELECT * FROM invoiceItem WHERE productSaleID = %d AND productSaleItemID IS NULL", $productSaleID);
+        $db = new db_alloc();
+        $q2 = $db->query($q);
+        $r2 = $db->row($q2);
+        $ii = new invoiceItem();
+        if ($r2) {
+            $ii->set_id($r2["invoiceItemID"]);
+        }
+        $ii->set_value("invoiceID", $invoiceID);
+        $ii->set_value("productSaleID", $productSale->get_id());
+        $ii->set_value("iiMemo", "Sale #".$productSale->get_id()." for ".person::get_fullname($productSale->get_value("personID")));
+        $ii->set_value("iiQuantity", 1);
+        $ii->set_value("iiUnitPrice", $amounts["total_sellPrice_value"]);
+        $ii->set_value("iiAmount", $amounts["total_sellPrice_value"]);
+        $ii->set_value("iiDate", $row["maxDate"]);
+      //$ii->set_value("iiTax",config::get_config_item("taxPercent"));
+        $ii->save();
     }
-    $ii->set_value("invoiceID",$invoiceID);
-    $ii->set_value("productSaleID",$productSale->get_id());
-    $ii->set_value("iiMemo","Sale #".$productSale->get_id()." for ".person::get_fullname($productSale->get_value("personID")));
-    $ii->set_value("iiQuantity",1);
-    $ii->set_value("iiUnitPrice",$amounts["total_sellPrice_value"]);
-    $ii->set_value("iiAmount",$amounts["total_sellPrice_value"]);
-    $ii->set_value("iiDate",$row["maxDate"]);
-    //$ii->set_value("iiTax",config::get_config_item("taxPercent"));
-    $ii->save();
-  }
 
-  function save_invoice_productSaleItems($invoiceID,$productSaleID) {
-    $productSale = new productSale();
-    $productSale->set_id($productSaleID);
-    $productSale->select();
-    $db = new db_alloc();
-    $q = prepare("SELECT * FROM productSaleItem WHERE productSaleID = %d",$productSale->get_id());
-    $q1 = $db->query($q);
-    while ($row = $db->row($q1)) {
-
-      $q = prepare("SELECT * FROM invoiceItem WHERE productSaleID = %d AND productSaleItemID = %d",$productSaleID,$row["productSaleItemID"]);
-      $db = new db_alloc();
-      $q2 = $db->query($q);
-      $r2 = $db->row($q2);
-      $ii = new invoiceItem();
-      if ($r2) {
-        $ii->set_id($r2["invoiceItemID"]);
-      }
-      $ii->currency = $row["sellPriceCurrencyTypeID"];
-      $ii->set_value("invoiceID",$invoiceID);
-      $ii->set_value("productSaleID",$productSale->get_id());
-      $ii->set_value("productSaleItemID",$row["productSaleItemID"]);
-      $ii->set_value("iiMemo","Sale (".$productSale->get_id().") item for ".person::get_fullname($productSale->get_value("personID")).", ".$row["description"]);
-      $ii->set_value("iiQuantity",$row["quantity"]);
-      $row["sellPrice"] = page::money($ii->currency,$row["sellPrice"]/$row["quantity"],"%mo");
-      $ii->set_value("iiUnitPrice",$row["sellPrice"]);
-      $ii->set_value("iiAmount",$row["sellPrice"]*$row["quantity"]);
-      $d = $productSale->get_value("productSaleDate") or $d = $productSale->get_value("productSaleModifiedTime") or $d = $productSale->get_value("productSaleCreatedTime");
-      $ii->set_value("iiDate",$d);
-      //$ii->set_value("iiTax",config::get_config_item("taxPercent")); // product sale items are always excl GST
-      $ii->save();
+    function save_invoice_productSaleItems($invoiceID, $productSaleID)
+    {
+        $productSale = new productSale();
+        $productSale->set_id($productSaleID);
+        $productSale->select();
+        $db = new db_alloc();
+        $q = prepare("SELECT * FROM productSaleItem WHERE productSaleID = %d", $productSale->get_id());
+        $q1 = $db->query($q);
+        while ($row = $db->row($q1)) {
+            $q = prepare("SELECT * FROM invoiceItem WHERE productSaleID = %d AND productSaleItemID = %d", $productSaleID, $row["productSaleItemID"]);
+            $db = new db_alloc();
+            $q2 = $db->query($q);
+            $r2 = $db->row($q2);
+            $ii = new invoiceItem();
+            if ($r2) {
+                $ii->set_id($r2["invoiceItemID"]);
+            }
+            $ii->currency = $row["sellPriceCurrencyTypeID"];
+            $ii->set_value("invoiceID", $invoiceID);
+            $ii->set_value("productSaleID", $productSale->get_id());
+            $ii->set_value("productSaleItemID", $row["productSaleItemID"]);
+            $ii->set_value("iiMemo", "Sale (".$productSale->get_id().") item for ".person::get_fullname($productSale->get_value("personID")).", ".$row["description"]);
+            $ii->set_value("iiQuantity", $row["quantity"]);
+            $row["sellPrice"] = page::money($ii->currency, $row["sellPrice"]/$row["quantity"], "%mo");
+            $ii->set_value("iiUnitPrice", $row["sellPrice"]);
+            $ii->set_value("iiAmount", $row["sellPrice"]*$row["quantity"]);
+            $d = $productSale->get_value("productSaleDate") or $d = $productSale->get_value("productSaleModifiedTime") or $d = $productSale->get_value("productSaleCreatedTime");
+            $ii->set_value("iiDate", $d);
+          //$ii->set_value("iiTax",config::get_config_item("taxPercent")); // product sale items are always excl GST
+            $ii->save();
+        }
     }
-  }
-
 }
-
-
-
-?>

--- a/invoice/lib/invoiceItem.inc.php
+++ b/invoice/lib/invoiceItem.inc.php
@@ -3,28 +3,29 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class invoiceItem extends db_entity {
-  public $data_table = "invoiceItem";
-  public $display_field_name = "iiMemo";
-  public $key_field = "invoiceItemID";
-  public $data_fields = array("invoiceID"
+class invoiceItem extends db_entity
+{
+    public $data_table = "invoiceItem";
+    public $display_field_name = "iiMemo";
+    public $key_field = "invoiceItemID";
+    public $data_fields = array("invoiceID"
                              ,"timeSheetID"
                              ,"timeSheetItemID"
                              ,"expenseFormID"
@@ -39,177 +40,179 @@ class invoiceItem extends db_entity {
                              ,"iiDate"
                              );
 
-  function is_owner($person = "") {
-    $current_user = &singleton("current_user");
+    function is_owner($person = "")
+    {
+        $current_user = &singleton("current_user");
 
-    if ($person == "") {
-      $person = $current_user;
-    }
-
-    $db = new db_alloc();
-    $q = prepare("SELECT * FROM transaction WHERE invoiceItemID = %d OR transactionID = %d",$this->get_id(),$this->get_value("transactionID"));
-    $db->query($q);
-    while ($db->next_record()) {
-      $transaction = new transaction();
-      $transaction->read_db_record($db);
-      if ($transaction->is_owner($person)) {
-        return true;
-      }
-    }
-
-    if ($this->get_value("timeSheetID")) {
-      $q = prepare("SELECT * FROM timeSheet WHERE timeSheetID = %d",$this->get_value("timeSheetID"));
-      $db->query($q);
-      while ($db->next_record()) {
-        $timeSheet = new timeSheet();
-        $timeSheet->read_db_record($db);
-        if ($timeSheet->is_owner($person)) {
-          return true;
+        if ($person == "") {
+            $person = $current_user;
         }
-      }
-    }
 
-    if ($this->get_value("expenseFormID")) {
-      $q = prepare("SELECT * FROM expenseForm WHERE expenseFormID = %d",$this->get_value("expenseFormID"));
-      $db->query($q);
-      while ($db->next_record()) {
-        $expenseForm = new expenseForm();
-        $expenseForm->read_db_record($db);
-        if ($expenseForm->is_owner($person)) {
-          return true;
+        $db = new db_alloc();
+        $q = prepare("SELECT * FROM transaction WHERE invoiceItemID = %d OR transactionID = %d", $this->get_id(), $this->get_value("transactionID"));
+        $db->query($q);
+        while ($db->next_record()) {
+            $transaction = new transaction();
+            $transaction->read_db_record($db);
+            if ($transaction->is_owner($person)) {
+                return true;
+            }
         }
-      }
+
+        if ($this->get_value("timeSheetID")) {
+            $q = prepare("SELECT * FROM timeSheet WHERE timeSheetID = %d", $this->get_value("timeSheetID"));
+            $db->query($q);
+            while ($db->next_record()) {
+                $timeSheet = new timeSheet();
+                $timeSheet->read_db_record($db);
+                if ($timeSheet->is_owner($person)) {
+                    return true;
+                }
+            }
+        }
+
+        if ($this->get_value("expenseFormID")) {
+            $q = prepare("SELECT * FROM expenseForm WHERE expenseFormID = %d", $this->get_value("expenseFormID"));
+            $db->query($q);
+            while ($db->next_record()) {
+                $expenseForm = new expenseForm();
+                $expenseForm->read_db_record($db);
+                if ($expenseForm->is_owner($person)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
-    return false;
-  }
+    function delete()
+    {
 
-  function delete() {
+        $db = new db_alloc();
+        $q = prepare("DELETE FROM transaction WHERE invoiceItemID = %d", $this->get_id());
+        $db->query($q);
 
-    $db = new db_alloc();
-    $q = prepare("DELETE FROM transaction WHERE invoiceItemID = %d",$this->get_id());
-    $db->query($q);
-
-    $invoiceID = $this->get_value("invoiceID");
-    $status = parent::delete();
-    $status2 = invoice::update_invoice_dates($invoiceID);
-    return $status && $status2;
-  }
-
-  function save() {
-
-    if (!imp($this->get_value("iiAmount"))) {
-      $this->set_value("iiAmount",$this->get_value("iiQuantity") * $this->get_value("iiUnitPrice"));
+        $invoiceID = $this->get_value("invoiceID");
+        $status = parent::delete();
+        $status2 = invoice::update_invoice_dates($invoiceID);
+        return $status && $status2;
     }
 
-    $status = parent::save();
-    $status2 = invoice::update_invoice_dates($this->get_value("invoiceID"));
-    return $status && $status2;
-  }
+    function save()
+    {
 
-  function close_related_entity() {
-    global $TPL;
+        if (!imp($this->get_value("iiAmount"))) {
+            $this->set_value("iiAmount", $this->get_value("iiQuantity") * $this->get_value("iiUnitPrice"));
+        }
 
-    // It checks for approved transactions and only approves the timesheets
-    // or expenseforms that are completely paid for by an invoice item.
-    $db = new db_alloc();
-    $q = prepare("SELECT amount, currencyTypeID, status 
+        $status = parent::save();
+        $status2 = invoice::update_invoice_dates($this->get_value("invoiceID"));
+        return $status && $status2;
+    }
+
+    function close_related_entity()
+    {
+        global $TPL;
+
+      // It checks for approved transactions and only approves the timesheets
+      // or expenseforms that are completely paid for by an invoice item.
+        $db = new db_alloc();
+        $q = prepare("SELECT amount, currencyTypeID, status 
                     FROM transaction 
                    WHERE invoiceItemID = %d 
                 ORDER BY transactionCreatedTime DESC 
                    LIMIT 1
-                 ",$this->get_id());
-    $db->query($q);
-    $row = $db->row();
-    $total = $row["amount"];
-    $currency = $row["currencyTypeID"];
-    $status = $row["status"];
+                 ", $this->get_id());
+        $db->query($q);
+        $row = $db->row();
+        $total = $row["amount"];
+        $currency = $row["currencyTypeID"];
+        $status = $row["status"];
 
-    $timeSheetID = $this->get_value("timeSheetID");
-    $expenseFormID = $this->get_value("expenseFormID");
+        $timeSheetID = $this->get_value("timeSheetID");
+        $expenseFormID = $this->get_value("expenseFormID");
 
-    if ($timeSheetID) {
-      $timeSheet = new timeSheet();
-      $timeSheet->set_id($timeSheetID);
-      $timeSheet->select();
+        if ($timeSheetID) {
+            $timeSheet = new timeSheet();
+            $timeSheet->set_id($timeSheetID);
+            $timeSheet->select();
       
-      $db = new db_alloc();
+            $db = new db_alloc();
 
-      if ($timeSheet->get_value("status") == "invoiced") {
-
-        // If the time sheet doesn't have any transactions and it is in
-        // status invoiced, then we'll simulate the "Create Default Transactions"
-        // button being pressed.
-        $q = prepare("SELECT count(*) as num_transactions 
+            if ($timeSheet->get_value("status") == "invoiced") {
+              // If the time sheet doesn't have any transactions and it is in
+              // status invoiced, then we'll simulate the "Create Default Transactions"
+              // button being pressed.
+                $q = prepare("SELECT count(*) as num_transactions 
                         FROM transaction 
                        WHERE timeSheetID = %d 
                          AND invoiceItemID IS NULL
-                     ",$timeSheet->get_id());
-        $db->query($q);
-        $row = $db->row();
-        if ($row["num_transactions"]==0) {
-          $_POST["create_transactions_default"] = true;
-          $timeSheet->createTransactions($status);
-          $TPL["message_good"][] = "Automatically created time sheet transactions.";
-        }
+                     ", $timeSheet->get_id());
+                $db->query($q);
+                $row = $db->row();
+                if ($row["num_transactions"]==0) {
+                        $_POST["create_transactions_default"] = true;
+                        $timeSheet->createTransactions($status);
+                        $TPL["message_good"][] = "Automatically created time sheet transactions.";
+                }
 
-        // Get total of all time sheet transactions.
-        $q = prepare("SELECT SUM(amount) AS total 
+              // Get total of all time sheet transactions.
+                $q = prepare("SELECT SUM(amount) AS total 
                         FROM transaction 
                        WHERE timeSheetID = %d 
                          AND status != 'rejected' 
                          AND invoiceItemID IS NULL
-                     ",$timeSheet->get_id());
-        $db->query($q);
-        $row = $db->row();
-        $total_timeSheet = $row["total"];
+                     ", $timeSheet->get_id());
+                $db->query($q);
+                $row = $db->row();
+                $total_timeSheet = $row["total"];
 
-        if ($total >= $total_timeSheet) {
-          $timeSheet->pending_transactions_to_approved();
-          $timeSheet->change_status("forwards");
-          $TPL["message_good"][] = "Closed Time Sheet #".$timeSheet->get_id()." and marked its Transactions: ".$status;
-        } else {
-          $TPL["message_help"][] = "Unable to close Time Sheet #".$timeSheet->get_id()." the sum of the Time Sheet's *Transactions* ("
-                                   .page::money($timeSheet->get_value("currencyTypeID"),$total_timeSheet,"%s%mo %c")
+                if ($total >= $total_timeSheet) {
+                        $timeSheet->pending_transactions_to_approved();
+                        $timeSheet->change_status("forwards");
+                        $TPL["message_good"][] = "Closed Time Sheet #".$timeSheet->get_id()." and marked its Transactions: ".$status;
+                } else {
+                    $TPL["message_help"][] = "Unable to close Time Sheet #".$timeSheet->get_id()." the sum of the Time Sheet's *Transactions* ("
+                                   .page::money($timeSheet->get_value("currencyTypeID"), $total_timeSheet, "%s%mo %c")
                                    .") is greater than the Invoice Item Transaction ("
-                                   .page::money($currency,$total,"%s%mo %c").")";
-        }
-      }
-    
-
-    } else if ($expenseFormID) {
-      $expenseForm = new expenseForm();
-      $expenseForm->set_id($expenseFormID);
-      $expenseForm->select();
-      $total_expenseForm = $expenseForm->get_abs_sum_transactions();
+                                   .page::money($currency, $total, "%s%mo %c").")";
+                }
+            }
+        } else if ($expenseFormID) {
+            $expenseForm = new expenseForm();
+            $expenseForm->set_id($expenseFormID);
+            $expenseForm->select();
+            $total_expenseForm = $expenseForm->get_abs_sum_transactions();
       
-      if ($total == $total_expenseForm) {
-        $expenseForm->set_status("approved");
-        $TPL["message_good"][] = "Approved Expense Form #".$expenseForm->get_id().".";
-      } else {
-        $TPL["message_help"][] = "Unable to approve Expense Form #".$expenseForm->get_id()." the sum of Expense Form Transactions does not equal the Invoice Item Transaction.";
-      }
+            if ($total == $total_expenseForm) {
+                $expenseForm->set_status("approved");
+                $TPL["message_good"][] = "Approved Expense Form #".$expenseForm->get_id().".";
+            } else {
+                $TPL["message_help"][] = "Unable to approve Expense Form #".$expenseForm->get_id()." the sum of Expense Form Transactions does not equal the Invoice Item Transaction.";
+            }
+        }
     }
 
-  }
+    function create_transaction($amount, $tfID, $status)
+    {
+        $transaction = new transaction();
+        $invoice = $this->get_foreign_object("invoice");
+        $this->currency = $invoice->get_value("currencyTypeID");
+        $db = new db_alloc();
 
-  function create_transaction($amount,$tfID,$status) {
-    $transaction = new transaction();
-    $invoice = $this->get_foreign_object("invoice");
-    $this->currency = $invoice->get_value("currencyTypeID");
-    $db = new db_alloc();
+      // If there already a transaction for this invoiceItem, use it instead of creating a new one
+        $q = prepare("SELECT * FROM transaction WHERE invoiceItemID = %d ORDER BY transactionCreatedTime DESC LIMIT 1", $this->get_id());
+        $db->query($q);
+        if ($db->row()) {
+            $transaction->set_id($db->f("transactionID"));
+            $transaction->select();
+        }
 
-    // If there already a transaction for this invoiceItem, use it instead of creating a new one
-    $q = prepare("SELECT * FROM transaction WHERE invoiceItemID = %d ORDER BY transactionCreatedTime DESC LIMIT 1",$this->get_id());
-    $db->query($q);
-    if ($db->row()) {
-      $transaction->set_id($db->f("transactionID"));
-      $transaction->select();
-    }
-
-    // If there already a transaction for this timeSheet, use it instead of creating a new one
-    if ($this->get_value("timeSheetID")) {
-      $q = prepare("SELECT * 
+      // If there already a transaction for this timeSheet, use it instead of creating a new one
+        if ($this->get_value("timeSheetID")) {
+            $q = prepare(
+                "SELECT * 
                       FROM transaction 
                      WHERE timeSheetID = %d 
                        AND fromTfID = %d
@@ -217,66 +220,62 @@ class invoiceItem extends db_entity {
                        AND amount = %d
                        AND (invoiceItemID = %d or invoiceItemID IS NULL)
                   ORDER BY transactionCreatedTime DESC LIMIT 1
-                         ",$this->get_value("timeSheetID"),config::get_config_item("inTfID")
-                          ,$tfID,page::money($this->currency,$amount,"%mi"),$this->get_id());
-      $db->query($q);
-      if ($db->row()) {
-        $transaction->set_id($db->f("transactionID"));
-        $transaction->select();
-      }
+                         ",
+                $this->get_value("timeSheetID"),
+                config::get_config_item("inTfID"),
+                $tfID,
+                page::money($this->currency, $amount, "%mi"),
+                $this->get_id()
+            );
+            $db->query($q);
+            if ($db->row()) {
+                  $transaction->set_id($db->f("transactionID"));
+                  $transaction->select();
+            }
+        }
+
+        $transaction->set_value("amount", $amount);
+        $transaction->set_value("currencyTypeID", $this->currency);
+        $transaction->set_value("fromTfID", config::get_config_item("inTfID"));
+        $transaction->set_value("tfID", $tfID);
+        $transaction->set_value("status", $status);
+        $transaction->set_value("invoiceID", $this->get_value("invoiceID"));
+        $transaction->set_value("invoiceItemID", $this->get_id());
+        $transaction->set_value("transactionDate", $this->get_value("iiDate"));
+        $transaction->set_value("transactionType", "invoice");
+        $transaction->set_value("product", sprintf("%s", $this->get_value("iiMemo")));
+        $this->get_value("timeSheetID") && $transaction->set_value("timeSheetID", $this->get_value("timeSheetID"));
+        $transaction->save();
     }
 
-    $transaction->set_value("amount",$amount);  
-    $transaction->set_value("currencyTypeID",$this->currency);  
-    $transaction->set_value("fromTfID",config::get_config_item("inTfID")); 
-    $transaction->set_value("tfID",$tfID);
-    $transaction->set_value("status",$status);
-    $transaction->set_value("invoiceID",$this->get_value("invoiceID"));
-    $transaction->set_value("invoiceItemID",$this->get_id());
-    $transaction->set_value("transactionDate",$this->get_value("iiDate"));
-    $transaction->set_value("transactionType","invoice");
-    $transaction->set_value("product",sprintf("%s",$this->get_value("iiMemo")));
-    $this->get_value("timeSheetID") && $transaction->set_value("timeSheetID",$this->get_value("timeSheetID"));
-    $transaction->save();
-  }
-
-  function get_list_filter($filter=array()) {
-    // Filter on invoiceID
-    if ($filter["invoiceID"] && is_array($filter["invoiceID"])) {
-      $sql[] = prepare("(invoice.invoiceID in (%s))",$filter["invoiceID"]);
-    } else if ($filter["invoiceID"]) {     
-      $sql[] = prepare("(invoice.invoiceID = %d)", $filter["invoiceID"]);
+    function get_list_filter($filter = array())
+    {
+      // Filter on invoiceID
+        if ($filter["invoiceID"] && is_array($filter["invoiceID"])) {
+            $sql[] = prepare("(invoice.invoiceID in (%s))", $filter["invoiceID"]);
+        } else if ($filter["invoiceID"]) {
+            $sql[] = prepare("(invoice.invoiceID = %d)", $filter["invoiceID"]);
+        }
+        return $sql;
     }
-    return $sql;
-  }
 
-  public static function get_list($_FORM) {
-    $filter = invoiceItem::get_list_filter($_FORM);
-    if (is_array($filter) && count($filter)) {
-      $f = " WHERE ".implode(" AND ",$filter);
-    }
-    $q = prepare("SELECT * FROM invoiceItem 
+    public static function get_list($_FORM)
+    {
+        $filter = invoiceItem::get_list_filter($_FORM);
+        if (is_array($filter) && count($filter)) {
+            $f = " WHERE ".implode(" AND ", $filter);
+        }
+        $q = prepare("SELECT * FROM invoiceItem 
                LEFT JOIN invoice ON invoice.invoiceID = invoiceItem.invoiceID
                LEFT JOIN client ON client.clientID = invoice.clientID
                ".$f);
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $row["iiAmount"] = page::money($row["currencyTypeID"],$row["iiAmount"],"%mo");
-      $row["iiUnitPrice"] = page::money($row["currencyTypeID"],$row["iiUnitPrice"],"%mo");
-      $rows[$row["invoiceItemID"]] = $row;
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $row["iiAmount"] = page::money($row["currencyTypeID"], $row["iiAmount"], "%mo");
+            $row["iiUnitPrice"] = page::money($row["currencyTypeID"], $row["iiUnitPrice"], "%mo");
+            $rows[$row["invoiceItemID"]] = $row;
+        }
+        return (array)$rows;
     }
-    return (array)$rows;
-  }
-
-
 }
-
-
-
-
-
-
-
-
-?>

--- a/invoice/lib/invoiceRepeat.inc.php
+++ b/invoice/lib/invoiceRepeat.inc.php
@@ -3,70 +3,73 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class invoiceRepeat extends db_entity {
-  public $classname = "invoiceRepeat";
-  public $data_table = "invoiceRepeat";
-  public $display_field_name = "invoiceRepeatID";
-  public $key_field = "invoiceRepeatID";
-  public $data_fields = array("invoiceID"
+class invoiceRepeat extends db_entity
+{
+    public $classname = "invoiceRepeat";
+    public $data_table = "invoiceRepeat";
+    public $display_field_name = "invoiceRepeatID";
+    public $key_field = "invoiceRepeatID";
+    public $data_fields = array("invoiceID"
                              ,"personID"
                              ,"message"
                              ,"active"
                              );
-  function save($dates="") {
-    $rtn = parent::save();
-    if ($rtn) {
-      $dates = str_replace(","," ",$dates);
-      $dates = preg_replace("/\s+/"," ",trim($dates));
-      $dates = explode(" ",$dates);
-      $db = new db_alloc();
-      $db->query("DELETE FROM invoiceRepeatDate WHERE invoiceRepeatID = %d",$this->get_id());
-      foreach ($dates as $date) {
-        $db->query("INSERT INTO invoiceRepeatDate (invoiceRepeatID,invoiceDate) VALUES (%d,'%s')",$this->get_id(),$date);
-      }
-    }
-  }
-
-  function set_values($prefix) {
-    global $TPL;
-    $db = new db_alloc();
-    $db->query("SELECT * FROM invoiceRepeatDate WHERE invoiceRepeatID = %d",$this->get_id());
-    while ($row = $db->row()) {
-      $rows[] = $row["invoiceDate"];
-    }
-    $TPL[$prefix."frequency"] = implode(" ",(array)$rows);
-    return parent::set_values($prefix);
-  }
-
-  function get_all_parties($invoiceID) {
-    if ($invoiceID) {
-      $invoice = new invoice();
-      $invoice->set_id($invoiceID);
-      $invoice->select();
-      $interestedPartyOptions = $invoice->get_all_partieS($invoice->get_value("projectID"),$invoice->get_value("clientID"));
+    function save($dates = "")
+    {
+        $rtn = parent::save();
+        if ($rtn) {
+            $dates = str_replace(",", " ", $dates);
+            $dates = preg_replace("/\s+/", " ", trim($dates));
+            $dates = explode(" ", $dates);
+            $db = new db_alloc();
+            $db->query("DELETE FROM invoiceRepeatDate WHERE invoiceRepeatID = %d", $this->get_id());
+            foreach ($dates as $date) {
+                $db->query("INSERT INTO invoiceRepeatDate (invoiceRepeatID,invoiceDate) VALUES (%d,'%s')", $this->get_id(), $date);
+            }
+        }
     }
 
-    if (is_object($this) && $this->get_id()) {
-      $interestedPartyOptions = interestedParty::get_interested_parties("invoiceRepeat",$this->get_id(),$interestedPartyOptions);
+    function set_values($prefix)
+    {
+        global $TPL;
+        $db = new db_alloc();
+        $db->query("SELECT * FROM invoiceRepeatDate WHERE invoiceRepeatID = %d", $this->get_id());
+        while ($row = $db->row()) {
+            $rows[] = $row["invoiceDate"];
+        }
+        $TPL[$prefix."frequency"] = implode(" ", (array)$rows);
+        return parent::set_values($prefix);
     }
-    return $interestedPartyOptions;
-  }
+
+    function get_all_parties($invoiceID)
+    {
+        if ($invoiceID) {
+            $invoice = new invoice();
+            $invoice->set_id($invoiceID);
+            $invoice->select();
+            $interestedPartyOptions = $invoice->get_all_partieS($invoice->get_value("projectID"), $invoice->get_value("clientID"));
+        }
+
+        if (is_object($this) && $this->get_id()) {
+            $interestedPartyOptions = interestedParty::get_interested_parties("invoiceRepeat", $this->get_id(), $interestedPartyOptions);
+        }
+        return $interestedPartyOptions;
+    }
 }
-?>

--- a/invoice/lib/invoiceRepeatDate.inc.php
+++ b/invoice/lib/invoiceRepeatDate.inc.php
@@ -3,32 +3,29 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class invoiceRepeatDate extends db_entity {
-  public $classname = "invoiceRepeatDate";
-  public $data_table = "invoiceRepeatDate";
-  public $key_field = "invoiceRepeatDateID";
-  public $data_fields = array("invoiceRepeatID"
+class invoiceRepeatDate extends db_entity
+{
+    public $classname = "invoiceRepeatDate";
+    public $data_table = "invoiceRepeatDate";
+    public $key_field = "invoiceRepeatDateID";
+    public $data_fields = array("invoiceRepeatID"
                              ,"invoiceDate"
                              );
 }
-
-
-
-?>

--- a/item/addItem.php
+++ b/item/addItem.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -29,103 +29,100 @@ global $TPL;
 $item = new item();
 
 if ($_POST["save"]) {
-  $item = new item();
-  $item->read_globals();
-  $item->save();
+    $item = new item();
+    $item->read_globals();
+    $item->save();
 }
 
 if ($_POST["import_from_file"]) {
-  if (is_uploaded_file($_FILES["import_file"]["tmp_name"])) {
-    $new_items = file($_FILES["import_file"]["tmp_name"]);
-    for ($i = 1; $i < count($new_items); $i++) {
-      $item = new item();
-      $item->read_globals();
-      $line = str_replace("\"", "", $new_items[$i]);
-      $entry = explode("\t", $line);
-      $item->set_value('itemName', $entry[0]);
-      $item->set_value('itemAuthor', $entry[1]);
-      $item->set_value('itemNotes', $entry[2]);
-      $item->set_value('itemType', $_POST["itemType"]);
-      $item->set_value('personID', $current_user);
-      $item->save();
+    if (is_uploaded_file($_FILES["import_file"]["tmp_name"])) {
+        $new_items = file($_FILES["import_file"]["tmp_name"]);
+        for ($i = 1; $i < count($new_items); $i++) {
+            $item = new item();
+            $item->read_globals();
+            $line = str_replace("\"", "", $new_items[$i]);
+            $entry = explode("\t", $line);
+            $item->set_value('itemName', $entry[0]);
+            $item->set_value('itemAuthor', $entry[1]);
+            $item->set_value('itemNotes', $entry[2]);
+            $item->set_value('itemType', $_POST["itemType"]);
+            $item->set_value('personID', $current_user);
+            $item->save();
+        }
+    } else {
+        alloc_error("Uploaded document error.  Please try again.");
     }
-  } else {
-    alloc_error("Uploaded document error.  Please try again.");
-  }
 }
 
 if ($_POST["update_item"]) {
-  $item = new item();
-  $item->set_id($_POST["update_itemID"]);
-  $item->select();
-  $item->set_value("itemName", $_POST["update_itemName"]);
-  $item->set_value("itemNotes", $_POST["update_itemNotes"]);
-  $item->set_value("itemType", $_POST["update_itemType"]);
-  $item->save();
+    $item = new item();
+    $item->set_id($_POST["update_itemID"]);
+    $item->select();
+    $item->set_value("itemName", $_POST["update_itemName"]);
+    $item->set_value("itemNotes", $_POST["update_itemNotes"]);
+    $item->set_value("itemType", $_POST["update_itemType"]);
+    $item->save();
 }
 
 if ($_POST["remove_items"]) {
-  for ($i = 0; $i < count($_POST["itemID"]); $i++) {
-    $item = new item();
-    $item->set_id($_POST["itemID"][$i]);
-    $item->select();
-    $item->delete();
-  }
+    for ($i = 0; $i < count($_POST["itemID"]); $i++) {
+        $item = new item();
+        $item->set_id($_POST["itemID"][$i]);
+        $item->select();
+        $item->delete();
+    }
 }
 
 //so that the user can edit the item later
-$TPL["personID"] = $current_user->get_id(); 
+$TPL["personID"] = $current_user->get_id();
 
 // item types
 $itemType = new meta("itemType");
-$TPL["itemTypes"] = page::select_options($itemType->get_assoc_array("itemTypeID","itemTypeID"), $item->get_value("itemType"));
+$TPL["itemTypes"] = page::select_options($itemType->get_assoc_array("itemTypeID", "itemTypeID"), $item->get_value("itemType"));
 
   // setup item list (for removals)
 $item_list = array();
 $db = new db_alloc();
 $db->query("SELECT * FROM item ORDER BY itemName");
 while ($db->next_record()) {
-  $item = new item();
-  $item->read_db_record($db);
-  $item_list[$item->get_id()] = $item->get_value('itemName');
+    $item = new item();
+    $item->read_db_record($db);
+    $item_list[$item->get_id()] = $item->get_value('itemName');
 }
 
 $TPL["item_list"] = page::select_options($item_list, "");
 
 if ($_POST["edit_items"]) {
-  $item = new item();
-  $item->set_id($_POST["itemID"][0]);
-  $item->select();
+    $item = new item();
+    $item->set_id($_POST["itemID"][0]);
+    $item->select();
 
-  if (count($_POST["itemID"]) < 1) {
-    alloc_error("You Must Select An Item");
-  } else {
-    if (count($_POST["itemID"]) > 1) {
-      alloc_error("Can Only Edit 1 Item At A Time");
-    } 
-    $TPL["edit_options"] =
-      "<table><tr>\n"
-     ."  <td>Name: </td>\n"
-     ."  <td colspan=\"2\"><input size=\"40\" type=\"text\" name=\"update_itemName\" value=\"".$item->get_value("itemName")."\"></td>\n"
-     ."</tr><tr>\n"
-     ."  <td>Notes: </td>\n"
-     ."  <td colspan=\"2\"><input size=\"40\" type=\"text\" name=\"update_itemNotes\" value=\"".$item->get_value("itemNotes")."\"></td>\n"
-     ."</tr><tr>\n"
-     ."  <td>Type: </td>\n"
-     ."  <td><select name=\"update_itemType\" value=\"".$item->get_value("itemType")."\">"
-     .        page::select_options($itemType->get_assoc_array("itemTypeID","itemTypeID"), $item->get_value("itemType"))
-     ."       </select>"
-     ."    <input type=\"hidden\" name=\"update_itemID\" value=\"".$item->get_id()."\"></td>"
-     ."  <td align=\"right\">"
-     .'    <button type="submit" name="update_item" value="1" class="save_button">Save Changes<i class="icon-ok-sign"></i></button>'
-     ." </td>\n"
-     ."</tr><td colspan=\"3\"><hr></td></tr>\n"
-     ."</tr></table>\n";
-  }
+    if (count($_POST["itemID"]) < 1) {
+        alloc_error("You Must Select An Item");
+    } else {
+        if (count($_POST["itemID"]) > 1) {
+            alloc_error("Can Only Edit 1 Item At A Time");
+        }
+        $TPL["edit_options"] =
+        "<table><tr>\n"
+        ."  <td>Name: </td>\n"
+        ."  <td colspan=\"2\"><input size=\"40\" type=\"text\" name=\"update_itemName\" value=\"".$item->get_value("itemName")."\"></td>\n"
+        ."</tr><tr>\n"
+        ."  <td>Notes: </td>\n"
+        ."  <td colspan=\"2\"><input size=\"40\" type=\"text\" name=\"update_itemNotes\" value=\"".$item->get_value("itemNotes")."\"></td>\n"
+        ."</tr><tr>\n"
+        ."  <td>Type: </td>\n"
+        ."  <td><select name=\"update_itemType\" value=\"".$item->get_value("itemType")."\">"
+        .        page::select_options($itemType->get_assoc_array("itemTypeID", "itemTypeID"), $item->get_value("itemType"))
+        ."       </select>"
+        ."    <input type=\"hidden\" name=\"update_itemID\" value=\"".$item->get_id()."\"></td>"
+        ."  <td align=\"right\">"
+        .'    <button type="submit" name="update_item" value="1" class="save_button">Save Changes<i class="icon-ok-sign"></i></button>'
+        ." </td>\n"
+        ."</tr><td colspan=\"3\"><hr></td></tr>\n"
+        ."</tr></table>\n";
+    }
 }
 
 $TPL["main_alloc_title"] = "Edit Items - ".APPLICATION_NAME;
 include_template("templates/addItemM.tpl");
-
-
-?>

--- a/item/item.php
+++ b/item/item.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -33,24 +33,24 @@ $loanID = $_POST["loanID"] or $loanID = $_GET["loanID"];
 $item = new item();
 $loan = new loan();
 $db = new db_alloc();
-$db->query("select * from item where itemID=%d",$itemID);
+$db->query("select * from item where itemID=%d", $itemID);
 $db->next_record();
 $item->read_db_record($db);
 $item->set_values();
 
 // new crap
 if ($current_user->have_role("admin") || $current_user->have_role("manage")) {
-  $users = array();
-  $_db = new db_alloc();
-  $_db->query("SELECT * FROM person ORDER BY username");
-  while ($_db->next_record()) {
-    $person = new person();
-    $person->read_db_record($_db);
-    $users[$person->get_id()] = $person->get_value('username');
-  }
-  $TPL["userSelect"] = "<select name=\"userID\">".page::select_options($users, $current_user->get_id())."</select><br>\n";
+    $users = array();
+    $_db = new db_alloc();
+    $_db->query("SELECT * FROM person ORDER BY username");
+    while ($_db->next_record()) {
+        $person = new person();
+        $person->read_db_record($_db);
+        $users[$person->get_id()] = $person->get_value('username');
+    }
+    $TPL["userSelect"] = "<select name=\"userID\">".page::select_options($users, $current_user->get_id())."</select><br>\n";
 } else {
-  $TPL["userSelect"] = "";
+    $TPL["userSelect"] = "";
 }
 
 $temp = mktime(0, 0, 0, date("m") + $_POST["timePeriod"], date("d"), date("Y"));
@@ -61,81 +61,76 @@ $whenToReturn = date("Y", $temp)."-".date("m", $temp)."-".date("d", $temp);
 $today = date("Y")."-".date("m")."-".date("d");
 
 if ($loanID) {
-  $loan->set_id($loanID);
-  $loan->select();
+    $loan->set_id($loanID);
+    $loan->select();
 }
 
 
 if ($_POST["borrowItem"]) {
-  $db->query("select * from loan where itemID=%d and dateReturned='0000-00-00'",$itemID);
+    $db->query("select * from loan where itemID=%d and dateReturned='0000-00-00'", $itemID);
 
-  if ($db->next_record()) {     // if the item is already borrowed
-    alloc_redirect($TPL["url_alloc_item"]."itemID=$itemID&badBorrow=true&error=already_borrowed");
-    exit();
-  } else {                      // else lets make a new loan!
-    $loan = new loan();
-    $loan->read_globals();
-    $loan->set_value("dateToBeReturned", $whenToReturn);
+    if ($db->next_record()) {     // if the item is already borrowed
+        alloc_redirect($TPL["url_alloc_item"]."itemID=$itemID&badBorrow=true&error=already_borrowed");
+        exit();
+    } else {                      // else lets make a new loan!
+        $loan = new loan();
+        $loan->read_globals();
+        $loan->set_value("dateToBeReturned", $whenToReturn);
 
-    // if admin/manager then check to see if an alternate user was selected
-    if ($_POST["userID"] && ($current_user->have_role("admin") || $current_user->have_role("manage"))) {
-      if ($_POST["userID"] != $current_user->get_id()) {
-        $person = new person();
-        $person->set_id($_POST["userID"]);
-        $person->select();
-      }
-      $loan->set_value("personID", $_POST["userID"]);
-    } else {
-      $loan->set_value("personID", $current_user->get_id());
+      // if admin/manager then check to see if an alternate user was selected
+        if ($_POST["userID"] && ($current_user->have_role("admin") || $current_user->have_role("manage"))) {
+            if ($_POST["userID"] != $current_user->get_id()) {
+                $person = new person();
+                $person->set_id($_POST["userID"]);
+                $person->select();
+            }
+            $loan->set_value("personID", $_POST["userID"]);
+        } else {
+            $loan->set_value("personID", $current_user->get_id());
+        }
+
+        $loan->set_value("dateBorrowed", $today);
+        $loan->set_value("dateReturned", "0000-00-00");
+        $loan->save();
+
+        alloc_redirect($TPL["url_alloc_loanAndReturn"]);
     }
-
-    $loan->set_value("dateBorrowed", $today);
-    $loan->set_value("dateReturned", "0000-00-00");
-    $loan->save();
-
-    alloc_redirect($TPL["url_alloc_loanAndReturn"]);
-  }
 }
 
 
 
 if ($_POST["returnItem"]) {
+    $dbTemp = new db_alloc();
+    $dbTemp->query("select * from loan where itemID=%d and dateReturned='0000-00-00'", $itemID);
 
-  $dbTemp = new db_alloc();
-  $dbTemp->query("select * from loan where itemID=%d and dateReturned='0000-00-00'",$itemID);
+    $db = new db_alloc();
+    $db->query("select * from loan where loan.itemID=%d and dateBorrowed>dateReturned", $itemID);
+    $db->next_record();
+    $loan->set_id($db->f("loanID"));
+    if ($loan->select()) {
+        $loan->set_value("dateReturned", $today);
+        $loan->set_value("itemID", $itemID);
 
-  $db = new db_alloc();
-  $db->query("select * from loan where loan.itemID=%d and dateBorrowed>dateReturned",$itemID);
-  $db->next_record();
-  $loan->set_id($db->f("loanID"));
-  if ($loan->select()) {
-    $loan->set_value("dateReturned", $today);
-    $loan->set_value("itemID", $itemID);
-
-    // check to see if admin/manager returning someone elses item, and sent email
-    if ($loan->get_value("personID") != $current_user->get_id()) {
-      if ($current_user->have_role("admin") || $current_user->have_role("manage")) {
-        $person = new person();
-        $person->set_id($loan->get_value("personID"));
-        $person->select();
-        $loan->save();
-      }
-    } else {
-      $loan->save();
+      // check to see if admin/manager returning someone elses item, and sent email
+        if ($loan->get_value("personID") != $current_user->get_id()) {
+            if ($current_user->have_role("admin") || $current_user->have_role("manage")) {
+                $person = new person();
+                $person->set_id($loan->get_value("personID"));
+                $person->select();
+                $loan->save();
+            }
+        } else {
+            $loan->save();
+        }
     }
-  }
 
-  alloc_redirect($TPL["url_alloc_loanAndReturn"]);
+    alloc_redirect($TPL["url_alloc_loanAndReturn"]);
 }
 
 
 
 if ($_GET["return"]) {
-  include_template("templates/itemReturnM.tpl");
+    include_template("templates/itemReturnM.tpl");
 } else {
-  include_template("templates/itemBorrowM.tpl");
+    include_template("templates/itemBorrowM.tpl");
 }
-
-
-
-?>

--- a/item/itemLoan.php
+++ b/item/itemLoan.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -30,48 +30,45 @@ include_template("templates/itemLoanM.tpl");
 
 
 
-function show_overdue($template_name) {
+function show_overdue($template_name)
+{
 
-  global $db;
-  global $TPL;
-  $current_user = &singleton("current_user");
+    global $db;
+    global $TPL;
+    $current_user = &singleton("current_user");
 
-  $db = new db_alloc();
-  $temp = mktime(0, 0, 0, date("m"), date("d"), date("Y"));
-  $today = date("Y", $temp)."-".date("m", $temp)."-".date("d", $temp);
+    $db = new db_alloc();
+    $temp = mktime(0, 0, 0, date("m"), date("d"), date("Y"));
+    $today = date("Y", $temp)."-".date("m", $temp)."-".date("d", $temp);
 
-  $q = prepare("SELECT itemName,itemType,item.itemID,dateBorrowed,dateToBeReturned,loan.personID 
+    $q = prepare("SELECT itemName,itemType,item.itemID,dateBorrowed,dateToBeReturned,loan.personID 
                   FROM loan,item 
                  WHERE dateToBeReturned < '%s' 
 					         AND dateReturned = '0000-00-00' 
 					         AND item.itemID = loan.itemID
-               ",$today);
+               ", $today);
 
-  if (!have_entity_perm("loan", PERM_READ, $current_user, false)) {
-    $q .= prepare("AND loan.personID = %d",$current_user->get_id());
-  }
+    if (!have_entity_perm("loan", PERM_READ, $current_user, false)) {
+        $q .= prepare("AND loan.personID = %d", $current_user->get_id());
+    }
 
-  $db->query($q);
+    $db->query($q);
 
-  while ($db->next_record()) {
-    $i++;
+    while ($db->next_record()) {
+        $i++;
 
-    $item = new item();
-    $loan = new loan();
-    $item->read_db_record($db);
-    $loan->read_db_record($db);
-    $item->set_values();
-    $loan->set_values();
-    $person = new person();
-    $person->set_id($loan->get_value("personID"));
-    $person->select();
-    $TPL["person"] = $person->get_name();
-    $TPL["overdue"] = "<a href=\"".$TPL["url_alloc_item"]."itemID=".$item->get_id()."&return=true\">Overdue!</a>";
+        $item = new item();
+        $loan = new loan();
+        $item->read_db_record($db);
+        $loan->read_db_record($db);
+        $item->set_values();
+        $loan->set_values();
+        $person = new person();
+        $person->set_id($loan->get_value("personID"));
+        $person->select();
+        $TPL["person"] = $person->get_name();
+        $TPL["overdue"] = "<a href=\"".$TPL["url_alloc_item"]."itemID=".$item->get_id()."&return=true\">Overdue!</a>";
 
-    include_template($template_name);
-  }
+        include_template($template_name);
+    }
 }
-
-
-
-?>

--- a/item/lib/init.php
+++ b/item/lib/init.php
@@ -3,26 +3,26 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class item_module extends module {
-  var $module = "item";
-  var $db_entities = array("item", "loan");
+class item_module extends module
+{
+    var $module = "item";
+    var $db_entities = array("item", "loan");
 }
-?>

--- a/item/lib/item.inc.php
+++ b/item/lib/item.inc.php
@@ -3,57 +3,55 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class item extends db_entity {
-  public $classname = "item";
-  public $data_table = "item";
-  public $display_field_name = "itemName";
-  public $key_field = "itemID";
-  public $data_fields = array("itemModifiedUser"
+class item extends db_entity
+{
+    public $classname = "item";
+    public $data_table = "item";
+    public $display_field_name = "itemName";
+    public $key_field = "itemID";
+    public $data_fields = array("itemModifiedUser"
                              ,"itemName"
                              ,"itemAuthor"
                              ,"itemNotes"
                              ,"itemModifiedTime"
                              ,"itemType"
-			                       ,"personID"
+                                   ,"personID"
                              );
 
-  function update_search_index_doc(&$index) {
-    $p =& get_cached_table("person");
-    $personID = $this->get_value("personID");
-    $person_field = $personID." ".$p[$personID]["username"]." ".$p[$personID]["name"];
-    $itemModifiedUser = $this->get_value("itemModifiedUser");
-    $itemModifiedUser_field = $itemModifiedUser." ".$p[$itemModifiedUser]["username"]." ".$p[$itemModifiedUser]["name"];
+    function update_search_index_doc(&$index)
+    {
+        $p =& get_cached_table("person");
+        $personID = $this->get_value("personID");
+        $person_field = $personID." ".$p[$personID]["username"]." ".$p[$personID]["name"];
+        $itemModifiedUser = $this->get_value("itemModifiedUser");
+        $itemModifiedUser_field = $itemModifiedUser." ".$p[$itemModifiedUser]["username"]." ".$p[$itemModifiedUser]["name"];
 
-    $doc = new Zend_Search_Lucene_Document();
-    $doc->addField(Zend_Search_Lucene_Field::Keyword('id'   ,$this->get_id()));
-    $doc->addField(Zend_Search_Lucene_Field::Text('name'    ,$this->get_value("itemName"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('desc'    ,$this->get_value("itemNotes"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('type'    ,$this->get_value("itemType"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('author'  ,$this->get_value("itemAuthor"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('creator' ,$person_field,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('modifier',$itemModifiedUser_field,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateModified',str_replace("-","",$this->get_value("itemModifiedTime")),"utf-8"));
-    $index->addDocument($doc);
-  }
+        $doc = new Zend_Search_Lucene_Document();
+        $doc->addField(Zend_Search_Lucene_Field::Keyword('id', $this->get_id()));
+        $doc->addField(Zend_Search_Lucene_Field::Text('name', $this->get_value("itemName"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('desc', $this->get_value("itemNotes"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('type', $this->get_value("itemType"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('author', $this->get_value("itemAuthor"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('creator', $person_field, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('modifier', $itemModifiedUser_field, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateModified', str_replace("-", "", $this->get_value("itemModifiedTime")), "utf-8"));
+        $index->addDocument($doc);
+    }
 }
-
-
-
-?>

--- a/item/lib/loan.inc.php
+++ b/item/lib/loan.inc.php
@@ -3,28 +3,29 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class loan extends db_entity {
-  public $data_table = "loan";
-  public $display_field_name = "itemID";
-  public $key_field = "loanID";
-  public $data_fields = array("itemID"
+class loan extends db_entity
+{
+    public $data_table = "loan";
+    public $display_field_name = "itemID";
+    public $key_field = "loanID";
+    public $data_fields = array("itemID"
                              ,"personID"
                              ,"loanModifiedUser"
                              ,"loanModifiedTime"
@@ -33,7 +34,3 @@ class loan extends db_entity {
                              ,"dateReturned"
                              );
 }
-
-
-
-?>

--- a/item/loanAndReturn.php
+++ b/item/loanAndReturn.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -28,78 +28,68 @@ $TPL["main_alloc_title"] = "Item Loans - ".APPLICATION_NAME;
 include_template("templates/loanAndReturnM.tpl");
 
 
-function show_items($template_name) {
-  global $TPL;
-  global $db;
-  global $db2;
-  $current_user = &singleton("current_user");
+function show_items($template_name)
+{
+    global $TPL;
+    global $db;
+    global $db2;
+    $current_user = &singleton("current_user");
 
-  $today = date("Y")."-".date("m")."-".date("d");
+    $today = date("Y")."-".date("m")."-".date("d");
 
-  $dbUsername = new db_alloc();
-  $db = new db_alloc();
-  $db2 = new db_alloc();
+    $dbUsername = new db_alloc();
+    $db = new db_alloc();
+    $db2 = new db_alloc();
 
-  $db->query("select * from item order by itemName");
-
-
-  while ($db->next_record()) {
-    $i++;
+    $db->query("select * from item order by itemName");
 
 
-    $item = new item();
-    $item->read_db_record($db);
+    while ($db->next_record()) {
+        $i++;
 
-    $db2->query("select * from loan where itemID=".$item->get_id()." and dateReturned='0000-00-00'");
-    $db2->next_record();
-    $loan = new loan();
-    $loan->read_db_record($db2);
 
-    $item->set_values();    // you need to have this repeated here for the a href bit below.
+        $item = new item();
+        $item->read_db_record($db);
 
-    if ($loan->get_value("dateReturned") == "0000-00-00") {
+        $db2->query("select * from loan where itemID=".$item->get_id()." and dateReturned='0000-00-00'");
+        $db2->next_record();
+        $loan = new loan();
+        $loan->read_db_record($db2);
 
-      if ($loan->have_perm(PERM_READ_WRITE)) {
+        $item->set_values();    // you need to have this repeated here for the a href bit below.
 
-        // if item is overdue
-        if ($loan->get_value("dateToBeReturned") < $today) {
-          $ret = "Return Now!";
-        } else {
-          $ret = "Return";
+        if ($loan->get_value("dateReturned") == "0000-00-00") {
+            if ($loan->have_perm(PERM_READ_WRITE)) {
+                // if item is overdue
+                if ($loan->get_value("dateToBeReturned") < $today) {
+                    $ret = "Return Now!";
+                } else {
+                    $ret = "Return";
+                }
+
+
+                $TPL["itemAction"] = "<td><a href=\"".$TPL["url_alloc_item"]
+                ."itemID=".$TPL["itemID"]
+                ."&return=true\">$ret</a></td>";
+            } else {                  // if you don't have permission to borrow or return item.
+                $TPL["itemAction"] = "<td>&nbsp;</td>";
+            }
+
+
+            $TPL["status"] = "Due ".$loan->get_value("dateToBeReturned");
+            $dbUsername->query("select username from person where personID=".$loan->get_value("personID"));
+            $dbUsername->next_record();
+            $TPL["person"] = "from ".$dbUsername->f("username");
+        } else {                    // if the item is available
+            $TPL["status"] = "Available";
+            $TPL["person"] = "";
+            $TPL["itemAction"] = "<td><a href=\"".$TPL["url_alloc_item"]."itemID=".$TPL["itemID"]."&borrow=true\">Borrow</a></td>";
+            $TPL["dueBack"] = "";
         }
 
 
-        $TPL["itemAction"] = "<td><a href=\"".$TPL["url_alloc_item"]
-          ."itemID=".$TPL["itemID"]
-          ."&return=true\">$ret</a></td>";
-
-      } else {                  // if you don't have permission to borrow or return item.
-        $TPL["itemAction"] = "<td>&nbsp;</td>";
-      }
-
-
-      $TPL["status"] = "Due ".$loan->get_value("dateToBeReturned");
-      $dbUsername->query("select username from person where personID=".$loan->get_value("personID"));
-      $dbUsername->next_record();
-      $TPL["person"] = "from ".$dbUsername->f("username");
-
-    } else {                    // if the item is available
-
-      $TPL["status"] = "Available";
-      $TPL["person"] = "";
-      $TPL["itemAction"] = "<td><a href=\"".$TPL["url_alloc_item"]."itemID=".$TPL["itemID"]."&borrow=true\">Borrow</a></td>";
-      $TPL["dueBack"] = "";
+        $loan->set_values();
+        $item->set_values();
+        include_template($template_name);
     }
-
-
-    $loan->set_values();
-    $item->set_values();
-    include_template($template_name);
-  }
-
-
 }
-
-
-
-?>

--- a/login/login.php
+++ b/login/login.php
@@ -21,87 +21,86 @@
 */
 
 
-define("NO_AUTH",1);
+define("NO_AUTH", 1);
 require_once("../alloc.php");
 
 $sess = new session();
 if (isset($_POST["forwardUrl"])) {
-  $url = $_POST["forwardUrl"];
+    $url = $_POST["forwardUrl"];
 } else if (isset($_GET["forward"])) {
-  $url = $_GET["forward"];
+    $url = $_GET["forward"];
 } else {
-  $url = $sess->GetUrl($TPL["url_alloc_home"]);
+    $url = $sess->GetUrl($TPL["url_alloc_home"]);
 }
 
 // If we already have a session
 if ($sess->Started()) {
-  alloc_redirect($url);
-  exit();
+    alloc_redirect($url);
+    exit();
 
 // Else log the user in
 } else if ($_POST["login"]) {
+    $person = new person();
+    $row = $person->get_valid_login_row($_POST["username"], $_POST["password"]);
 
-  $person = new person();
-  $row = $person->get_valid_login_row($_POST["username"],$_POST["password"]);
+    if ($row) {
+        $sess->Start($row);
 
-  if ($row) {
+        $q = prepare(
+            "UPDATE person SET lastLoginDate = '%s' WHERE personID = %d",
+            date("Y-m-d H:i:s"),
+            $row["personID"]
+        );
+        $db = new db_alloc();
+        $db->query($q);
 
-    $sess->Start($row);
 
-    $q = prepare("UPDATE person SET lastLoginDate = '%s' WHERE personID = %d"
-                 ,date("Y-m-d H:i:s"),$row["personID"]);
-    $db = new db_alloc();
-    $db->query($q);
+        if ($sess->TestCookie()) {
+            $sess->UseCookie();
+            $sess->SetTestCookie($_POST["username"]);
+        } else {
+            $sess->UseGet();
+        }
 
-
-    if ($sess->TestCookie()) {
-      $sess->UseCookie();
-      $sess->SetTestCookie($_POST["username"]);
-    } else {
-      $sess->UseGet();
+        $sess->Save();
+        alloc_redirect($url);
     }
-
-    $sess->Save();
-    alloc_redirect($url);
-  }
-  $error = "Invalid username or password.";
-
+    $error = "Invalid username or password.";
 } else if ($_POST["new_pass"]) {
+    $db = new db_alloc();
+    $db->query("SELECT * FROM person WHERE emailAddress = '%s'", $_POST["email"]);
 
-  $db = new db_alloc();
-  $db->query("SELECT * FROM person WHERE emailAddress = '%s'", $_POST["email"]);
+    if ($db->next_record()) {
+      // generate new random password
+        $password = "";
+        $pwSource = "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!?";
+        srand((float) microtime() * 1000000);
+        for ($i = 0; $i < 8; $i++) {
+            $password.= substr($pwSource, rand(0, strlen($pwSource)), 1);
+        }
 
-  if ($db->next_record()) {
-    // generate new random password
-    $password = "";
-    $pwSource = "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!?";
-    srand((float) microtime() * 1000000);
-    for ($i = 0; $i < 8; $i++) {
-      $password.= substr($pwSource, rand(0, strlen($pwSource)), 1);
-    }
+        $q = prepare("UPDATE person SET password = '%s' WHERE emailAddress = '%s'
+                 ", password_hash($password, PASSWORD_BCRYPT), $_POST["email"]);
+        $db2 = new db_alloc();
+        $db2->query($q);
 
-    $q = prepare("UPDATE person SET password = '%s' WHERE emailAddress = '%s'
-                 ",password_hash($password, PASSWORD_BCRYPT), $_POST["email"]);
-    $db2 = new db_alloc();
-    $db2->query($q);
-
-    $e = new email_send($_POST["email"], "New Password", "Your new temporary password: ".$password, "new_password");
-    #echo "Your new temporary password: ".$password;
-    if ($e->send()) {
-      $TPL["message_good"][] = "New password sent to: ".$_POST["email"];
+        $e = new email_send($_POST["email"], "New Password", "Your new temporary password: ".$password, "new_password");
+      #echo "Your new temporary password: ".$password;
+        if ($e->send()) {
+            $TPL["message_good"][] = "New password sent to: ".$_POST["email"];
+        } else {
+            $error = "Unable to send email.";
+        }
     } else {
-      $error = "Unable to send email.";
+        $error = "Invalid email address.";
     }
-  } else {
-    $error = "Invalid email address.";
-  }
 
 
 // Else if just visiting the page
 } else {
-  if (!$sess->TestCookie()) {
-    $sess->SetTestCookie();
-  }
+    if (!$sess->TestCookie()) {
+        $sess->SetTestCookie();
+    }
 }
 
 $error and alloc_error($error);
@@ -110,41 +109,41 @@ $account = $_POST["account"] or $account = $_GET["account"];
 $TPL["account"] = $account;
 
 if (isset($_POST["username"])) {
-  $TPL["username"] = $_POST["username"];
+    $TPL["username"] = $_POST["username"];
 } else if ($sess->TestCookie() != "alloc_test_cookie") {
-  $TPL["username"] = $sess->TestCookie();
+    $TPL["username"] = $sess->TestCookie();
 }
 
 if (isset($_GET["forward"])) {
-  $TPL["forward_url"] = strip_tags($_GET["forward"]);
+    $TPL["forward_url"] = strip_tags($_GET["forward"]);
 }
 
 $TPL["status_line"] = APPLICATION_NAME." ".get_alloc_version()." &copy; ".date("Y")." <a href=\"http://www.cyber.com.au\">Cyber IT Solutions</a>";
 
 
 if (!is_dir(ATTACHMENTS_DIR."whatsnew".DIRECTORY_SEPARATOR."0")) {
-  mkdir(ATTACHMENTS_DIR."whatsnew".DIRECTORY_SEPARATOR."0");
+    mkdir(ATTACHMENTS_DIR."whatsnew".DIRECTORY_SEPARATOR."0");
 }
 
-$files = get_attachments("whatsnew",0);
+$files = get_attachments("whatsnew", 0);
 
 if (is_array($files) && count($files)) {
-  while ($f = array_pop($files)) {
-    // Only show entries that are newer that 4 weeks old
-    if (format_date("U",basename($f["path"])) > mktime() - (60*60*24*28)) {
-      $x++;
-      if($x>3) break;
-      $str.= $br."<b>".$f["restore_name"]."</b>";
-      $str.= "<br><ul>".trim(file_get_contents($f["path"]))."</ul>";
-      $br = "<br><br>";
+    while ($f = array_pop($files)) {
+      // Only show entries that are newer that 4 weeks old
+        if (format_date("U", basename($f["path"])) > mktime() - (60*60*24*28)) {
+            $x++;
+            if ($x>3) {
+                break;
+            }
+            $str.= $br."<b>".$f["restore_name"]."</b>";
+            $str.= "<br><ul>".trim(file_get_contents($f["path"]))."</ul>";
+            $br = "<br><br>";
+        }
     }
-  }
-  $str and $TPL["latest_changes"] = $str;
+    $str and $TPL["latest_changes"] = $str;
 }
 
 $TPL["body_id"] = "login";
 $TPL["main_alloc_title"] = "allocPSA login";
 
 include_template("templates/login.tpl");
-
-?>

--- a/login/logout.php
+++ b/login/logout.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -25,5 +25,3 @@ require_once("../alloc.php");
 $sess->Destroy();
 $url = $TPL["url_alloc_index"];
 alloc_redirect($url);
-
-?>

--- a/person/absence.php
+++ b/person/absence.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -30,38 +30,38 @@ $urls["calendar"] = $TPL["url_alloc_taskCalendar"]."personID=".$personID;
 
 $absence = new absence();
 if ($absenceID) {
-  $absence->set_id($absenceID);
-  $absence->select();
-  $absence->set_values();
-  $personID = $absence->get_value("personID");
+    $absence->set_id($absenceID);
+    $absence->select();
+    $absence->set_values();
+    $personID = $absence->get_value("personID");
 }
 
 $person = new person();
 $personID = $personID or $personID = $_POST["personID"] or $personID = $_GET["personID"];
 if ($personID) {
-  $person->set_id($personID);
-  $person->select();
+    $person->set_id($personID);
+    $person->select();
 }
 
 $db = new db_alloc();
 
 if ($_POST["save"]) {
   // Saving a record
-  $absence->read_globals();
-  $absence->set_value("contactDetails",rtrim($absence->get_value("contactDetails")));
-  $success = $absence->save();
-  if ($success && !$TPL["message"]) {
+    $absence->read_globals();
+    $absence->set_value("contactDetails", rtrim($absence->get_value("contactDetails")));
+    $success = $absence->save();
+    if ($success && !$TPL["message"]) {
+        $url = $TPL["url_alloc_person"]."personID=".$personID;
+        $urls[$returnToParent] and $url = $urls[$returnToParent];
+        alloc_redirect($url);
+    }
+} else if ($_POST["delete"]) {
+  // Deleting a record
+    $absence->read_globals();
+    $absence->delete();
     $url = $TPL["url_alloc_person"]."personID=".$personID;
     $urls[$returnToParent] and $url = $urls[$returnToParent];
     alloc_redirect($url);
-  }
-} else if ($_POST["delete"]) {
-  // Deleting a record
-  $absence->read_globals();
-  $absence->delete();
-  $url = $TPL["url_alloc_person"]."personID=".$personID;
-  $urls[$returnToParent] and $url = $urls[$returnToParent];
-  alloc_redirect($url);
 }
 
   // create a new record
@@ -80,4 +80,3 @@ $absenceType_array = array('Annual Leave'=>'Annual Leave'
 $TPL["absenceType_options"] = page::select_options($absenceType_array, $absence->get_value("absenceType"));
 $TPL["main_alloc_title"] = "Absence Form - ".APPLICATION_NAME;
 include_template("templates/absenceFormM.tpl");
-?>

--- a/person/lib/absence.inc.php
+++ b/person/lib/absence.inc.php
@@ -3,35 +3,32 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class absence extends db_entity {
-  public $data_table = "absence";
-  public $display_field_name = "personID";
-  public $key_field = "absenceID";
-  public $data_fields = array("dateFrom"
+class absence extends db_entity
+{
+    public $data_table = "absence";
+    public $display_field_name = "personID";
+    public $key_field = "absenceID";
+    public $data_fields = array("dateFrom"
                              ,"dateTo"
                              ,"personID"
                              ,"absenceType"
                              ,"contactDetails"
                              );
 }
-
-
-
-?>

--- a/person/lib/init.php
+++ b/person/lib/init.php
@@ -3,26 +3,26 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class person_module extends module {
-  var $module = "person";
-  var $db_entities = array("person", "absence", "skill", "proficiency");
+class person_module extends module
+{
+    var $module = "person";
+    var $db_entities = array("person", "absence", "skill", "proficiency");
 }
-?>

--- a/person/lib/person.inc.php
+++ b/person/lib/person.inc.php
@@ -25,12 +25,13 @@ define("PERM_PERSON_READ_MANAGEMENT", 512);
 define("PERM_PERSON_WRITE_MANAGEMENT", 1024);
 define("PERM_PERSON_WRITE_ROLES", 2048);
 
-class person extends db_entity {
-  public $classname = "person";
-  public $data_table = "person";
-  public $display_field_name = "username";
-  public $key_field = "personID";
-  public $data_fields = array("username"
+class person extends db_entity
+{
+    public $classname = "person";
+    public $data_table = "person";
+    public $display_field_name = "username";
+    public $key_field = "personID";
+    public $data_fields = array("username"
                              ,"lastLoginDate"
                              ,"password"          => array("read_perm_name"=>PERM_PERSON_READ_DETAILS)
                              ,"perms"             => array("write_perm_name"=>PERM_PERSON_WRITE_ROLES)
@@ -53,493 +54,516 @@ class person extends db_entity {
                              ,"defaultTimeSheetRateUnitID" => array("write_perm_name"=>PERM_PERSON_WRITE_MANAGEMENT)
                              );
 
-  public $prefs = array();
-  public $permissions = array(PERM_PERSON_READ_DETAILS => "read details"
+    public $prefs = array();
+    public $permissions = array(PERM_PERSON_READ_DETAILS => "read details"
                              ,PERM_PERSON_READ_MANAGEMENT => "read management fields"
                              ,PERM_PERSON_WRITE_MANAGEMENT => "write management fields"
                              ,PERM_PERSON_WRITE_ROLES => "set roles");
 
 
-  function get_tasks_for_email() {
+    function get_tasks_for_email()
+    {
 
-    $options = array();
-    #$options["projectType"] = "mine";
-    $options["limit"] = 3;
-    $options["current_user"] = $this->get_id();
-    $options["personID"] = $this->get_id();
-    $options["taskView"] = "prioritised";
-    $options["taskStatus"] = "open";
+        $options = array();
+      #$options["projectType"] = "mine";
+        $options["limit"] = 3;
+        $options["current_user"] = $this->get_id();
+        $options["personID"] = $this->get_id();
+        $options["taskView"] = "prioritised";
+        $options["taskStatus"] = "open";
 
-    $tasks = task::get_list($options);
+        $tasks = task::get_list($options);
 
-    foreach ($tasks as $task) {
-      $s[] = "";
-      $s[] = "";
-      $s[] = "Project: ".$task["project_name"];
-      $s[] = "Task: ".$task["taskName"];
-      $s[] = $task["taskStatusLabel"];
-      $s[] = $task["taskURL"];
-    }
-    $summary = implode("\n",$s);
+        foreach ($tasks as $task) {
+            $s[] = "";
+            $s[] = "";
+            $s[] = "Project: ".$task["project_name"];
+            $s[] = "Task: ".$task["taskName"];
+            $s[] = $task["taskStatusLabel"];
+            $s[] = $task["taskURL"];
+        }
+        $summary = implode("\n", $s);
 
-    if ($summary) {
-      $topThree = "\n\nTop Three Tasks";
-      $topThree.= $summary;
-    }
-
-    unset($summary,$s);
-    unset($options["limit"]);
-    $options["taskDate"] = "due_today";
-    $tasks = task::get_list($options);
-
-    foreach ($tasks as $task) {
-      $s[] = "";
-      $s[] = "";
-      $s[] = "Project: ".$task["project_name"];
-      $s[] = "Task: ".$task["taskName"];
-      $s[] = $task["taskStatusLabel"];
-      $s[] = $task["taskURL"];
-    }
-    $summary = implode("\n",$s);
-
-    if ($summary) {
-      $dueToday = "\n\nTasks Due Today";
-      $dueToday.= $summary;
-    }
-
-    unset($summary,$s);
-    unset($options["limit"]);
-    $options["taskDate"] = "new";
-    $tasks = task::get_list($options);
-
-    foreach ($tasks as $task) {
-      $s[] = "";
-      $s[] = "";
-      $s[] = "Project: ".$task["project_name"];
-      $s[] = "Task: ".$task["taskName"];
-      $s[] = $task["taskStatusLabel"];
-      $s[] = $task["taskURL"];
-    }
-    $summary = implode("\n",$s);
-
-    if ($summary) {
-      $newTasks = "\n\nNew Tasks";
-      $newTasks.= $summary;
-    }
-
-    return $topThree.$dueToday.$newTasks;
-  }
-
-  function get_announcements_for_email() {
-    $db = new db_alloc();
-    $db->query("SELECT * FROM announcement WHERE CURDATE() <= displayToDate AND CURDATE() >= displayFromDate");
-
-    while ($db->next_record()) {
-      $announcement["heading"] = "Announcement\n".$db->f("heading");
-      $announcement["body"] = $db->f("body");
-    }
-    return $announcement;
-  }
-
-  function have_role($perm_name) {
-    $perms = explode(",",$this->get_value("perms"));
-    return in_array($perm_name,$perms);
-  }
-
-  function is_employee() {
-    // Function to check if the person is an employee
-    $current_user = &singleton("current_user");
-    return true;
-    $permissions = explode(",", $current_user->get_value("perms"));
-
-    if (in_array("employee", $permissions)) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  function check_employee() {
-    // Ensure the current user is an employee
-    if (!$this->is_employee()) {
-      alloc_error("You must be an employee to access this function",true);
-    }
-  }
-
-  function get_skills($proficiency) {
-    // Return a string of skills with a given proficiency
-    $query = "SELECT * FROM proficiency LEFT JOIN skill on proficiency.skillID=skill.skillID";
-    $query.= prepare(" WHERE personID=%d AND skillProficiency='%s' ORDER BY skillName", $this->get_id(), $proficiency);
-
-    $db = new db_alloc();
-    $db->query($query);
-    while ($db->next_record()) {
-      $skill = new skill();
-      $skill->read_db_record($db);
-      if ($rtn) {
-        $rtn.= ", ";
-      }
-      $rtn.= $skill->get_value('skillName');
-    }
-    return $rtn;
-  }
-
-  public static function get_username_list($push_personID="") {
-    static $rows;
-
-    // Cache rows
-    if(!$rows) {
-      $q = prepare("SELECT personID, username, firstName, surname, personActive FROM person ORDER BY firstname,surname,username");
-      $db = new db_alloc();
-      $db->query($q);
-      while($db->next_record()) {
-        if ($db->f("firstName") && $db->f("surname")){
-          $name = $db->f("firstName")." ".$db->f("surname");
-        } else {
-          $name = $db->f("username");
+        if ($summary) {
+            $topThree = "\n\nTop Three Tasks";
+            $topThree.= $summary;
         }
 
-        $rows[$db->f("personID")] = array("active"=>$db->f("personActive"), "name"=>$name);
+        unset($summary, $s);
+        unset($options["limit"]);
+        $options["taskDate"] = "due_today";
+        $tasks = task::get_list($options);
 
-      }
+        foreach ($tasks as $task) {
+            $s[] = "";
+            $s[] = "";
+            $s[] = "Project: ".$task["project_name"];
+            $s[] = "Task: ".$task["taskName"];
+            $s[] = $task["taskStatusLabel"];
+            $s[] = $task["taskURL"];
+        }
+        $summary = implode("\n", $s);
+
+        if ($summary) {
+            $dueToday = "\n\nTasks Due Today";
+            $dueToday.= $summary;
+        }
+
+        unset($summary, $s);
+        unset($options["limit"]);
+        $options["taskDate"] = "new";
+        $tasks = task::get_list($options);
+
+        foreach ($tasks as $task) {
+            $s[] = "";
+            $s[] = "";
+            $s[] = "Project: ".$task["project_name"];
+            $s[] = "Task: ".$task["taskName"];
+            $s[] = $task["taskStatusLabel"];
+            $s[] = $task["taskURL"];
+        }
+        $summary = implode("\n", $s);
+
+        if ($summary) {
+            $newTasks = "\n\nNew Tasks";
+            $newTasks.= $summary;
+        }
+
+        return $topThree.$dueToday.$newTasks;
     }
 
-    // If person is active or the person is the selected person (to enable drpodown list to have people who have since been made inactive)
-    foreach ((array)$rows as $personID => $info) {
-      if ($info["active"] || $personID == $push_personID) {
-        $rtn[$personID] = $info["name"];
-      }
+    function get_announcements_for_email()
+    {
+        $db = new db_alloc();
+        $db->query("SELECT * FROM announcement WHERE CURDATE() <= displayToDate AND CURDATE() >= displayFromDate");
+
+        while ($db->next_record()) {
+            $announcement["heading"] = "Announcement\n".$db->f("heading");
+            $announcement["body"] = $db->f("body");
+        }
+        return $announcement;
     }
 
-    return $rtn;
-  }
-
-  public static function get_fullname($personID) {
-    // Get vars for the emails below
-    $people_cache =& get_cached_table("person");
-    return $people_cache[$personID]["name"];
-  }
-
-  function get_name($_FORM=array()) {
-    $firstName = $this->get_value("firstName");
-    $surname   = $this->get_value("surname");
-    $username  = $this->get_value("username");
-
-    if ($_FORM["format"] == "nick") {
-      $rtn = $username;
-    } else if ($firstName && $surname) {
-      $rtn = $firstName." ".$surname;
-    } else {
-      $rtn = $username;
+    function have_role($perm_name)
+    {
+        $perms = explode(",", $this->get_value("perms"));
+        return in_array($perm_name, $perms);
     }
 
-    if ($_FORM["return"] == "html") {
-      return page::htmlentities($rtn);
-    } else {
-      return $rtn;
-    }
-  }
+    function is_employee()
+    {
+      // Function to check if the person is an employee
+        $current_user = &singleton("current_user");
+        return true;
+        $permissions = explode(",", $current_user->get_value("perms"));
 
-  function get_tfIDs() {
-    $db = new db_alloc();
-    $db->query("SELECT tfID FROM tfPerson WHERE personID = %d",$this->get_id());
-    while ($row = $db->row()) {
-      $tfIDs[] = $row["tfID"];
-    }
-    return $tfIDs;
-  }
-
-  function get_valid_login_row($username, $password="") {
-    $db = new db_alloc();
-    $q = prepare("SELECT * FROM person WHERE username = '%s' AND personActive = 1"
-                 ,$username);
-
-    $db->query($q);
-    $row = $db->row();
-
-    if (password_verify($password, $row["password"])) {
-      return $row;
-    }
-  }
-
-  function load_current_user($personID) {
-    $this->set_id($personID);
-    if ($this->select()) {
-      $this->load_prefs();
-    }
-  }
-
-  function load_prefs() {
-    $this->prefs = unserialize($this->get_value("sessData"));
-    !isset($this->prefs["customizedFont"]) and $this->prefs["customizedFont"] = 0;
-  }
-
-  function update_prefs($p=array()) {
-    isset($p["font"])                      and $this->prefs["customizedFont"]            = sprintf("%d",$p["font"]);
-    isset($p["theme"])                     and $this->prefs["customizedTheme2"]          = $p["theme"];
-    isset($p["weeks"])                     and $this->prefs["tasksGraphPlotHome"]        = $p["weeks"];
-    isset($p["weeksBack"])                 and $this->prefs["tasksGraphPlotHomeStart"]   = $p["weeksBack"];
-    isset($p["projectListNum"])            and $this->prefs["projectListNum"]            = $p["projectListNum"];
-    isset($p["dailyTaskEmail"])            and $this->prefs["dailyTaskEmail"]            = $p["dailyTaskEmail"];
-    isset($p["receiveOwnTaskComments"])    and $this->prefs["receiveOwnTaskComments"]    = $p["receiveOwnTaskComments"];
-    isset($p["showFilters"])               and $this->prefs["showFilters"]               = $p["showFilters"];
-    isset($p["privateMode"])               and $this->prefs["privateMode"]               = $p["privateMode"];
-    isset($p["timeSheetHoursWarn"])        and $this->prefs["timeSheetHoursWarn"]        = $p["timeSheetHoursWarn"];
-    isset($p["timeSheetDaysWarn"])         and $this->prefs["timeSheetDaysWarn"]         = $p["timeSheetDaysWarn"];
-    isset($p["showTaskListHome"])          and $this->prefs["showTaskListHome"]          = $p["showTaskListHome"];
-    isset($p["showCalendarHome"])          and $this->prefs["showCalendarHome"]          = $p["showCalendarHome"];
-    isset($p["showProjectHome"])           and $this->prefs["showProjectHome"]           = $p["showProjectHome"];
-    isset($p["showTimeSheetStatsHome"])    and $this->prefs["showTimeSheetStatsHome"]    = $p["showTimeSheetStatsHome"];
-    isset($p["showTimeSheetItemHome"])     and $this->prefs["showTimeSheetItemHome"]     = $p["showTimeSheetItemHome"];
-    isset($p["showTimeSheetItemHintHome"]) and $this->prefs["showTimeSheetItemHintHome"] = $p["showTimeSheetItemHintHome"];
-  }
-
-  function store_prefs() {
-    $p = new person();
-    $p->set_id($this->get_id());
-    $p->select();
-    $p->load_prefs();
-
-    $old_prefs = $p->prefs or $old_prefs = array();
-    foreach ($old_prefs as $k => $v) {
-      if ($this->prefs[$k] != $v) {
-        $save = true;
-      }
-    }
-    foreach ($this->prefs as $k => $v) {
-      if ($old_prefs[$k] != $v) {
-        $save = true;
-      }
+        if (in_array("employee", $permissions)) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
-    if ($save || (!is_array($old_prefs) || !count($old_prefs))) {
-      $arr = serialize($this->prefs);
-      $p->set_value("sessData",$arr);
-      $p->currency = config::get_config_item('currency');
-      $p->save();
+    function check_employee()
+    {
+      // Ensure the current user is an employee
+        if (!$this->is_employee()) {
+            alloc_error("You must be an employee to access this function", true);
+        }
     }
 
-  }
+    function get_skills($proficiency)
+    {
+      // Return a string of skills with a given proficiency
+        $query = "SELECT * FROM proficiency LEFT JOIN skill on proficiency.skillID=skill.skillID";
+        $query.= prepare(" WHERE personID=%d AND skillProficiency='%s' ORDER BY skillName", $this->get_id(), $proficiency);
 
-  function has_messages() {
-    if (is_object($this)) {
+        $db = new db_alloc();
+        $db->query($query);
+        while ($db->next_record()) {
+            $skill = new skill();
+            $skill->read_db_record($db);
+            if ($rtn) {
+                $rtn.= ", ";
+            }
+            $rtn.= $skill->get_value('skillName');
+        }
+        return $rtn;
+    }
 
-      list($ts_open,$ts_pending,$ts_closed) = task::get_task_status_in_set_sql();
-      $db = new db_alloc();
-      $query = prepare("SELECT *
+    public static function get_username_list($push_personID = "")
+    {
+        static $rows;
+
+      // Cache rows
+        if (!$rows) {
+            $q = prepare("SELECT personID, username, firstName, surname, personActive FROM person ORDER BY firstname,surname,username");
+            $db = new db_alloc();
+            $db->query($q);
+            while ($db->next_record()) {
+                if ($db->f("firstName") && $db->f("surname")) {
+                    $name = $db->f("firstName")." ".$db->f("surname");
+                } else {
+                    $name = $db->f("username");
+                }
+
+                $rows[$db->f("personID")] = array("active"=>$db->f("personActive"), "name"=>$name);
+            }
+        }
+
+      // If person is active or the person is the selected person (to enable drpodown list to have people who have since been made inactive)
+        foreach ((array)$rows as $personID => $info) {
+            if ($info["active"] || $personID == $push_personID) {
+                $rtn[$personID] = $info["name"];
+            }
+        }
+
+        return $rtn;
+    }
+
+    public static function get_fullname($personID)
+    {
+      // Get vars for the emails below
+        $people_cache =& get_cached_table("person");
+        return $people_cache[$personID]["name"];
+    }
+
+    function get_name($_FORM = array())
+    {
+        $firstName = $this->get_value("firstName");
+        $surname   = $this->get_value("surname");
+        $username  = $this->get_value("username");
+
+        if ($_FORM["format"] == "nick") {
+            $rtn = $username;
+        } else if ($firstName && $surname) {
+            $rtn = $firstName." ".$surname;
+        } else {
+            $rtn = $username;
+        }
+
+        if ($_FORM["return"] == "html") {
+            return page::htmlentities($rtn);
+        } else {
+            return $rtn;
+        }
+    }
+
+    function get_tfIDs()
+    {
+        $db = new db_alloc();
+        $db->query("SELECT tfID FROM tfPerson WHERE personID = %d", $this->get_id());
+        while ($row = $db->row()) {
+            $tfIDs[] = $row["tfID"];
+        }
+        return $tfIDs;
+    }
+
+    function get_valid_login_row($username, $password = "")
+    {
+        $db = new db_alloc();
+        $q = prepare(
+            "SELECT * FROM person WHERE username = '%s' AND personActive = 1",
+            $username
+        );
+
+        $db->query($q);
+        $row = $db->row();
+
+        if (password_verify($password, $row["password"])) {
+            return $row;
+        }
+    }
+
+    function load_current_user($personID)
+    {
+        $this->set_id($personID);
+        if ($this->select()) {
+            $this->load_prefs();
+        }
+    }
+
+    function load_prefs()
+    {
+        $this->prefs = unserialize($this->get_value("sessData"));
+        !isset($this->prefs["customizedFont"]) and $this->prefs["customizedFont"] = 0;
+    }
+
+    function update_prefs($p = array())
+    {
+        isset($p["font"])                      and $this->prefs["customizedFont"]            = sprintf("%d", $p["font"]);
+        isset($p["theme"])                     and $this->prefs["customizedTheme2"]          = $p["theme"];
+        isset($p["weeks"])                     and $this->prefs["tasksGraphPlotHome"]        = $p["weeks"];
+        isset($p["weeksBack"])                 and $this->prefs["tasksGraphPlotHomeStart"]   = $p["weeksBack"];
+        isset($p["projectListNum"])            and $this->prefs["projectListNum"]            = $p["projectListNum"];
+        isset($p["dailyTaskEmail"])            and $this->prefs["dailyTaskEmail"]            = $p["dailyTaskEmail"];
+        isset($p["receiveOwnTaskComments"])    and $this->prefs["receiveOwnTaskComments"]    = $p["receiveOwnTaskComments"];
+        isset($p["showFilters"])               and $this->prefs["showFilters"]               = $p["showFilters"];
+        isset($p["privateMode"])               and $this->prefs["privateMode"]               = $p["privateMode"];
+        isset($p["timeSheetHoursWarn"])        and $this->prefs["timeSheetHoursWarn"]        = $p["timeSheetHoursWarn"];
+        isset($p["timeSheetDaysWarn"])         and $this->prefs["timeSheetDaysWarn"]         = $p["timeSheetDaysWarn"];
+        isset($p["showTaskListHome"])          and $this->prefs["showTaskListHome"]          = $p["showTaskListHome"];
+        isset($p["showCalendarHome"])          and $this->prefs["showCalendarHome"]          = $p["showCalendarHome"];
+        isset($p["showProjectHome"])           and $this->prefs["showProjectHome"]           = $p["showProjectHome"];
+        isset($p["showTimeSheetStatsHome"])    and $this->prefs["showTimeSheetStatsHome"]    = $p["showTimeSheetStatsHome"];
+        isset($p["showTimeSheetItemHome"])     and $this->prefs["showTimeSheetItemHome"]     = $p["showTimeSheetItemHome"];
+        isset($p["showTimeSheetItemHintHome"]) and $this->prefs["showTimeSheetItemHintHome"] = $p["showTimeSheetItemHintHome"];
+    }
+
+    function store_prefs()
+    {
+        $p = new person();
+        $p->set_id($this->get_id());
+        $p->select();
+        $p->load_prefs();
+
+        $old_prefs = $p->prefs or $old_prefs = array();
+        foreach ($old_prefs as $k => $v) {
+            if ($this->prefs[$k] != $v) {
+                $save = true;
+            }
+        }
+        foreach ($this->prefs as $k => $v) {
+            if ($old_prefs[$k] != $v) {
+                $save = true;
+            }
+        }
+
+        if ($save || (!is_array($old_prefs) || !count($old_prefs))) {
+            $arr = serialize($this->prefs);
+            $p->set_value("sessData", $arr);
+            $p->currency = config::get_config_item('currency');
+            $p->save();
+        }
+    }
+
+    function has_messages()
+    {
+        if (is_object($this)) {
+            list($ts_open,$ts_pending,$ts_closed) = task::get_task_status_in_set_sql();
+            $db = new db_alloc();
+            $query = prepare(
+                "SELECT *
                           FROM task
                          WHERE taskTypeID = 'Message'
                            AND personID = %d
-                           AND taskStatus NOT IN (".$ts_closed.")"
-                       ,$this->get_id());
-      $db->query($query);
-      if ($db->next_record()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  function find_by_name($name=false,$certainty=90) {
-
-    $stack1 = array();
-    $people =& get_cached_table("person");
-    foreach ($people as $personID => $row) {
-      if ($row["personActive"]) {
-        similar_text(strtolower($row["name"]),strtolower($name),$percent1);
-        $stack1[$personID] = $percent1;
-      }
+                           AND taskStatus NOT IN (".$ts_closed.")",
+                $this->get_id()
+            );
+            $db->query($query);
+            if ($db->next_record()) {
+                  return true;
+            }
+        }
+        return false;
     }
 
-    asort($stack1);
-    end($stack1);
-    $probable1_personID = key($stack1);
-    $person_percent1 = current($stack1);
+    function find_by_name($name = false, $certainty = 90)
+    {
 
-    if ($probable1_personID && $person_percent1 >= $certainty) {
-      return $probable1_personID;
-    }
-  }
+        $stack1 = array();
+        $people =& get_cached_table("person");
+        foreach ($people as $personID => $row) {
+            if ($row["personActive"]) {
+                similar_text(strtolower($row["name"]), strtolower($name), $percent1);
+                $stack1[$personID] = $percent1;
+            }
+        }
 
-  function find_by_email($email=false) {
-    $email = str_replace(array("<",">"),"",$email);
-    $people =& get_cached_table("person");
-    foreach ($people as $personID => $row) {
-      if ($row["personActive"] && $email == str_replace(array("<",">"),"",$row["emailAddress"])) {
-        return $personID;
-      }
-    }
-  }
+        asort($stack1);
+        end($stack1);
+        $probable1_personID = key($stack1);
+        $person_percent1 = current($stack1);
 
-  function get_from() {
-    $name = $this->get_name();
-    $name and $name = '"'.$name.'"';
-    $email = $this->get_value("emailAddress");
-    if ($email) {
-      $str = $name;
-      $str and $str.= " <";
-      $str and $end = ">";
-      return $str.$email.$end;
-    }
-  }
-
-  function get_list_filter($filter=array()) {
-    $filter["username"]     and $sql[] = sprintf_implode("username = '%s'", $filter["username"]);
-    $filter["personActive"] and $sql[] = sprintf_implode("personActive = %d", $filter["personActive"]);
-    $filter["firstName"]    and $sql[] = sprintf_implode("firstName = '%s'", $filter["firstName"]);
-    $filter["surname"]      and $sql[] = sprintf_implode("surname = '%s'", $filter["surname"]);
-    $filter["personID"]     and $sql[] = sprintf_implode("personID = %d", $filter["personID"]);
-
-    $filter["skill"]        and $sql["skill"] = sprintf_implode("skillID=%d", $filter["skill"]);
-
-    if ($filter["skill_class"]) {
-      $q = prepare("SELECT * FROM skill WHERE skillClass='%s'", $filter["skill_class"]);
-      $db = new db_alloc();
-      $db->query($q);
-      while ($db->next_record()) {
-        $skill = new skill();
-        $skill->read_db_record($db);
-        $sql2[] = prepare("(skillID=%d)", $skill->get_id());
-      }
+        if ($probable1_personID && $person_percent1 >= $certainty) {
+            return $probable1_personID;
+        }
     }
 
-    $filter["expertise"]    and $sql[] = sprintf_implode("skillProficiency='%s'", $filter["expertise"]);
-
-    return array($sql,$sql2);
-  }
-
-  public static function get_list($_FORM=array()) {
-    global $TPL;
-    $current_user = &singleton("current_user");
-    list($filter,$filter2) = person::get_list_filter($_FORM);
-
-    $debug = $_FORM["debug"];
-    $debug and print "<pre>_FORM: ".print_r($_FORM,1)."</pre>";
-    $debug and print "<pre>filter: ".print_r($filter,1)."</pre>";
-
-    $_FORM["return"] or $_FORM["return"] = "html";
-
-    // Get averages for hours worked over the past fortnight and year
-    if ($current_user->have_perm(PERM_PERSON_READ_MANAGEMENT) && $_FORM["showHours"]) {
-      $t = new timeSheetItem();
-      list($ts_hrs_col_1,$ts_dollars_col_1) = $t->get_averages(date("Y-m-d",mktime(0,0,0,date("m"),date("d")-14, date("Y"))));
-      list($ts_hrs_col_2,$ts_dollars_col_2) = $t->get_fortnightly_average();
-    } else {
-      unset($_FORM["showHours"]);
+    function find_by_email($email = false)
+    {
+        $email = str_replace(array("<",">"), "", $email);
+        $people =& get_cached_table("person");
+        foreach ($people as $personID => $row) {
+            if ($row["personActive"] && $email == str_replace(array("<",">"), "", $row["emailAddress"])) {
+                return $personID;
+            }
+        }
     }
 
-    // A header row
-    $summary.= person::get_list_tr_header($_FORM);
-
-    if (is_array($filter) && count($filter)) {
-      $filter = " WHERE ".implode(" AND ",$filter);
+    function get_from()
+    {
+        $name = $this->get_name();
+        $name and $name = '"'.$name.'"';
+        $email = $this->get_value("emailAddress");
+        if ($email) {
+            $str = $name;
+            $str and $str.= " <";
+            $str and $end = ">";
+            return $str.$email.$end;
+        }
     }
-    if (is_array($filter2) && count($filter2)) {
-      unset($filter["skill"]);
-      $filter.= " AND ".implode(" OR ",$filter2);
+
+    function get_list_filter($filter = array())
+    {
+        $filter["username"]     and $sql[] = sprintf_implode("username = '%s'", $filter["username"]);
+        $filter["personActive"] and $sql[] = sprintf_implode("personActive = %d", $filter["personActive"]);
+        $filter["firstName"]    and $sql[] = sprintf_implode("firstName = '%s'", $filter["firstName"]);
+        $filter["surname"]      and $sql[] = sprintf_implode("surname = '%s'", $filter["surname"]);
+        $filter["personID"]     and $sql[] = sprintf_implode("personID = %d", $filter["personID"]);
+
+        $filter["skill"]        and $sql["skill"] = sprintf_implode("skillID=%d", $filter["skill"]);
+
+        if ($filter["skill_class"]) {
+            $q = prepare("SELECT * FROM skill WHERE skillClass='%s'", $filter["skill_class"]);
+            $db = new db_alloc();
+            $db->query($q);
+            while ($db->next_record()) {
+                $skill = new skill();
+                $skill->read_db_record($db);
+                $sql2[] = prepare("(skillID=%d)", $skill->get_id());
+            }
+        }
+
+        $filter["expertise"]    and $sql[] = sprintf_implode("skillProficiency='%s'", $filter["expertise"]);
+
+        return array($sql,$sql2);
     }
 
-    $q = "SELECT person.*
+    public static function get_list($_FORM = array())
+    {
+        global $TPL;
+        $current_user = &singleton("current_user");
+        list($filter,$filter2) = person::get_list_filter($_FORM);
+
+        $debug = $_FORM["debug"];
+        $debug and print "<pre>_FORM: ".print_r($_FORM, 1)."</pre>";
+        $debug and print "<pre>filter: ".print_r($filter, 1)."</pre>";
+
+        $_FORM["return"] or $_FORM["return"] = "html";
+
+      // Get averages for hours worked over the past fortnight and year
+        if ($current_user->have_perm(PERM_PERSON_READ_MANAGEMENT) && $_FORM["showHours"]) {
+            $t = new timeSheetItem();
+            list($ts_hrs_col_1,$ts_dollars_col_1) = $t->get_averages(date("Y-m-d", mktime(0, 0, 0, date("m"), date("d")-14, date("Y"))));
+            list($ts_hrs_col_2,$ts_dollars_col_2) = $t->get_fortnightly_average();
+        } else {
+            unset($_FORM["showHours"]);
+        }
+
+      // A header row
+        $summary.= person::get_list_tr_header($_FORM);
+
+        if (is_array($filter) && count($filter)) {
+            $filter = " WHERE ".implode(" AND ", $filter);
+        }
+        if (is_array($filter2) && count($filter2)) {
+            unset($filter["skill"]);
+            $filter.= " AND ".implode(" OR ", $filter2);
+        }
+
+        $q = "SELECT person.*
             FROM person
        LEFT JOIN proficiency ON person.personID = proficiency.personID
            ".$filter."
         GROUP BY username
         ORDER BY firstName,surname,username";
 
-    $debug and print "Query: ".$q;
-    $db = new db_alloc();
-    $db->query($q);
+        $debug and print "Query: ".$q;
+        $db = new db_alloc();
+        $db->query($q);
 
-    while ($row = $db->next_record()) {
-      $p = new person();
-      if (!$p->read_db_record($db)) {
-        continue;
-      }
-      $row = $p->perm_cleanup($row); // this is not the right way to do this - alla
-      $print = true;
-      $_FORM["showHours"] and $row["hoursSum"] = $ts_hrs_col_1[$row["personID"]];
-      $_FORM["showHours"] and $row["hoursAvg"] = $ts_hrs_col_2[$row["personID"]];
+        while ($row = $db->next_record()) {
+            $p = new person();
+            if (!$p->read_db_record($db)) {
+                continue;
+            }
+            $row = $p->perm_cleanup($row); // this is not the right way to do this - alla
+            $print = true;
+            $_FORM["showHours"] and $row["hoursSum"] = $ts_hrs_col_1[$row["personID"]];
+            $_FORM["showHours"] and $row["hoursAvg"] = $ts_hrs_col_2[$row["personID"]];
 
-      $row["name"] = $p->get_name();
-      $row["name_link"] = $p->get_link($_FORM);
-      $row["personActive_label"] = $p->get_value("personActive") == 1 ? "Y":"";
+            $row["name"] = $p->get_name();
+            $row["name_link"] = $p->get_link($_FORM);
+            $row["personActive_label"] = $p->get_value("personActive") == 1 ? "Y":"";
 
-      if ($_FORM["showSkills"]) {
-        $senior_skills = $p->get_skills('Senior');
-        $advanced_skills = $p->get_skills('Advanced');
-        $intermediate_skills = $p->get_skills('Intermediate');
-        $junior_skills = $p->get_skills('Junior');
-        $novice_skills = $p->get_skills('Novice');
+            if ($_FORM["showSkills"]) {
+                $senior_skills = $p->get_skills('Senior');
+                $advanced_skills = $p->get_skills('Advanced');
+                $intermediate_skills = $p->get_skills('Intermediate');
+                $junior_skills = $p->get_skills('Junior');
+                $novice_skills = $p->get_skills('Novice');
 
-        $skills = array();
-        $senior_skills       and $skills[] = "<img src=\"../images/skill_senior.png\" alt=\"Senior=\"> ".page::htmlentities($senior_skills);
-        $advanced_skills     and $skills[] = "<img src=\"../images/skill_advanced.png\" alt=\"Advanced=\"> ".page::htmlentities($advanced_skills);
-        $intermediate_skills and $skills[] = "<img src=\"../images/skill_intermediate.png\" alt=\"Intermediate=\"> ".page::htmlentities($intermediate_skills);
-        $junior_skills       and $skills[] = "<img src=\"../images/skill_junior.png\" alt=\"Junior=\"> ".page::htmlentities($junior_skills);
-        $novice_skills       and $skills[] = "<img src=\"../images/skill_novice.png\" alt=\"Novice\"> ".page::htmlentities($novice_skills);
-        $row["skills_list"] = implode("<br>",$skills);
-      }
+                $skills = array();
+                $senior_skills       and $skills[] = "<img src=\"../images/skill_senior.png\" alt=\"Senior=\"> ".page::htmlentities($senior_skills);
+                $advanced_skills     and $skills[] = "<img src=\"../images/skill_advanced.png\" alt=\"Advanced=\"> ".page::htmlentities($advanced_skills);
+                $intermediate_skills and $skills[] = "<img src=\"../images/skill_intermediate.png\" alt=\"Intermediate=\"> ".page::htmlentities($intermediate_skills);
+                $junior_skills       and $skills[] = "<img src=\"../images/skill_junior.png\" alt=\"Junior=\"> ".page::htmlentities($junior_skills);
+                $novice_skills       and $skills[] = "<img src=\"../images/skill_novice.png\" alt=\"Novice\"> ".page::htmlentities($novice_skills);
+                $row["skills_list"] = implode("<br>", $skills);
+            }
 
-      if ($_FORM["showLinks"]) {
-        $row["navLinks"] = '<a href="'.$TPL["url_alloc_taskList"].'personID='.$row["personID"].'&taskView=byProject&applyFilter=1';
-        $row["navLinks"].= '&dontSave=1&taskStatus=open&projectType=Current">Tasks</a>&nbsp;&nbsp;';
-        has("project") and $row["navLinks"].= '<a href="'.$TPL["url_alloc_personGraph"].'personID='.$row["personID"].'">Graph</a>&nbsp;&nbsp;';
-        $row["navLinks"].= '<a href="'.$TPL["url_alloc_taskCalendar"].'personID='.$row["personID"].'">Calendar</a>&nbsp;&nbsp;';
-        $dateFrom = date("Y-m-d",mktime(0,0,0,date("m"), date("d")-28, date("Y")));
-        $dateTo = date("Y-m-d",mktime(0,0,0,date("m"), date("d")+1, date("Y")));
-        $row["navLinks"].= '<a href="'.$TPL["url_alloc_timeSheetGraph"].'personID='.$row["personID"].'&dateFrom='.$dateFrom.'&dateTo='.$dateTo.'&applyFilter=1&dontSave=1">Hours</a>';
-      }
+            if ($_FORM["showLinks"]) {
+                $row["navLinks"] = '<a href="'.$TPL["url_alloc_taskList"].'personID='.$row["personID"].'&taskView=byProject&applyFilter=1';
+                $row["navLinks"].= '&dontSave=1&taskStatus=open&projectType=Current">Tasks</a>&nbsp;&nbsp;';
+                has("project") and $row["navLinks"].= '<a href="'.$TPL["url_alloc_personGraph"].'personID='.$row["personID"].'">Graph</a>&nbsp;&nbsp;';
+                $row["navLinks"].= '<a href="'.$TPL["url_alloc_taskCalendar"].'personID='.$row["personID"].'">Calendar</a>&nbsp;&nbsp;';
+                $dateFrom = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d")-28, date("Y")));
+                $dateTo = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d")+1, date("Y")));
+                $row["navLinks"].= '<a href="'.$TPL["url_alloc_timeSheetGraph"].'personID='.$row["personID"].'&dateFrom='.$dateFrom.'&dateTo='.$dateTo.'&applyFilter=1&dontSave=1">Hours</a>';
+            }
 
-      $summary.= person::get_list_tr($row,$_FORM);
-      $rows[$row["personID"]] = $row;
+            $summary.= person::get_list_tr($row, $_FORM);
+            $rows[$row["personID"]] = $row;
+        }
+
+        $rows or $rows = array();
+        if ($print && $_FORM["return"] == "array") {
+            return $rows;
+        } else if ($print && $_FORM["return"] == "html") {
+            return "<table class=\"list sortable\">".$summary."</table>";
+        } else if (!$print && $_FORM["return"] == "html") {
+            return "<table style=\"width:100%\"><tr><td colspan=\"10\" style=\"text-align:center\"><b>No People Found</b></td></tr></table>";
+        }
     }
 
-    $rows or $rows = array();
-    if ($print && $_FORM["return"] == "array") {
-      return $rows;
-
-    } else if ($print && $_FORM["return"] == "html") {
-      return "<table class=\"list sortable\">".$summary."</table>";
-
-    } else if (!$print && $_FORM["return"] == "html") {
-      return "<table style=\"width:100%\"><tr><td colspan=\"10\" style=\"text-align:center\"><b>No People Found</b></td></tr></table>";
+    function get_list_tr_header($_FORM)
+    {
+        if ($_FORM["showHeader"]) {
+            $summary[] = "<tr>";
+            $_FORM["showName"]    and $summary[] = "<th>Name</th>";
+            $_FORM["showActive"]  and $summary[] = "<th>Enabled</th>";
+            $_FORM["showNos"]     and $summary[] = "<th>Contact</th>";
+            if ($_FORM["showSkills"]) {
+                $summary[] = "<th>";
+                $summary[] = "Senior";
+                $summary[] = '<img src="../images/skill_senior.png" alt="Senior" align="absmiddle">';
+                $summary[] = '<img src="../images/skill_advanced.png" alt="Advanced" align="absmiddle">';
+                $summary[] = '<img src="../images/skill_intermediate.png" alt="Intermediate" align="absmiddle">';
+                $summary[] = '<img src="../images/skill_junior.png" alt="Junior" align="absmiddle">';
+                $summary[] = '<img src="../images/skill_novice.png" alt="Novice" align="absmiddle"> Novice';
+                $summary[] = "</th>";
+            }
+            $_FORM["showHours"]   and $summary[] = "<th>Sum Prev Fort</th>";
+            $_FORM["showHours"]   and $summary[] = "<th>Avg Per Fort</th>";
+            $_FORM["showLinks"]   and $summary[] = "<th></th>";
+            $summary[] ="</tr>";
+            $summary = "\n".implode("\n", $summary);
+            return $summary;
+        }
     }
-  }
 
-  function get_list_tr_header($_FORM) {
-    if ($_FORM["showHeader"]) {
-      $summary[] = "<tr>";
-      $_FORM["showName"]    and $summary[] = "<th>Name</th>";
-      $_FORM["showActive"]  and $summary[] = "<th>Enabled</th>";
-      $_FORM["showNos"]     and $summary[] = "<th>Contact</th>";
-      if ($_FORM["showSkills"]) {
-        $summary[] = "<th>";
-        $summary[] = "Senior";
-        $summary[] = '<img src="../images/skill_senior.png" alt="Senior" align="absmiddle">';
-        $summary[] = '<img src="../images/skill_advanced.png" alt="Advanced" align="absmiddle">';
-        $summary[] = '<img src="../images/skill_intermediate.png" alt="Intermediate" align="absmiddle">';
-        $summary[] = '<img src="../images/skill_junior.png" alt="Junior" align="absmiddle">';
-        $summary[] = '<img src="../images/skill_novice.png" alt="Novice" align="absmiddle"> Novice';
-        $summary[] = "</th>";
-      }
-      $_FORM["showHours"]   and $summary[] = "<th>Sum Prev Fort</th>";
-      $_FORM["showHours"]   and $summary[] = "<th>Avg Per Fort</th>";
-      $_FORM["showLinks"]   and $summary[] = "<th></th>";
-      $summary[] ="</tr>";
-      $summary = "\n".implode("\n",$summary);
-      return $summary;
+    function get_list_tr($row, $_FORM)
+    {
+        global $TPL;
+        $TPL["_FORM"] = $_FORM;
+        $TPL = array_merge($TPL, (array)$row);
+        return include_template(dirname(__FILE__)."/../templates/personListR.tpl", true);
     }
-  }
 
-  function get_list_tr($row, $_FORM) {
-    global $TPL;
-    $TPL["_FORM"] = $_FORM;
-    $TPL = array_merge($TPL,(array)$row);
-    return include_template(dirname(__FILE__)."/../templates/personListR.tpl", true);
-  }
-
-  function get_list_vars() {
-    return array("return"       => "[MANDATORY] eg: array | html"
+    function get_list_vars()
+    {
+        return array("return"       => "[MANDATORY] eg: array | html"
                 ,"username"     => "Search by the person username"
                 ,"personActive" => "Search by persons active/inactive status eg: 1 | 0"
                 ,"firstName"    => "Search by persons first name"
@@ -559,75 +583,75 @@ class person extends db_entity {
                 ,"showLinks"    => "Show the person action links"
                 ,"showSkills"   => "Show the persons skills"
                 );
-  }
-
-  function load_form_data($defaults=array()) {
-    $current_user = &singleton("current_user");
-    $page_vars = array_keys(person::get_list_vars());
-    $_FORM = get_all_form_data($page_vars,$defaults);
-
-    if (!$_FORM["applyFilter"]) {
-      $_FORM = $current_user->prefs[$_FORM["form_name"]];
-      if (!isset($current_user->prefs[$_FORM["form_name"]])) {
-        $_FORM["personActive"] = true;
-      }
-
-    } else if ($_FORM["applyFilter"] && is_object($current_user) && !$_FORM["dontSave"]) {
-      $url = $_FORM["url_form_action"];
-      unset($_FORM["url_form_action"]);
-      $current_user->prefs[$_FORM["form_name"]] = $_FORM;
-      $_FORM["url_form_action"] = $url;
     }
 
-    return $_FORM;
-  }
+    function load_form_data($defaults = array())
+    {
+        $current_user = &singleton("current_user");
+        $page_vars = array_keys(person::get_list_vars());
+        $_FORM = get_all_form_data($page_vars, $defaults);
 
-  function load_person_filter($_FORM) {
-    global $TPL;
-    $current_user = &singleton("current_user");
+        if (!$_FORM["applyFilter"]) {
+            $_FORM = $current_user->prefs[$_FORM["form_name"]];
+            if (!isset($current_user->prefs[$_FORM["form_name"]])) {
+                $_FORM["personActive"] = true;
+            }
+        } else if ($_FORM["applyFilter"] && is_object($current_user) && !$_FORM["dontSave"]) {
+            $url = $_FORM["url_form_action"];
+            unset($_FORM["url_form_action"]);
+            $current_user->prefs[$_FORM["form_name"]] = $_FORM;
+            $_FORM["url_form_action"] = $url;
+        }
 
-    $db = new db_alloc();
-    $_FORM["showSkills"]   and $rtn["show_skills_checked"] = " checked";
-    $_FORM["showHours"]    and $rtn["show_hours_checked"] = " checked";
-    $_FORM["personActive"] and $rtn["show_all_users_checked"] = " checked";
+        return $_FORM;
+    }
 
-    $employee_expertise = array(""            =>"Any Expertise"
+    function load_person_filter($_FORM)
+    {
+        global $TPL;
+        $current_user = &singleton("current_user");
+
+        $db = new db_alloc();
+        $_FORM["showSkills"]   and $rtn["show_skills_checked"] = " checked";
+        $_FORM["showHours"]    and $rtn["show_hours_checked"] = " checked";
+        $_FORM["personActive"] and $rtn["show_all_users_checked"] = " checked";
+
+        $employee_expertise = array(""            =>"Any Expertise"
                                ,"Novice"      =>"Novice"
                                ,"Junior"      =>"Junior"
                                ,"Intermediate"=>"Intermediate"
                                ,"Advanced"    =>"Advanced"
                                ,"Senior"      =>"Senior"
                                );
-    $rtn["employee_expertise"] = page::select_options($employee_expertise, $_FORM["expertise"]);
+        $rtn["employee_expertise"] = page::select_options($employee_expertise, $_FORM["expertise"]);
 
-    $skill_classes = skill::get_skill_classes();
-    $rtn["skill_classes"] = page::select_options($skill_classes, $_FORM["skill_class"]);
+        $skill_classes = skill::get_skill_classes();
+        $rtn["skill_classes"] = page::select_options($skill_classes, $_FORM["skill_class"]);
 
-    $skills = skill::get_skills();
-    // if a skill class is selected and a skill that is not in that class is also selected,
-    // clear the skill as this is what the filter options will do
-    if ($skill_class && !in_array($skills[$_FORM["skill"]], $skills)) {
-      $_FORM["skill"] = "";
+        $skills = skill::get_skills();
+      // if a skill class is selected and a skill that is not in that class is also selected,
+      // clear the skill as this is what the filter options will do
+        if ($skill_class && !in_array($skills[$_FORM["skill"]], $skills)) {
+            $_FORM["skill"] = "";
+        }
+        $rtn["skills"] = page::select_options($skills, $_FORM["skill"]);
+
+        return $rtn;
     }
-    $rtn["skills"] = page::select_options($skills, $_FORM["skill"]);
 
-    return $rtn;
-  }
-
-  function get_link($_FORM=array()) {
-    global $TPL;
-    $_FORM["return"] or $_FORM["return"] = "html";
-    return "<a href=\"".$TPL["url_alloc_person"]."personID=".$this->get_id()."\">".$this->get_name($_FORM)."</a>";
-  }
-
-  function get_people_by_username($field="username") {
-    $people =& get_cached_table("person");
-    foreach ($people as $personID => $person) {
-      $people_by_username[$person[$field]] = $person;
+    function get_link($_FORM = array())
+    {
+        global $TPL;
+        $_FORM["return"] or $_FORM["return"] = "html";
+        return "<a href=\"".$TPL["url_alloc_person"]."personID=".$this->get_id()."\">".$this->get_name($_FORM)."</a>";
     }
-    return $people_by_username;
-  }
 
+    function get_people_by_username($field = "username")
+    {
+        $people =& get_cached_table("person");
+        foreach ($people as $personID => $person) {
+            $people_by_username[$person[$field]] = $person;
+        }
+        return $people_by_username;
+    }
 }
-
-?>

--- a/person/lib/proficiency.inc.php
+++ b/person/lib/proficiency.inc.php
@@ -3,33 +3,30 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class proficiency extends db_entity {
-  public $data_table = "proficiency";
-  public $display_field_name = "personID";
-  public $key_field = "proficiencyID";
-  public $data_fields = array("personID"
+class proficiency extends db_entity
+{
+    public $data_table = "proficiency";
+    public $display_field_name = "personID";
+    public $key_field = "proficiencyID";
+    public $data_fields = array("personID"
                              ,"skillID"
                              ,"skillProficiency"
                              );
 }
-
-
-
-?>

--- a/person/lib/skill.inc.php
+++ b/person/lib/skill.inc.php
@@ -3,87 +3,85 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class skill extends db_entity {
-  public $data_table = "skill";
-  public $display_field_name = "skillName";
-  public $key_field = "skillID";
-  public $data_fields = array("skillName"
+class skill extends db_entity
+{
+    public $data_table = "skill";
+    public $display_field_name = "skillName";
+    public $key_field = "skillID";
+    public $data_fields = array("skillName"
                              ,"skillDescription"
                              ,"skillClass"
                              );
 
   // return true if a skill with same name and class already exists
   // and update fields of current if it does exist
-  function skill_exists() {
-    $query = "SELECT * FROM skill";
-    $query.= prepare(" WHERE skillName='%s'", $this->get_value('skillName'));
-    $query.= prepare(" AND skillClass='%s'", $this->get_value('skillClass'));
-    $db = new db_alloc();
-    $db->query($query);
-    if ($db->next_record()) {
-      $skill = new skill();
-      $skill->read_db_record($db);
-      $this->set_id($skill->get_id());
-      $this->set_value('skillDescription', $skill->get_value('skillDescription'));
-      return TRUE;
+    function skill_exists()
+    {
+        $query = "SELECT * FROM skill";
+        $query.= prepare(" WHERE skillName='%s'", $this->get_value('skillName'));
+        $query.= prepare(" AND skillClass='%s'", $this->get_value('skillClass'));
+        $db = new db_alloc();
+        $db->query($query);
+        if ($db->next_record()) {
+            $skill = new skill();
+            $skill->read_db_record($db);
+            $this->set_id($skill->get_id());
+            $this->set_value('skillDescription', $skill->get_value('skillDescription'));
+            return true;
+        }
+        return false;
     }
-    return FALSE;
-  }
 
-  function get_skill_classes() {
-    $db = new db_alloc();
-    $skill_classes = array(""=>"Any Class");
-    $query = "SELECT skillClass FROM skill ORDER BY skillClass";
-    $db->query($query);
-    while ($db->next_record()) {
-      $skill = new skill();
-      $skill->read_db_record($db);
-      if (!in_array($skill->get_value('skillClass'), $skill_classes)) {
-        $skill_classes[$skill->get_value('skillClass')] = $skill->get_value('skillClass');
-      }
+    function get_skill_classes()
+    {
+        $db = new db_alloc();
+        $skill_classes = array(""=>"Any Class");
+        $query = "SELECT skillClass FROM skill ORDER BY skillClass";
+        $db->query($query);
+        while ($db->next_record()) {
+            $skill = new skill();
+            $skill->read_db_record($db);
+            if (!in_array($skill->get_value('skillClass'), $skill_classes)) {
+                $skill_classes[$skill->get_value('skillClass')] = $skill->get_value('skillClass');
+            }
+        }
+        return $skill_classes;
     }
-    return $skill_classes;
-  }
 
-  function get_skills() {
-    global $TPL;
-    global $skill_class;
-    $skills = array(""=>"Any Skill");
-    $query = "SELECT * FROM skill";
-    if ($skill_class != "") {
-      $query.= prepare(" WHERE skillClass='%s'", $skill_class);
+    function get_skills()
+    {
+        global $TPL;
+        global $skill_class;
+        $skills = array(""=>"Any Skill");
+        $query = "SELECT * FROM skill";
+        if ($skill_class != "") {
+            $query.= prepare(" WHERE skillClass='%s'", $skill_class);
+        }
+        $query.= " ORDER BY skillClass,skillName";
+        $db = new db_alloc();
+        $db->query($query);
+        while ($db->next_record()) {
+            $skill = new skill();
+            $skill->read_db_record($db);
+            $skills[$skill->get_id()] = sprintf("%s - %s", $skill->get_value('skillClass'), $skill->get_value('skillName'));
+        }
+        return $skills;
     }
-    $query.= " ORDER BY skillClass,skillName";
-    $db = new db_alloc();
-    $db->query($query);
-    while ($db->next_record()) {
-      $skill = new skill();
-      $skill->read_db_record($db);
-      $skills[$skill->get_id()] = sprintf("%s - %s", $skill->get_value('skillClass'), $skill->get_value('skillName'));
-    }
-    return $skills;
-  }
-
-  
 }
-
-
-
-?>

--- a/person/person.php
+++ b/person/person.php
@@ -22,28 +22,30 @@
 
 require_once("../alloc.php");
 
-  function show_perm_select() {
+function show_perm_select()
+{
     global $person;
     if ($person->have_perm(PERM_PERSON_WRITE_ROLES)) {
-      $selected = explode(",",$person->get_value("perms"));
-      $ops = role::get_roles_array("person");
-      foreach ($ops as $p => $l) {
-        unset($sel);
-        in_array($p,$selected) and $sel = " checked";
-        echo $br."<input type=\"checkbox\" name=\"perm_select[]\" value=\"".$p."\"".$sel."> ".$l;
-        $br = "<br>";
-      }
+        $selected = explode(",", $person->get_value("perms"));
+        $ops = role::get_roles_array("person");
+        foreach ($ops as $p => $l) {
+            unset($sel);
+            in_array($p, $selected) and $sel = " checked";
+            echo $br."<input type=\"checkbox\" name=\"perm_select[]\" value=\"".$p."\"".$sel."> ".$l;
+            $br = "<br>";
+        }
     } else {
-      $selected = explode(",",$person->get_value("perms"));
-      $ops = role::get_roles_array("person");
-      foreach ($selected as $sel) {
-        echo $br.$ops[$sel];
-        $br = "<br>";
-      }
+        $selected = explode(",", $person->get_value("perms"));
+        $ops = role::get_roles_array("person");
+        foreach ($selected as $sel) {
+            echo $br.$ops[$sel];
+            $br = "<br>";
+        }
     }
-  }
+}
 
-  function show_absence_forms($template) {
+function show_absence_forms($template)
+{
     global $personID;
 
     $db = new db_alloc();
@@ -51,33 +53,37 @@ require_once("../alloc.php");
     $db->query($query);
     $absence = new absence();
     while ($db->next_record()) {
-      $absence->read_db_record($db);
-      $absence->set_values("absence_");
-      include_template($template);
+        $absence->read_db_record($db);
+        $absence->set_values("absence_");
+        include_template($template);
     }
-  }
+}
 
-  function show_action_buttons() {
+function show_action_buttons()
+{
     global $person;
     global $TPL;
     if ($person->have_perm(PERM_DELETE)) {
-      echo '<button type="submit" name="delete" value="1" class="delete_button">Delete<i class="icon-trash"></i></button> ';
+        echo '<button type="submit" name="delete" value="1" class="delete_button">Delete<i class="icon-trash"></i></button> ';
     }
     echo '<button type="submit" name="save" value="1" class="save_button">Save<i class="icon-ok-sign"></i></button> ';
-  }
+}
 
-  function include_employee_fields() {
+function include_employee_fields()
+{
     global $person;
     show_skills_list();
     include_template("templates/personEmployeeFieldsS.tpl");
-  }
+}
 
-  function include_employee_skill_fields() {
+function include_employee_skill_fields()
+{
     global $person;
     include_template("templates/personEmployeeSkillFieldsS.tpl");
-  }
+}
 
-  function show_person_areasOfExpertise($template) {
+function show_person_areasOfExpertise($template)
+{
     global $TPL;
     global $personID;
     global $skill_header;
@@ -99,31 +105,32 @@ require_once("../alloc.php");
     $db->query($query);
     $currSkillClass = null;
     while ($db->next_record()) {
-      $skill = new skill();
-      $skill->read_db_record($db);
-      $skill->set_tpl_values();
+        $skill = new skill();
+        $skill->read_db_record($db);
+        $skill->set_tpl_values();
 
-      $skillProficiencys = new proficiency();
-      $skillProficiencys->read_db_record($db);
-      $skillProficiencys->set_values();
+        $skillProficiencys = new proficiency();
+        $skillProficiencys->read_db_record($db);
+        $skillProficiencys->set_values();
 
       # if they do and there is no heading for this segment put a heading
-      $thisSkillClass = $skill->get_value('skillClass');
-      if ($currSkillClass != $thisSkillClass) {
-        $currSkillClass = $thisSkillClass;
-        $skill_header = true;
-      } else {
-        $skill_header = false;
-      }
-      $skill_prof = $skillProficiencys->get_value('skillProficiency');
-      $TPL["skill_proficiencys"] = page::select_options($proficiencys, $skill_prof);
+        $thisSkillClass = $skill->get_value('skillClass');
+        if ($currSkillClass != $thisSkillClass) {
+            $currSkillClass = $thisSkillClass;
+            $skill_header = true;
+        } else {
+            $skill_header = false;
+        }
+        $skill_prof = $skillProficiencys->get_value('skillProficiency');
+        $TPL["skill_proficiencys"] = page::select_options($proficiencys, $skill_prof);
 
       # display rating if there is one
-      include_template($template);
+        include_template($template);
     }
-  }
+}
 
-  function show_skills_list() {
+function show_skills_list()
+{
     global $TPL;
     global $personID;
     global $skills;
@@ -133,37 +140,39 @@ require_once("../alloc.php");
     $db->query($query);
     $skills_got = array();
     while ($db->next_record()) {
-      $skill = new skill();
-      $skill->read_db_record($db);
-      array_push($skills_got, $skill->get_id());
+        $skill = new skill();
+        $skill->read_db_record($db);
+        array_push($skills_got, $skill->get_id());
     }
     $query = "SELECT * FROM skill ORDER BY skillClass";
     $db->query($query);
     while ($db->next_record()) {
-      $skill = new skill();
-      $skill->read_db_record($db);
-      if (in_array($skill->get_id(), $skills_got)) {
-        // dont show this item
-      } else {
-        $skills[$skill->get_id()] = sprintf("%s - %s", $skill->get_value('skillClass'), $skill->get_value('skillName'));
-      }
+        $skill = new skill();
+        $skill->read_db_record($db);
+        if (in_array($skill->get_id(), $skills_got)) {
+          // dont show this item
+        } else {
+            $skills[$skill->get_id()] = sprintf("%s - %s", $skill->get_value('skillClass'), $skill->get_value('skillName'));
+        }
     }
     if (count($skills) > 0) {
-      $TPL["skills"] = page::select_options($skills, "");
+        $TPL["skills"] = page::select_options($skills, "");
     }
-  }
+}
 
-  function check_optional_person_skills_header() {
+function check_optional_person_skills_header()
+{
     global $skill_header;
     return $skill_header;
-  }
+}
 
-  function include_management_fields() {
+function include_management_fields()
+{
     global $person;
     if ($person->have_perm(PERM_PERSON_READ_MANAGEMENT)) {
-      include_template("templates/personManagementFieldsS.tpl");
+        include_template("templates/personManagementFieldsS.tpl");
     }
-  }
+}
 
 $skill_header = false;
 $person = new person();
@@ -171,99 +180,94 @@ $person = new person();
 $personID = $_POST["personID"] or $personID = $_GET["personID"];
 
 if ($personID) {
-  $person->set_id($personID);
-  $person->select();
+    $person->set_id($personID);
+    $person->select();
 }
 
 
 if ($_POST["personExpertiseItem_add"] || $_POST["personExpertiseItem_save"] || $_POST["personExpertiseItem_delete"]) {
-  $proficiency = new proficiency();
-  $proficiency->read_globals();
+    $proficiency = new proficiency();
+    $proficiency->read_globals();
 
 
-  if ($_POST["skillID"] != null) {
-    if ($_POST["personExpertiseItem_delete"]) {
-      $proficiency->delete();
-    } else if ($_POST["personExpertiseItem_save"]) {
-      $proficiency->save();
-    } else if ($_POST["personExpertiseItem_add"]) {
-      // skillID is an array if when adding but not when saving or deleting
-      $skillProficiency = $proficiency->get_value('skillProficiency');
-      for ($i = 0; $i < count($_POST["skillID"]); $i++) {
-        $proficiency = new proficiency();
+    if ($_POST["skillID"] != null) {
+        if ($_POST["personExpertiseItem_delete"]) {
+            $proficiency->delete();
+        } else if ($_POST["personExpertiseItem_save"]) {
+            $proficiency->save();
+        } else if ($_POST["personExpertiseItem_add"]) {
+          // skillID is an array if when adding but not when saving or deleting
+            $skillProficiency = $proficiency->get_value('skillProficiency');
+            for ($i = 0; $i < count($_POST["skillID"]); $i++) {
+                $proficiency = new proficiency();
 
-        $proficiency->set_value('skillID', $_POST["skillID"][$i]);
-        $proficiency->set_value('skillProficiency', $_POST["skillProficiency"]);
-        $proficiency->set_value('personID', $personID);
+                $proficiency->set_value('skillID', $_POST["skillID"][$i]);
+                $proficiency->set_value('skillProficiency', $_POST["skillProficiency"]);
+                $proficiency->set_value('personID', $personID);
 
-        $db = new db_alloc();
-        $query = prepare("SELECT * FROM proficiency WHERE personID = %d", $personID);
-        $query.= prepare(" AND skillID = %d", $_POST["skillID"][$i]);
-        $db->query($query);
-        if (!$db->next_record()) {
-          $proficiency->save();
+                $db = new db_alloc();
+                $query = prepare("SELECT * FROM proficiency WHERE personID = %d", $personID);
+                $query.= prepare(" AND skillID = %d", $_POST["skillID"][$i]);
+                $db->query($query);
+                if (!$db->next_record()) {
+                    $proficiency->save();
+                }
+            }
         }
-      }
     }
-  }
 }
 
 if ($_POST["save"]) {
-  $person->read_globals();
+    $person->read_globals();
 
-  if ($person->can_write_field("perms")) {
-    $_POST["perm_select"] or $_POST["perm_select"] = array();
-    $person->set_value("perms", implode(",", $_POST["perm_select"]));
-  }
-
-  if ($_POST["password1"] && $_POST["password1"] == $_POST["password2"]) {
-    $person->set_value('password', password_hash($_POST["password1"], PASSWORD_BCRYPT));
-
-  } else if (!$_POST["password1"] && $personID) {
-    // nothing required here, just don't update the password field
-
-  } else {
-    alloc_error("Please re-type the passwords");
-  }
-
-
-  if ($_POST["username"]) {
-    $q = prepare("SELECT personID FROM person WHERE username = '%s'",$_POST["username"]);
-    $db = new db_alloc();
-    $db->query($q);
-    $num_rows = $db->num_rows();
-    $row = $db->row();
-
-    if (($num_rows > 0 && !$person->get_id()) || ($num_rows > 0 && $person->get_id() != $row["personID"])){
-      alloc_error("That username is already taken. Please select another.");
+    if ($person->can_write_field("perms")) {
+        $_POST["perm_select"] or $_POST["perm_select"] = array();
+        $person->set_value("perms", implode(",", $_POST["perm_select"]));
     }
-  } else {
-    alloc_error("Please enter a username.");
-  }
 
-  $person->set_value("personActive", $_POST["personActive"] ? 1 : "0");
-
-  $max_alloc_users = get_max_alloc_users();
-  if (!$person->get_id() && $max_alloc_users && get_num_alloc_users() >= $max_alloc_users && $_POST["personActive"]) {
-    alloc_error(get_max_alloc_users_message());
-  }
-
-  if (!$TPL["message"]) {
-    $person->set_value("availability",rtrim($person->get_value("availability")));
-    $person->set_value("areasOfInterest",rtrim($person->get_value("areasOfInterest")));
-    $person->set_value("comments",rtrim($person->get_value("comments")));
-    $person->set_value("emergencyContact",rtrim($person->get_value("emergencyContact")));
-    $person->set_value("managementComments",rtrim($person->get_value("managementComments")));
-    $person->currency = config::get_config_item('currency');
-    $person->save();
-    alloc_redirect($TPL["url_alloc_personList"]);
-  }
+    if ($_POST["password1"] && $_POST["password1"] == $_POST["password2"]) {
+        $person->set_value('password', password_hash($_POST["password1"], PASSWORD_BCRYPT));
+    } else if (!$_POST["password1"] && $personID) {
+      // nothing required here, just don't update the password field
+    } else {
+        alloc_error("Please re-type the passwords");
+    }
 
 
+    if ($_POST["username"]) {
+        $q = prepare("SELECT personID FROM person WHERE username = '%s'", $_POST["username"]);
+        $db = new db_alloc();
+        $db->query($q);
+        $num_rows = $db->num_rows();
+        $row = $db->row();
 
+        if (($num_rows > 0 && !$person->get_id()) || ($num_rows > 0 && $person->get_id() != $row["personID"])) {
+            alloc_error("That username is already taken. Please select another.");
+        }
+    } else {
+        alloc_error("Please enter a username.");
+    }
+
+    $person->set_value("personActive", $_POST["personActive"] ? 1 : "0");
+
+    $max_alloc_users = get_max_alloc_users();
+    if (!$person->get_id() && $max_alloc_users && get_num_alloc_users() >= $max_alloc_users && $_POST["personActive"]) {
+        alloc_error(get_max_alloc_users_message());
+    }
+
+    if (!$TPL["message"]) {
+        $person->set_value("availability", rtrim($person->get_value("availability")));
+        $person->set_value("areasOfInterest", rtrim($person->get_value("areasOfInterest")));
+        $person->set_value("comments", rtrim($person->get_value("comments")));
+        $person->set_value("emergencyContact", rtrim($person->get_value("emergencyContact")));
+        $person->set_value("managementComments", rtrim($person->get_value("managementComments")));
+        $person->currency = config::get_config_item('currency');
+        $person->save();
+        alloc_redirect($TPL["url_alloc_personList"]);
+    }
 } else if ($_POST["delete"]) {
-  $person->delete();
-  alloc_redirect($TPL["url_alloc_personList"]);
+    $person->delete();
+    alloc_redirect($TPL["url_alloc_personList"]);
 }
 
 #$person = new person();
@@ -272,36 +276,36 @@ if ($_POST["save"]) {
 $person->set_values("person_");
 
 if ($person->get_id()) {
-  $q = prepare("SELECT tfPerson.tfID AS value, tf.tfName AS label
+    $q = prepare(
+        "SELECT tfPerson.tfID AS value, tf.tfName AS label
                   FROM tf, tfPerson
   				       WHERE tf.tfID = tfPerson.tfID
                    AND tfPerson.personID = %d
-                   AND (tf.tfActive = 1 OR tf.tfID = %d)"
-                ,$person->get_id(),$person->get_value("preferred_tfID"));
-  $TPL["preferred_tfID_options"] = page::select_options($q, $person->get_value("preferred_tfID"));
+                   AND (tf.tfActive = 1 OR tf.tfID = %d)",
+        $person->get_id(),
+        $person->get_value("preferred_tfID")
+    );
+    $TPL["preferred_tfID_options"] = page::select_options($q, $person->get_value("preferred_tfID"));
 
-  $tf = new tf();
-  $tf->set_id($person->get_value("preferred_tfID"));
-  $tf->select();
+    $tf = new tf();
+    $tf->set_id($person->get_value("preferred_tfID"));
+    $tf->select();
 }
 
 $TPL["absence_url"] = $TPL["url_alloc_absence"]."personID=".$personID;
 $TPL["personActive"] = (!$person->get_id() || $person->get_value("personActive")) ? " checked" : "";
 
 if (has("time")) {
-  $timeUnit = new timeUnit();
-  $rate_type_array = $timeUnit->get_assoc_array("timeUnitID","timeUnitLabelB");
+    $timeUnit = new timeUnit();
+    $rate_type_array = $timeUnit->get_assoc_array("timeUnitID", "timeUnitLabelB");
 }
 $TPL["timeSheetRateUnit_select"] = page::select_options($rate_type_array, $person->get_value("defaultTimeSheetRateUnitID"));
 $TPL["timeSheetRateUnit_label"] = $rate_type_array[$person->get_value("defaultTimeSheetRateUnitID")];
 
 if ($personID) {
-  $TPL["main_alloc_title"] = "Person Details: " . $person->get_value("username")." - ".APPLICATION_NAME;
+    $TPL["main_alloc_title"] = "Person Details: " . $person->get_value("username")." - ".APPLICATION_NAME;
 } else {
-  $TPL["main_alloc_title"] = "New Person - ".APPLICATION_NAME;
+    $TPL["main_alloc_title"] = "New Person - ".APPLICATION_NAME;
 }
 
 include_template("templates/personM.tpl");
-
-
-?>

--- a/person/personList.php
+++ b/person/personList.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -31,20 +31,22 @@ $defaults = array("return"       => "html"
                  ,"form_name"    => "personList_filter"
                  );
 
-function show_filter() {
-  global $TPL;
-  global $defaults;
-  $_FORM = person::load_form_data($defaults);
-  $arr = person::load_person_filter($_FORM);
-  is_array($arr) and $TPL = array_merge($TPL,$arr);
-  include_template("templates/personListFilterS.tpl");
+function show_filter()
+{
+    global $TPL;
+    global $defaults;
+    $_FORM = person::load_form_data($defaults);
+    $arr = person::load_person_filter($_FORM);
+    is_array($arr) and $TPL = array_merge($TPL, $arr);
+    include_template("templates/personListFilterS.tpl");
 }
 
-function show_people() {
-  global $defaults;
-  $_FORM = person::load_form_data($defaults);
+function show_people()
+{
+    global $defaults;
+    $_FORM = person::load_form_data($defaults);
   #echo "<pre>".print_r($_FORM,1)."</pre>";
-  echo person::get_list($_FORM);
+    echo person::get_list($_FORM);
 }
 
 $TPL["main_alloc_title"] = "People - ".APPLICATION_NAME;
@@ -52,15 +54,13 @@ $TPL["main_alloc_title"] = "People - ".APPLICATION_NAME;
 $max_alloc_users = get_max_alloc_users();
 $num_alloc_users = get_num_alloc_users();
 if ($max_alloc_users && $num_alloc_users > $max_alloc_users) {
-  alloc_error("Maximum number of active user accounts: ".$max_alloc_users);
-  alloc_error("Current number of active user accounts: ".$num_alloc_users."<br>");
-  alloc_error(get_max_alloc_users_message());
+    alloc_error("Maximum number of active user accounts: ".$max_alloc_users);
+    alloc_error("Current number of active user accounts: ".$num_alloc_users."<br>");
+    alloc_error(get_max_alloc_users_message());
 } else if ($max_alloc_users) {
-  $TPL["message_help"][] = "Maximum number of active user accounts: ".$max_alloc_users;
-  $TPL["message_help"][] = "Current number of active user accounts: ".$num_alloc_users;
+    $TPL["message_help"][] = "Maximum number of active user accounts: ".$max_alloc_users;
+    $TPL["message_help"][] = "Current number of active user accounts: ".$num_alloc_users;
 }
 
 
 include_template("templates/personListM.tpl");
-
-?>

--- a/person/personSkillAdd.php
+++ b/person/personSkillAdd.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -26,33 +26,33 @@ require_once("../alloc.php");
 
 // add new skill to database
 if ($_POST["add_skill"]) {
-  $failed = FALSE;
-  $skill = new skill();
-  if ($_POST["new_skill_class"] != "") {
-    $skill->set_value('skillClass', $_POST["new_skill_class"]);
-  } else if ($_POST["other_new_skill_class"] != "") {
-    $skill->set_value('skillClass', $_POST["other_new_skill_class"]);
-  } else {
-    $failed = TRUE;
-  } 
-  if ($_POST["other_new_skill_name"] != "") {
-    $skill->set_value('skillName', $_POST["other_new_skill_name"]);
-    // description for now can be the same as the name
-    $skill->set_value('skillDescription', $_POST["other_new_skill_name"]);
-  } else {
-    $failed = TRUE;
-  } 
-  if ($failed == FALSE && $skill->skill_exists() == FALSE) {
-    $skill->save();
-  } 
-} 
+    $failed = false;
+    $skill = new skill();
+    if ($_POST["new_skill_class"] != "") {
+        $skill->set_value('skillClass', $_POST["new_skill_class"]);
+    } else if ($_POST["other_new_skill_class"] != "") {
+        $skill->set_value('skillClass', $_POST["other_new_skill_class"]);
+    } else {
+        $failed = true;
+    }
+    if ($_POST["other_new_skill_name"] != "") {
+        $skill->set_value('skillName', $_POST["other_new_skill_name"]);
+      // description for now can be the same as the name
+        $skill->set_value('skillDescription', $_POST["other_new_skill_name"]);
+    } else {
+        $failed = true;
+    }
+    if ($failed == false && $skill->skill_exists() == false) {
+        $skill->save();
+    }
+}
 if ($_POST["delete_skill"]) {
-  $skill = new skill();
-  if ($_POST["new_skill_name"] != "") {
-    $skill->set_id($_POST["new_skill_name"]);
-    $skill->delete();
-  } 
-} 
+    $skill = new skill();
+    if ($_POST["new_skill_name"] != "") {
+        $skill->set_id($_POST["new_skill_name"]);
+        $skill->delete();
+    }
+}
 
 
 $skill_classes = skill::get_skill_classes();
@@ -61,12 +61,14 @@ $TPL["new_skill_classes"] = page::select_options($skill_classes, $_POST["skill_c
 
 $skills = skill::get_skills();
 // if a skill class is selected and a skill that is not in that class is also selected, clear the skill as this is what the filter options will do
-if ($skill_class && !in_array($skills[$_POST["skill"]], $skills)) { $_POST["skill"] = ""; }
+if ($skill_class && !in_array($skills[$_POST["skill"]], $skills)) {
+    $_POST["skill"] = "";
+}
 $skills[""] = ">> NEW >>";
 $TPL["new_skills"] = page::select_options($skills, $_POST["skill"]);
 
 
 $TPL["main_alloc_title"] = "Edit Skills - ".APPLICATION_NAME;
 if ($current_user->have_perm(PERM_PERSON_READ_MANAGEMENT)) {
-  include_template("templates/personSkillAdd.tpl");
+    include_template("templates/personSkillAdd.tpl");
 }

--- a/person/personSkillMatrix.php
+++ b/person/personSkillMatrix.php
@@ -3,155 +3,161 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function show_filter($template) {
-  global $TPL;
-  show_skill_classes();
-  show_skills();
-  include_template($template);
+function show_filter($template)
+{
+    global $TPL;
+    show_skill_classes();
+    show_skills();
+    include_template($template);
 }
 
-function show_skill_classes() {
-  global $TPL;
-  global $skill_class;
-  global $db;
-  $skill_classes = array(""=>"Any class");
-  $query = "SELECT skillClass FROM skill ORDER BY skillClass";
-  $db->query($query);
-  while ($db->next_record()) {
-    $skill = new skill();
-    $skill->read_db_record($db);
-    if (!in_array($skill->get_value('skillClass'), $skill_classes)) {
-      $skill_classes[$skill->get_value('skillClass')] = $skill->get_value('skillClass');
+function show_skill_classes()
+{
+    global $TPL;
+    global $skill_class;
+    global $db;
+    $skill_classes = array(""=>"Any class");
+    $query = "SELECT skillClass FROM skill ORDER BY skillClass";
+    $db->query($query);
+    while ($db->next_record()) {
+        $skill = new skill();
+        $skill->read_db_record($db);
+        if (!in_array($skill->get_value('skillClass'), $skill_classes)) {
+            $skill_classes[$skill->get_value('skillClass')] = $skill->get_value('skillClass');
+        }
     }
-  }
-  $TPL["skill_classes"] = page::select_options($skill_classes, $skill_class);
+    $TPL["skill_classes"] = page::select_options($skill_classes, $skill_class);
 }
 
-function show_skills() {
-  global $TPL;
-  global $talent;
-  global $skills;
-  global $skill_class;
-  global $db;
-  $skills = array(""=>"Any skill");
-  $query = "SELECT * FROM skill";
-  if ($skill_class != "") {
-    $query.= prepare(" WHERE skillClass='%s'", $skill_class);
-  }
-  $query.= " ORDER BY skillClass,skillName";
-  $db->query($query);
-  while ($db->next_record()) {
-    $skill = new skill();
-    $skill->read_db_record($db);
-    $skills[$skill->get_id()] = sprintf("%s - %s", $skill->get_value('skillClass'), $skill->get_value('skillName'));
-  }
-  if ($skill_class != "" && !in_array($skills[$talent], $skills)) {
-    $talent = "";
-  }
-  $TPL["skills"] = page::select_options($skills, $talent);
+function show_skills()
+{
+    global $TPL;
+    global $talent;
+    global $skills;
+    global $skill_class;
+    global $db;
+    $skills = array(""=>"Any skill");
+    $query = "SELECT * FROM skill";
+    if ($skill_class != "") {
+        $query.= prepare(" WHERE skillClass='%s'", $skill_class);
+    }
+    $query.= " ORDER BY skillClass,skillName";
+    $db->query($query);
+    while ($db->next_record()) {
+        $skill = new skill();
+        $skill->read_db_record($db);
+        $skills[$skill->get_id()] = sprintf("%s - %s", $skill->get_value('skillClass'), $skill->get_value('skillName'));
+    }
+    if ($skill_class != "" && !in_array($skills[$talent], $skills)) {
+        $talent = "";
+    }
+    $TPL["skills"] = page::select_options($skills, $talent);
 }
 
-function get_people_header() {
-  global $TPL;
-  global $people_ids;
-  global $people_header;
-  global $talent;
-  global $skill_class;
+function get_people_header()
+{
+    global $TPL;
+    global $people_ids;
+    global $people_header;
+    global $talent;
+    global $skill_class;
 
-  $people_ids = array();
+    $people_ids = array();
 
-  $where = FALSE;
-  $db = new db_alloc();
-  $query = "SELECT * FROM person";
-  $query.= " LEFT JOIN proficiency ON person.personID=proficiency.personID";
-  $query.= " LEFT JOIN skill ON proficiency.skillID=skill.skillID WHERE personActive = 1 ";
-  if ($talent) {
-    $query.= prepare(" AND skill.skillID=%d", $talent);
-
-  } else if ($skill_class) {
-    $query.= prepare(" AND skill.skillClass='%s'", $skill_class);
-  }
-  $query.= " GROUP BY username ORDER BY username";
-  $db->query($query);
-  while ($db->next_record()) {
-    $person = new person();
-    $person->read_db_record($db);
-    array_push($people_ids, $person->get_id());
-    $people_header.= sprintf("<th style=\"text-align:center\">%s</th>\n", $person->get_value('username'));
-  }
+    $where = false;
+    $db = new db_alloc();
+    $query = "SELECT * FROM person";
+    $query.= " LEFT JOIN proficiency ON person.personID=proficiency.personID";
+    $query.= " LEFT JOIN skill ON proficiency.skillID=skill.skillID WHERE personActive = 1 ";
+    if ($talent) {
+        $query.= prepare(" AND skill.skillID=%d", $talent);
+    } else if ($skill_class) {
+        $query.= prepare(" AND skill.skillClass='%s'", $skill_class);
+    }
+    $query.= " GROUP BY username ORDER BY username";
+    $db->query($query);
+    while ($db->next_record()) {
+        $person = new person();
+        $person->read_db_record($db);
+        array_push($people_ids, $person->get_id());
+        $people_header.= sprintf("<th style=\"text-align:center\">%s</th>\n", $person->get_value('username'));
+    }
 }
 
-function show_skill_expertise() {
-  global $TPL;
-  global $people_ids;
-  global $people_header;
-  global $talent;
-  global $skill_class;
+function show_skill_expertise()
+{
+    global $TPL;
+    global $people_ids;
+    global $people_header;
+    global $talent;
+    global $skill_class;
 
-  $currSkillClass = null;
+    $currSkillClass = null;
 
-  $db = new db_alloc();
-  $query = "SELECT * FROM proficiency";
-  $query.= " LEFT JOIN skill ON proficiency.skillID=skill.skillID";
-  if ($talent != "" || $skill_class != "") {
-    if ($talent != "") {
-      $query.= prepare(" WHERE proficiency.skillID=%d", $talent);
-    } else {
-      $query.= prepare(" WHERE skillClass='%s'", $skill_class);
+    $db = new db_alloc();
+    $query = "SELECT * FROM proficiency";
+    $query.= " LEFT JOIN skill ON proficiency.skillID=skill.skillID";
+    if ($talent != "" || $skill_class != "") {
+        if ($talent != "") {
+            $query.= prepare(" WHERE proficiency.skillID=%d", $talent);
+        } else {
+            $query.= prepare(" WHERE skillClass='%s'", $skill_class);
+        }
     }
-  }
-  $query.= " GROUP BY skillName ORDER BY skillClass,skillName";
-  $db->query($query);
-  while ($db->next_record()) {
-    $skill = new skill();
-    $skill->read_db_record($db);
-    $thisSkillClass = $skill->get_value('skillClass');
-    if ($currSkillClass != $thisSkillClass) {
-      $currSkillClass = $thisSkillClass;
-      if (!isset($people_header)) {
-        get_people_header();
-      }
-      $class_header = sprintf("<tr class=\"highlighted\">\n<th width=\"5%%\">%s&nbsp;&nbsp;&nbsp;</th>\n", $skill->get_value('skillClass',DST_HTML_DISPLAY));
-      print $class_header.$people_header."</tr>\n";
+    $query.= " GROUP BY skillName ORDER BY skillClass,skillName";
+    $db->query($query);
+    while ($db->next_record()) {
+        $skill = new skill();
+        $skill->read_db_record($db);
+        $thisSkillClass = $skill->get_value('skillClass');
+        if ($currSkillClass != $thisSkillClass) {
+            $currSkillClass = $thisSkillClass;
+            if (!isset($people_header)) {
+                get_people_header();
+            }
+            $class_header = sprintf("<tr class=\"highlighted\">\n<th width=\"5%%\">%s&nbsp;&nbsp;&nbsp;</th>\n", $skill->get_value('skillClass', DST_HTML_DISPLAY));
+            print $class_header.$people_header."</tr>\n";
+        }
+        print sprintf("<tr>\n<th>%s</th>\n", $skill->get_value('skillName', DST_HTML_DISPLAY));
+        for ($i = 0; $i < count($people_ids); $i++) {
+            $db2 = new db_alloc();
+            $query = "SELECT * FROM proficiency";
+            $query.= prepare(" WHERE skillID=%d AND personID=%d", $skill->get_id(), $people_ids[$i]);
+            $db2->query($query);
+            if ($db2->next_record()) {
+                $proficiency = new proficiency();
+                $proficiency->read_db_record($db2);
+                $p = sprintf(
+                    "<td align=\"center\"><img src=\"../images/skill_%s.png\" alt=\"%s\"/></td>\n",
+                    strtolower($proficiency->get_value('skillProficiency')),
+                    substr($proficiency->get_value('skillProficiency'), 0, 1)
+                );
+                print $p;
+            } else {
+                print "<td align=\"center\">-</td>\n";
+            }
+        }
+        print "</tr>\n";
     }
-    print sprintf("<tr>\n<th>%s</th>\n", $skill->get_value('skillName',DST_HTML_DISPLAY));
-    for ($i = 0; $i < count($people_ids); $i++) {
-      $db2 = new db_alloc();
-      $query = "SELECT * FROM proficiency";
-      $query.= prepare(" WHERE skillID=%d AND personID=%d", $skill->get_id(), $people_ids[$i]);
-      $db2->query($query);
-      if ($db2->next_record()) {
-        $proficiency = new proficiency();
-        $proficiency->read_db_record($db2);
-        $p = sprintf("<td align=\"center\"><img src=\"../images/skill_%s.png\" alt=\"%s\"/></td>\n"
-                              ,strtolower($proficiency->get_value('skillProficiency'))
-                              ,substr($proficiency->get_value('skillProficiency'), 0, 1));
-        print $p;
-      } else {
-        print "<td align=\"center\">-</td>\n";
-      }
-    }
-    print "</tr>\n";
-  }
 }
 
 $talent or $talent = $_POST["talent"];
@@ -159,5 +165,3 @@ $skill_class or $skill_class = $_POST["skill_class"];
 
 $TPL["main_alloc_title"] = "Skill Matrix - ".APPLICATION_NAME;
 include_template("templates/personSkillMatrix.tpl");
-
-?>

--- a/person/sendEmail.php
+++ b/person/sendEmail.php
@@ -3,30 +3,30 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_AUTH",true);
-define("IS_GOD",true);
+define("NO_AUTH", true);
+define("IS_GOD", true);
 require_once("../alloc.php");
 
 
 if (date("D") == "Sat" || date("D") == "Sun") {
-  alloc_error("IT'S THE WEEKEND - GET OUTTA HERE",true);
+    alloc_error("IT'S THE WEEKEND - GET OUTTA HERE", true);
 }
 
 
@@ -39,44 +39,39 @@ $db->query("SELECT personID,emailAddress,firstName,surname FROM person WHERE per
 
 
 while ($db->next_record()) {
-
-  $person = new person();
-  $person->read_db_record($db);
-  $person->set_id($db->f("personID"));
-  $person->load_prefs();
-  if (!$person->prefs["dailyTaskEmail"]) {
-    continue;
-  }
-
-  $msg = "";
-  $tasks = "";
-  $to = "";
-
-  if ($announcement["heading"]) {
-    $msg.= $announcement["heading"];
-    $msg.= "\n".$announcement["body"]."\n";
-    $msg.= "\n- - - - - - - - - -\n";
-  }
-
-  if ($person->get_value("emailAddress")) {
-    $tasks = $person->get_tasks_for_email();
-    $msg.= $tasks;
-
-    $subject = commentTemplate::populate_string(config::get_config_item("emailSubject_dailyDigest", ""));
-    $to = $person->get_value("emailAddress");
-    if ($person->get_value("firstName") && $person->get_value("surname") && $to) {
-      $to = $person->get_value("firstName")." ".$person->get_value("surname")." <".$to.">";  
+    $person = new person();
+    $person->read_db_record($db);
+    $person->set_id($db->f("personID"));
+    $person->load_prefs();
+    if (!$person->prefs["dailyTaskEmail"]) {
+        continue;
     }
 
-    if ($tasks && $to) {
-      $email = new email_send($to, $subject, $msg, "daily_digest");
-      if ($email->send()) {
-        echo "\n<br>Sent email to: ".$to;
-      }
-    } 
+    $msg = "";
+    $tasks = "";
+    $to = "";
 
-  }
+    if ($announcement["heading"]) {
+        $msg.= $announcement["heading"];
+        $msg.= "\n".$announcement["body"]."\n";
+        $msg.= "\n- - - - - - - - - -\n";
+    }
+
+    if ($person->get_value("emailAddress")) {
+        $tasks = $person->get_tasks_for_email();
+        $msg.= $tasks;
+
+        $subject = commentTemplate::populate_string(config::get_config_item("emailSubject_dailyDigest", ""));
+        $to = $person->get_value("emailAddress");
+        if ($person->get_value("firstName") && $person->get_value("surname") && $to) {
+            $to = $person->get_value("firstName")." ".$person->get_value("surname")." <".$to.">";
+        }
+
+        if ($tasks && $to) {
+            $email = new email_send($to, $subject, $msg, "daily_digest");
+            if ($email->send()) {
+                echo "\n<br>Sent email to: ".$to;
+            }
+        }
+    }
 }
-
-
-?>

--- a/project/lib/import_export.inc.php
+++ b/project/lib/import_export.inc.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -24,658 +24,687 @@
 
 define('CSV_EXPIRY', 60*30); //30 mins
 
-function store_csv($file) {
+function store_csv($file)
+{
 
   // Before storing it, go through the tmp directory and clean up any old files.
   // This is the only point where the number of files should increase, so this
   // is a good time to limit the expansion.
-  $dir = ATTACHMENTS_DIR . 'tmp' . DIRECTORY_SEPARATOR;
-  $files = glob($dir . "csv_*");
+    $dir = ATTACHMENTS_DIR . 'tmp' . DIRECTORY_SEPARATOR;
+    $files = glob($dir . "csv_*");
 
-  $expiry = time() - CSV_EXPIRY;
-  foreach ($files as $fn) {
-    // read the timestamp out of the filename... or maybe stat it?
-    $props = stat($fn);
-    if ($props['mtime'] < $expiry) {
-      unlink($fn);
+    $expiry = time() - CSV_EXPIRY;
+    foreach ($files as $fn) {
+      // read the timestamp out of the filename... or maybe stat it?
+        $props = stat($fn);
+        if ($props['mtime'] < $expiry) {
+            unlink($fn);
+        }
     }
-  }
 
-  if (!is_uploaded_file($file)) {
-    //client messing around
-    error_log("CSV Upload: '$file' was not an uploaded file.");
-    return false;
-  }
+    if (!is_uploaded_file($file)) {
+      //client messing around
+        error_log("CSV Upload: '$file' was not an uploaded file.");
+        return false;
+    }
 
-  $filename = "csv_" . time();
-  if (!move_uploaded_file($file, $dir . $filename)) {
-    error_log("CSV Upload: Couldn't move file $file to " . $dir . $filename);
-    return false;
-  }
+    $filename = "csv_" . time();
+    if (!move_uploaded_file($file, $dir . $filename)) {
+        error_log("CSV Upload: Couldn't move file $file to " . $dir . $filename);
+        return false;
+    }
 
-  return $filename;
+    return $filename;
 }
 
 // Sort out the list of interested parties and add them to the task.
-function add_ips($parties, $taskID, $projectID) {
-  // each ip can be either a username or an email address. If it's a username, 
-  // look them up. If it's an email address, see if it belongs to anybody. If 
-  // the email doesn't match a client contact, drop it - if it's added as an IP 
+function add_ips($parties, $taskID, $projectID)
+{
+  // each ip can be either a username or an email address. If it's a username,
+  // look them up. If it's an email address, see if it belongs to anybody. If
+  // the email doesn't match a client contact, drop it - if it's added as an IP
   // their name can't be changed later.
   
-  foreach ($parties as $party) {
-    $ipdata = array('entity' => 'task',
-      'entityID' => $taskID);
-    // same logic as the real interested parties code - if the name contains an 
-    // '@', it's an email address. Otherwise, it's a login.
-    if (strpos($party, '@') === false) {
-      $person = import_find_username(array($party));
-      if (!$person) {
-        continue;
-      }
-      $ipdata['personID'] = $person->get_id();
-      $ipdata['name'] = person::get_fullname($person->get_id());
-      $ipdata['emailAddress'] = $person->get_value("emailAddress");
-    } else {
-      $ipdata['emailAddress'] = $party;
-      // add_client_contact will figure out the rest
+    foreach ($parties as $party) {
+        $ipdata = array('entity' => 'task',
+        'entityID' => $taskID);
+      // same logic as the real interested parties code - if the name contains an
+      // '@', it's an email address. Otherwise, it's a login.
+        if (strpos($party, '@') === false) {
+            $person = import_find_username(array($party));
+            if (!$person) {
+                continue;
+            }
+            $ipdata['personID'] = $person->get_id();
+            $ipdata['name'] = person::get_fullname($person->get_id());
+            $ipdata['emailAddress'] = $person->get_value("emailAddress");
+        } else {
+            $ipdata['emailAddress'] = $party;
+          // add_client_contact will figure out the rest
+        }
+        interestedparty::add_interested_party($ipdata);
     }
-    interestedparty::add_interested_party($ipdata);
-  }
 }
 
-function import_csv($infile, $mapping, $header = true) {
-  global $TPL;
-  global $projectID;
-  $current_user = &singleton("current_user");
+function import_csv($infile, $mapping, $header = true)
+{
+    global $TPL;
+    global $projectID;
+    $current_user = &singleton("current_user");
 
-  /* Make sure the user isn't messing around and inserting ../../ into the 
+  /* Make sure the user isn't messing around and inserting ../../ into the
    * filename.
    */
 
-  $rp = realpath(ATTACHMENTS_DIR.'tmp'.DIRECTORY_SEPARATOR.$infile);
-  if ($rp === FALSE || strpos($rp, ATTACHMENTS_DIR.'tmp'.DIRECTORY_SEPARATOR) !== 0)
-    alloc_error("Illegal file path.",true); //should occur through user dodginess
+    $rp = realpath(ATTACHMENTS_DIR.'tmp'.DIRECTORY_SEPARATOR.$infile);
+    if ($rp === false || strpos($rp, ATTACHMENTS_DIR.'tmp'.DIRECTORY_SEPARATOR) !== 0) {
+        alloc_error("Illegal file path.", true); //should occur through user dodginess
+    }
 
-  $db = new db_alloc(); //import_find_username needs it
+    $db = new db_alloc(); //import_find_username needs it
   //Import a CSV file
-  $project = new project();
-  $project->set_id($projectID);
-  $project->select();
+    $project = new project();
+    $project->set_id($projectID);
+    $project->select();
 
-  $filename = $rp;
-  $result = array();
-  $result[0] = array();
-  $fh = @fopen($filename, 'rb');
-  if ($fh === FALSE) {
-    $result[0] = "There was a problem reading the uploaded file.";
-  } else {
-
-    $line = 1;
-    // Find the project manager
-    $projectManager = $project->get_project_manager();
-    if ($header) {
-      fgetcsv($fh, 8192);               // Skip the header line
-      $line++;
-    }
-    
-    while($row = fgetcsv($fh, 8192)) {
-      $warning = false;
-
-      $task_result = array();
-
-      $task = new task();
-      $ips = array();
-      for ($i = 0;$i < count($row);$i++) {
-        switch($mapping[$i]) {
-        case 'ignore':
-          break;
-        case 'name':
-          $task->set_value('taskName', $row[$i]);
-          break;
-        case 'description':
-          $task->set_value('taskDescription', $row[$i]);
-          break;
-        case 'assignee':
-          $assignee = import_find_username(array($row[$i]));
-          if($assignee) {
-            $task->set_value('personID', $assignee->get_id());
-          } else {
-            //We don't know who the manager is, so assign it to the project manager
-            $task->set_value('personID', $projectManager);
-            $task_result []= sprintf('Warning: Unable to find a username corresponding to "%s", assigning task to project manager.', $row[$i]);
-          }
-          break;
-        case 'manager':
-          $manager = import_find_username(array($row[$i]));
-          if($manager) {
-            $task->set_value('managerID', $manager->get_id());
-          } else {
-            //We don't know who the manager is, so assign it to the project manager
-            $task->set_value('managerID', $projectManager);
-            $task_result []= sprintf('Warning: Unable to find a username corresponding to "%s", setting task manager to project manager.', $row[$i]);
-          }
-          break;
-        case 'limit':
-          $task->set_value('timeLimit', $row[$i]);
-          break;
-        case 'timeBest':
-          $task->set_value('timeBest', $row[$i]);
-          break;
-        case 'timeWorst':
-          $task->set_value('timeWorst', $row[$i]);
-          break;
-        case 'timeExpected':
-          $task->set_value('timeExpected', $row[$i]);
-          break;
-        case 'startDate':
-          $task->set_value('dateTargetStart', date("Y-m-d", strtotime($row[$i])));
-          break;
-        case 'completionDate':
-          $task->set_value('dateTargetCompletion', date("Y-m-d", strtotime($row[$i])));
-          break;
-        case 'interestedParties':
-          // Field is a grouped list of names
-          $ips = explode(" ", $row[$i]);
-          break;
-	}
-      }
-      $task->set_value('projectID', $projectID);
-      // if no manager set, use the uploader
-
-      // Having a blank assignee actually works, but set it back to the 
-      // project manager
-      if (!$task->get_value('personID')) {
-        $task->set_value('personID', $projectManager);
-      }
-      if (!$task->get_value('taskName')) {
-        $result[0] []= "Line " . $line . ": Task has no name, creation failed.";
-        $line++;
-        continue;
-      }
-      // Hardcoded defaults
-      $task->set_value('taskTypeID', 'Task');
-
-      $task->set_value('priority', '3');
-      $task->set_value('dateCreated', date('Y-m-d H:i:s'));
-      $task->set_value('dateAssigned', date('Y-m-d H:i:s'));
-      $task->set_value('taskStatus', 'open_notstarted');
-      $task->save();
-
-      $task_result []= "Task ".$task->get_value('taskName') . " created";
-
-      // can only add interested parties after the task has an ID
-      if ($ips) {
-        add_ips($ips, $task->get_id(), $projectID);
-      }
-
-      $result[$task->get_id()] = $task_result;
-      $line++;
-    }
-
-    fclose($fh);
-    unlink($filename);
-  }
-  return $result;
-}
-
-function import_gnome_planner($infile) {
-  global $TPL;
-  global $projectID;
-  $current_user = &singleton("current_user");
-  //Import a GNOME Planner XML file
-  $filename = $_FILES[$infile]['tmp_name'];
-  $result = array();
-  $fileIsValid = true;
-  if(is_uploaded_file($filename)) {
-    $doc = get_xml_document();
-    if(@$doc->load($filename) === FALSE) {
-      // Something's wrong with the file, bail out
-      $result[] = "The file does not seem to be a valid GNOME Planner XML file.";
-      $TPL['import_result'] = implode("<br>", $result);
-      return;
-    }
-    // This function does two passes of each file. First, it does a set of basic tests to check the file is valid.
-    // If it is, the function then actually imports the data.
-    $result[] = "<li>Checking the file for validity...</li>";
-    // Check that every <resource /> element has a short-name that corresponds to the user id of a user we know about
-    $resource_people = array();
-    $resources = $doc->getElementsByTagName("resource");
-    for($i = 0; $i < $resources->length; $i++) {
-      $resource = $resources->item($i);
-      $user = import_find_username(array($resource->getAttribute("name"), $resource->getAttribute("short-name")));
-      if(!$user) {
-        $result[] = sprintf("Couldn't find the person who corresponds to %s (%s).", $resource->getAttribute("short-name"), $resource->getAttribute("name"));
-        $fileIsValid = false;
-      } else {
-        // Remember this person for when we do the actual import
-        $resource_people[$resource->getAttribute("id")] = $user;
-      }
-    }
-    $result[] = "<li>Done checking resource names.</li>";
-    // Check that at most one person is assigned to each task
-    $task_allocation = array();
-    $allocations = $doc->getElementsByTagName("allocation");
-    for($i = 0; $i < $allocations->length; $i++) {
-      $allocation = $allocations->item($i);
-      $taskid = $allocation->getAttribute("task-id");
-      if(isset($task_allocation[$taskid])) {
-        // multiple people assigned to this task
-        if(is_array($task_allocation[$taskid])) {
-          // > 2 people assigned to the task, add to the array
-          $task_allocation[$taskid][] = $allocation->getAttribute("resource-id");
-        } else {
-          // 2 people assigned to the task (so far), convert to an array
-          $task_allocation[$taskid] = array($task_allocation[$taskid], $allocation->getAttribute("resource-id"));
-        }
-      } else {
-        $task_allocation[$allocation->getAttribute("task-id")] = $allocation->getAttribute("resource-id");
-      }
-    }
-    $result[] = "<li>Done checking task allocations.</li>";
-
-    // OK, checks are done, now we attempt to actually do the import
-    if($fileIsValid) {
-      $project = new project();
-      $project->set_id($projectID);
-      $project->select();
-      $projectManager = $project->get_project_manager();
-
-      $result[] = "<li>File looks valid, running import.</li>";
-      // First import tasks
-      $taskNode = $doc->getElementsByTagName("tasks");
-      $result = array_merge($result, import_planner_tasks($taskNode->item(0), '0', 0, $task_allocation, $resource_people, $projectManager));
-      $result[] = "<li>Import completed.</li>";
+    $filename = $rp;
+    $result = array();
+    $result[0] = array();
+    $fh = @fopen($filename, 'rb');
+    if ($fh === false) {
+        $result[0] = "There was a problem reading the uploaded file.";
     } else {
-      $result[] = "<li>Please fix the above problems and then attempt to reimport the file. No changes have been made to alloc's database.</li>";
+        $line = 1;
+      // Find the project manager
+        $projectManager = $project->get_project_manager();
+        if ($header) {
+            fgetcsv($fh, 8192);               // Skip the header line
+            $line++;
+        }
+    
+        while ($row = fgetcsv($fh, 8192)) {
+            $warning = false;
+
+            $task_result = array();
+
+            $task = new task();
+            $ips = array();
+            for ($i = 0; $i < count($row); $i++) {
+                switch ($mapping[$i]) {
+                    case 'ignore':
+                        break;
+                    case 'name':
+                        $task->set_value('taskName', $row[$i]);
+                        break;
+                    case 'description':
+                        $task->set_value('taskDescription', $row[$i]);
+                        break;
+                    case 'assignee':
+                        $assignee = import_find_username(array($row[$i]));
+                        if ($assignee) {
+                            $task->set_value('personID', $assignee->get_id());
+                        } else {
+                      //We don't know who the manager is, so assign it to the project manager
+                            $task->set_value('personID', $projectManager);
+                            $task_result []= sprintf('Warning: Unable to find a username corresponding to "%s", assigning task to project manager.', $row[$i]);
+                        }
+                        break;
+                    case 'manager':
+                        $manager = import_find_username(array($row[$i]));
+                        if ($manager) {
+                            $task->set_value('managerID', $manager->get_id());
+                        } else {
+                      //We don't know who the manager is, so assign it to the project manager
+                            $task->set_value('managerID', $projectManager);
+                            $task_result []= sprintf('Warning: Unable to find a username corresponding to "%s", setting task manager to project manager.', $row[$i]);
+                        }
+                        break;
+                    case 'limit':
+                        $task->set_value('timeLimit', $row[$i]);
+                        break;
+                    case 'timeBest':
+                        $task->set_value('timeBest', $row[$i]);
+                        break;
+                    case 'timeWorst':
+                        $task->set_value('timeWorst', $row[$i]);
+                        break;
+                    case 'timeExpected':
+                        $task->set_value('timeExpected', $row[$i]);
+                        break;
+                    case 'startDate':
+                        $task->set_value('dateTargetStart', date("Y-m-d", strtotime($row[$i])));
+                        break;
+                    case 'completionDate':
+                        $task->set_value('dateTargetCompletion', date("Y-m-d", strtotime($row[$i])));
+                        break;
+                    case 'interestedParties':
+                        // Field is a grouped list of names
+                        $ips = explode(" ", $row[$i]);
+                        break;
+                }
+            }
+            $task->set_value('projectID', $projectID);
+          // if no manager set, use the uploader
+
+          // Having a blank assignee actually works, but set it back to the
+          // project manager
+            if (!$task->get_value('personID')) {
+                $task->set_value('personID', $projectManager);
+            }
+            if (!$task->get_value('taskName')) {
+                $result[0] []= "Line " . $line . ": Task has no name, creation failed.";
+                $line++;
+                continue;
+            }
+          // Hardcoded defaults
+            $task->set_value('taskTypeID', 'Task');
+
+            $task->set_value('priority', '3');
+            $task->set_value('dateCreated', date('Y-m-d H:i:s'));
+            $task->set_value('dateAssigned', date('Y-m-d H:i:s'));
+            $task->set_value('taskStatus', 'open_notstarted');
+            $task->save();
+
+            $task_result []= "Task ".$task->get_value('taskName') . " created";
+
+          // can only add interested parties after the task has an ID
+            if ($ips) {
+                add_ips($ips, $task->get_id(), $projectID);
+            }
+
+            $result[$task->get_id()] = $task_result;
+            $line++;
+        }
+
+        fclose($fh);
+        unlink($filename);
     }
-  } else {
-    $result[] = "<li>There was a problem with the upload.</li>";
-  }
-  $TPL['import_result'] = "<ul>" . implode("", $result) . "</ul>";
+    return $result;
 }
 
-function import_planner_tasks($parentNode, $parentTaskId, $depth, $task_allocation, $resource_people, $project_manager_ID) {
-  //Recursively imports tasks from GNOME Planner, given the parentNode.
-  global $projectID;
-  $current_user = &singleton("current_user");
-  $result = array();
-  // our dodgy DOM_NodeList doesn't support foreach....
-  for($i = 0; $i < $parentNode->childNodes->length; $i++) {
-    $taskXML = $parentNode->childNodes->item($i);
-    if($taskXML->nodeType == XML_ELEMENT_NODE && $taskXML->tagName == "task") {
-      $task = new task();
-      $task->set_value('taskName', trim($taskXML->getAttribute("name")));
-      $task->set_value('projectID', $projectID);
-      // We can find the task assignee's id in the $task_allocation array, and that person's Person record in the $resource_people array
-      $planner_taskid = $taskXML->getAttribute("id");
-      // Dates we guess at (i.e., set to now)
-      $task->set_value('dateCreated', date("Y-m-d H:i:s"));
-      $task->set_value('dateAssigned', date("Y-m-d H:i:s"));
-      if($taskXML->hasAttribute("work-start")) {
-        $task->set_value('dateTargetStart', import_planner_date($taskXML->getAttribute("work-start")));
-      } else {
-        $task->set_value('dateTargetStart', import_planner_date($taskXML->getAttribute("start")));
-        $result[] = "Resorting to work value for " . $task->get_value('taskName');
-      }
-      $task->set_value('dateTargetCompletion', import_planner_date($taskXML->getAttribute("end")));
-      if($taskXML->hasAttribute("note")) {
-        $task->set_value('taskDescription', $taskXML->getAttribute("note"));
-      }
-      $task->set_value('creatorID', $current_user->get_id());
-      $task->set_value('managerID', $project_manager_ID);
-      if($taskXML->hasAttribute("type") and $taskXML->getAttribute("type") == "milestone") {
-        $task->set_value('taskTypeID', 'Milestone');
-      } else {
-        $task->set_value('taskTypeID', 'Task');
-      }
-      $task->set_value('taskStatus', 'open_notstarted');
-      $task->set_value('priority', '3');
-      $task->set_value('parentTaskID', ($parentTaskId == 0 ? "" : $parentTaskId));
-      // The following fields we leave at their default values: duplicateTaskID, dateActualCompletion, dateActualStart, closerID, timeExpected, dateClosed, parentTaskID, taskModifiedUser
-
-      // Handle task assignment
-      if(isset($task_allocation[$planner_taskid])) {
-        if(is_array($task_allocation[$planner_taskid])) {
-          // This task was assigned to more than one person. Assign it to the project manager and make a comment about it.
-          $task->set_value('personID', $project_manager_ID);
-          // Save the task so we have a task ID
-          $task->save();
-          // Make a comment about this task
-          $comment = new comment();
-          $comment->set_value("commentType","task");
-          $comment->set_value("commentLinkID", $task->get_id());
-          $comment->set_value("commentCreatedTime", date("Y-m-d H:i:s"));
-          // The user doing the import is (implicitly) the user creating the comment
-          $comment->set_value("commentCreatedUser", $current_user->get_id());
-          // Get the relevant usernames
-          $names = array();
-          foreach($task_allocation[$planner_taskid] as $assignee) {
-            $names[] = person::get_fullname($assignee);
-          }
-
-          $comment->set_value("comment", "Import notice: This task was originally assigned to " . implode($names, ', ') . ".");
-          $comment->save();
-          $result[] = sprintf("<li>Note: multiple people were assigned to the task %d %s</li>", $task->get_id(), $task->get_value("taskName"));
-        } else {
-          $task->set_value('personID', $resource_people[$task_allocation[$taskXML->getAttribute("id")]]->get_id());
+function import_gnome_planner($infile)
+{
+    global $TPL;
+    global $projectID;
+    $current_user = &singleton("current_user");
+  //Import a GNOME Planner XML file
+    $filename = $_FILES[$infile]['tmp_name'];
+    $result = array();
+    $fileIsValid = true;
+    if (is_uploaded_file($filename)) {
+        $doc = get_xml_document();
+        if (@$doc->load($filename) === false) {
+          // Something's wrong with the file, bail out
+            $result[] = "The file does not seem to be a valid GNOME Planner XML file.";
+            $TPL['import_result'] = implode("<br>", $result);
+            return;
         }
-      } else {
-        // Task not assigned to anyone, assign the task to the nominated manager
-        $task->set_value('personID', $project_manager_ID);
-      }
+      // This function does two passes of each file. First, it does a set of basic tests to check the file is valid.
+      // If it is, the function then actually imports the data.
+        $result[] = "<li>Checking the file for validity...</li>";
+      // Check that every <resource /> element has a short-name that corresponds to the user id of a user we know about
+        $resource_people = array();
+        $resources = $doc->getElementsByTagName("resource");
+        for ($i = 0; $i < $resources->length; $i++) {
+            $resource = $resources->item($i);
+            $user = import_find_username(array($resource->getAttribute("name"), $resource->getAttribute("short-name")));
+            if (!$user) {
+                $result[] = sprintf("Couldn't find the person who corresponds to %s (%s).", $resource->getAttribute("short-name"), $resource->getAttribute("name"));
+                $fileIsValid = false;
+            } else {
+                // Remember this person for when we do the actual import
+                $resource_people[$resource->getAttribute("id")] = $user;
+            }
+        }
+        $result[] = "<li>Done checking resource names.</li>";
+      // Check that at most one person is assigned to each task
+        $task_allocation = array();
+        $allocations = $doc->getElementsByTagName("allocation");
+        for ($i = 0; $i < $allocations->length; $i++) {
+            $allocation = $allocations->item($i);
+            $taskid = $allocation->getAttribute("task-id");
+            if (isset($task_allocation[$taskid])) {
+                // multiple people assigned to this task
+                if (is_array($task_allocation[$taskid])) {
+                  // > 2 people assigned to the task, add to the array
+                    $task_allocation[$taskid][] = $allocation->getAttribute("resource-id");
+                } else {
+                  // 2 people assigned to the task (so far), convert to an array
+                    $task_allocation[$taskid] = array($task_allocation[$taskid], $allocation->getAttribute("resource-id"));
+                }
+            } else {
+                $task_allocation[$allocation->getAttribute("task-id")] = $allocation->getAttribute("resource-id");
+            }
+        }
+        $result[] = "<li>Done checking task allocations.</li>";
 
-      $task->save();
+      // OK, checks are done, now we attempt to actually do the import
+        if ($fileIsValid) {
+            $project = new project();
+            $project->set_id($projectID);
+            $project->select();
+            $projectManager = $project->get_project_manager();
 
-      $result[] = sprintf('<li>%sCreated task <a href="%s">%d %s</a>.</li>', str_repeat("&gt;", $depth), $task->get_url(), $task->get_id(), $task->get_value('taskName'));
-
-      // Do child nodes
-      if($taskXML->hasChildNodes()) {
-        $result = array_merge($result, import_planner_tasks($taskXML, $task->get_id(), $depth + 1, $task_allocation, $resource_people, $project_manager_ID));
-      }
+            $result[] = "<li>File looks valid, running import.</li>";
+          // First import tasks
+            $taskNode = $doc->getElementsByTagName("tasks");
+            $result = array_merge($result, import_planner_tasks($taskNode->item(0), '0', 0, $task_allocation, $resource_people, $projectManager));
+            $result[] = "<li>Import completed.</li>";
+        } else {
+            $result[] = "<li>Please fix the above problems and then attempt to reimport the file. No changes have been made to alloc's database.</li>";
+        }
+    } else {
+        $result[] = "<li>There was a problem with the upload.</li>";
     }
-  }
-  return $result;
+    $TPL['import_result'] = "<ul>" . implode("", $result) . "</ul>";
+}
+
+function import_planner_tasks($parentNode, $parentTaskId, $depth, $task_allocation, $resource_people, $project_manager_ID)
+{
+  //Recursively imports tasks from GNOME Planner, given the parentNode.
+    global $projectID;
+    $current_user = &singleton("current_user");
+    $result = array();
+  // our dodgy DOM_NodeList doesn't support foreach....
+    for ($i = 0; $i < $parentNode->childNodes->length; $i++) {
+        $taskXML = $parentNode->childNodes->item($i);
+        if ($taskXML->nodeType == XML_ELEMENT_NODE && $taskXML->tagName == "task") {
+            $task = new task();
+            $task->set_value('taskName', trim($taskXML->getAttribute("name")));
+            $task->set_value('projectID', $projectID);
+          // We can find the task assignee's id in the $task_allocation array, and that person's Person record in the $resource_people array
+            $planner_taskid = $taskXML->getAttribute("id");
+          // Dates we guess at (i.e., set to now)
+            $task->set_value('dateCreated', date("Y-m-d H:i:s"));
+            $task->set_value('dateAssigned', date("Y-m-d H:i:s"));
+            if ($taskXML->hasAttribute("work-start")) {
+                $task->set_value('dateTargetStart', import_planner_date($taskXML->getAttribute("work-start")));
+            } else {
+                $task->set_value('dateTargetStart', import_planner_date($taskXML->getAttribute("start")));
+                $result[] = "Resorting to work value for " . $task->get_value('taskName');
+            }
+            $task->set_value('dateTargetCompletion', import_planner_date($taskXML->getAttribute("end")));
+            if ($taskXML->hasAttribute("note")) {
+                $task->set_value('taskDescription', $taskXML->getAttribute("note"));
+            }
+            $task->set_value('creatorID', $current_user->get_id());
+            $task->set_value('managerID', $project_manager_ID);
+            if ($taskXML->hasAttribute("type") and $taskXML->getAttribute("type") == "milestone") {
+                $task->set_value('taskTypeID', 'Milestone');
+            } else {
+                $task->set_value('taskTypeID', 'Task');
+            }
+            $task->set_value('taskStatus', 'open_notstarted');
+            $task->set_value('priority', '3');
+            $task->set_value('parentTaskID', ($parentTaskId == 0 ? "" : $parentTaskId));
+          // The following fields we leave at their default values: duplicateTaskID, dateActualCompletion, dateActualStart, closerID, timeExpected, dateClosed, parentTaskID, taskModifiedUser
+
+          // Handle task assignment
+            if (isset($task_allocation[$planner_taskid])) {
+                if (is_array($task_allocation[$planner_taskid])) {
+                  // This task was assigned to more than one person. Assign it to the project manager and make a comment about it.
+                    $task->set_value('personID', $project_manager_ID);
+                  // Save the task so we have a task ID
+                    $task->save();
+                  // Make a comment about this task
+                    $comment = new comment();
+                    $comment->set_value("commentType", "task");
+                    $comment->set_value("commentLinkID", $task->get_id());
+                    $comment->set_value("commentCreatedTime", date("Y-m-d H:i:s"));
+                  // The user doing the import is (implicitly) the user creating the comment
+                    $comment->set_value("commentCreatedUser", $current_user->get_id());
+                  // Get the relevant usernames
+                    $names = array();
+                    foreach ($task_allocation[$planner_taskid] as $assignee) {
+                        $names[] = person::get_fullname($assignee);
+                    }
+
+                    $comment->set_value("comment", "Import notice: This task was originally assigned to " . implode($names, ', ') . ".");
+                    $comment->save();
+                    $result[] = sprintf("<li>Note: multiple people were assigned to the task %d %s</li>", $task->get_id(), $task->get_value("taskName"));
+                } else {
+                    $task->set_value('personID', $resource_people[$task_allocation[$taskXML->getAttribute("id")]]->get_id());
+                }
+            } else {
+                // Task not assigned to anyone, assign the task to the nominated manager
+                $task->set_value('personID', $project_manager_ID);
+            }
+
+            $task->save();
+
+            $result[] = sprintf('<li>%sCreated task <a href="%s">%d %s</a>.</li>', str_repeat("&gt;", $depth), $task->get_url(), $task->get_id(), $task->get_value('taskName'));
+
+          // Do child nodes
+            if ($taskXML->hasChildNodes()) {
+                $result = array_merge($result, import_planner_tasks($taskXML, $task->get_id(), $depth + 1, $task_allocation, $resource_people, $project_manager_ID));
+            }
+        }
+    }
+    return $result;
 }
 
 ////EXPORT FUNCTIONS
-function export_gnome_planner($projectID) {
-  $project = new project();
-  $project->set_id($projectID);
-  $project->select();
+function export_gnome_planner($projectID)
+{
+    $project = new project();
+    $project->set_id($projectID);
+    $project->select();
 
   // Note: DOM_Document is a wrapper that wraps DOMDocument for PHP5 and DomDocument for PHP4
-  $doc = get_xml_document();
-  $doc->load(ALLOC_MOD_DIR."shared".DIRECTORY_SEPARATOR."export_templates".DIRECTORY_SEPARATOR."template.planner");
+    $doc = get_xml_document();
+    $doc->load(ALLOC_MOD_DIR."shared".DIRECTORY_SEPARATOR."export_templates".DIRECTORY_SEPARATOR."template.planner");
   // General metadata
-  $rootNode = $doc->getElementsByTagName("project"); $rootNode = $rootNode->item(0);
-  $rootNode->setAttribute("company", config::get_config_item("companyName"));
+    $rootNode = $doc->getElementsByTagName("project");
+    $rootNode = $rootNode->item(0);
+    $rootNode->setAttribute("company", config::get_config_item("companyName"));
   // Get the project manager
-  $projectManager = $project->get_project_manager();
-  $rootNode->setAttribute("manager", person::get_fullname($projectManager[0]));
-  $rootNode->setAttribute("name", $project->get_value("projectName"));
-  if($project->get_value("dateActualStart")) {
-    $projectStartDate = export_planner_date(planner_date_timestamp($project->get_value("dateActualStart")));
-  } else {
-    $projectStartDate = export_planner_date(planner_date_timestamp($project->get_value("dateTargetStart")));
-  }
-  $rootNode->setAttribute("project-start", $projectStartDate);
+    $projectManager = $project->get_project_manager();
+    $rootNode->setAttribute("manager", person::get_fullname($projectManager[0]));
+    $rootNode->setAttribute("name", $project->get_value("projectName"));
+    if ($project->get_value("dateActualStart")) {
+        $projectStartDate = export_planner_date(planner_date_timestamp($project->get_value("dateActualStart")));
+    } else {
+        $projectStartDate = export_planner_date(planner_date_timestamp($project->get_value("dateTargetStart")));
+    }
+    $rootNode->setAttribute("project-start", $projectStartDate);
 
-  $resourcesUsed = array();
+    $resourcesUsed = array();
   // Export all tasks in the project
-  $taskOptions["projectIDs"] = array($project->get_id());
-  $taskOptions["return"] = "array";
-  $taskOptions["taskView"] = "byProject";
+    $taskOptions["projectIDs"] = array($project->get_id());
+    $taskOptions["return"] = "array";
+    $taskOptions["taskView"] = "byProject";
 
-  $tasks = task::get_list($taskOptions);
+    $tasks = task::get_list($taskOptions);
   // We need to sort by taskID (we assume taskIDs were assigned linearly on import) otherwise Planner will get very confused with ordering
-  foreach($tasks as $task) {
-    $taskIDs[] = $task['taskID'];
-  }
-  array_multisort($taskIDs, $tasks);
-  $taskRootNode = $doc->getElementsByTagName("tasks"); $taskRootNode = $taskRootNode->item(0);
-  foreach($tasks as $task) {
-    $taskNode = $doc->createElement("task");
-    // Use the alloc internal ID rather than pointlessly renumbering things
-    $taskNode->setAttribute("id", $task["taskID"]);
-    $taskNode->setAttribute("name", $task["taskName"]);
-    $taskNode->setAttribute("note", $task["taskDescription"]);
-
-    // Ugly date handling
-    if(!$task["dateActualStart"]) {
-      if(!$task["dateTargetStart"]) {
-        // This is a reasonably bad situation
-        $taskStartDate = time();
-      } else {
-        $taskStartDate = planner_date_timestamp($task["dateTargetStart"]);
-      }
-    } else {
-      $taskStartDate = planner_date_timestamp($task["dateActualStart"]);
+    foreach ($tasks as $task) {
+        $taskIDs[] = $task['taskID'];
     }
-    if(!$task["dateActualCompletion"]) {
-      if(!$task["dateTargetCompletion"]) {
-        //The task has to last for some amount of time, so end = start (otherwise we get end = 1970)
-        $taskEndDate = $taskStartDate;
-      } else {
-        $taskEndDate = planner_date_timestamp($task["dateTargetCompletion"]);
-      }
-    } else {
-      $taskEndDate = planner_date_timestamp($task["dateActualCompletion"]);
+    array_multisort($taskIDs, $tasks);
+    $taskRootNode = $doc->getElementsByTagName("tasks");
+    $taskRootNode = $taskRootNode->item(0);
+    foreach ($tasks as $task) {
+        $taskNode = $doc->createElement("task");
+      // Use the alloc internal ID rather than pointlessly renumbering things
+        $taskNode->setAttribute("id", $task["taskID"]);
+        $taskNode->setAttribute("name", $task["taskName"]);
+        $taskNode->setAttribute("note", $task["taskDescription"]);
+
+      // Ugly date handling
+        if (!$task["dateActualStart"]) {
+            if (!$task["dateTargetStart"]) {
+                // This is a reasonably bad situation
+                $taskStartDate = time();
+            } else {
+                $taskStartDate = planner_date_timestamp($task["dateTargetStart"]);
+            }
+        } else {
+            $taskStartDate = planner_date_timestamp($task["dateActualStart"]);
+        }
+        if (!$task["dateActualCompletion"]) {
+            if (!$task["dateTargetCompletion"]) {
+                //The task has to last for some amount of time, so end = start (otherwise we get end = 1970)
+                $taskEndDate = $taskStartDate;
+            } else {
+                $taskEndDate = planner_date_timestamp($task["dateTargetCompletion"]);
+            }
+        } else {
+            $taskEndDate = planner_date_timestamp($task["dateActualCompletion"]);
+        }
+
+      // Take a stab at the duration we need to give this task
+        $taskDuration = $taskEndDate - $taskStartDate;
+      // That's the total number of seconds, Planner expects the number of 8-hour days worth of seconds
+        $taskDuration = ($taskDuration / 86400) * 28800;
+      // note: the above doesn't account for weekends so there is a discrepancy between task durations in alloc and those in Planner, the solution is to make people work on the weekends
+
+        $taskNode->setAttribute("work", $taskDuration);
+        $taskNode->setAttribute("start", export_planner_date($taskStartDate));
+        $taskNode->setAttribute("work-start", export_planner_date($taskStartDate));
+        $taskNode->setAttribute("end", export_planner_date($taskEndDate));
+        $taskNode->setAttribute("scheduling", "fixed-work");
+
+        $constraintNode = $doc->createElement("constraint");
+        $constraintNode->setAttribute("type", "start-no-earlier-than");
+        $constraintNode->setAttribute("time", export_planner_date($taskStartDate));
+        $taskNode->appendChild($constraintNode);
+
+        if ($task["taskTypeID"] == "Milestone") {
+            $taskNode->setAttribute("type", "milestone");
+        }
+
+        $resourcesUsed[$task["taskID"]] = $task['personID'];
+
+        $taskRootNode->appendChild($taskNode);
     }
-
-    // Take a stab at the duration we need to give this task
-    $taskDuration = $taskEndDate - $taskStartDate;
-    // That's the total number of seconds, Planner expects the number of 8-hour days worth of seconds
-    $taskDuration = ($taskDuration / 86400) * 28800;
-    // note: the above doesn't account for weekends so there is a discrepancy between task durations in alloc and those in Planner, the solution is to make people work on the weekends
-
-    $taskNode->setAttribute("work", $taskDuration);
-    $taskNode->setAttribute("start", export_planner_date($taskStartDate));
-    $taskNode->setAttribute("work-start", export_planner_date($taskStartDate));
-    $taskNode->setAttribute("end", export_planner_date($taskEndDate));
-    $taskNode->setAttribute("scheduling", "fixed-work");
-
-    $constraintNode = $doc->createElement("constraint");
-    $constraintNode->setAttribute("type", "start-no-earlier-than");
-    $constraintNode->setAttribute("time", export_planner_date($taskStartDate));
-    $taskNode->appendChild($constraintNode);
-
-    if($task["taskTypeID"] == "Milestone") { 
-      $taskNode->setAttribute("type", "milestone");
-    }
-
-    $resourcesUsed[$task["taskID"]] = $task['personID'];
-
-    $taskRootNode->appendChild($taskNode);
-  }
 
   // Now do the resources and their linkage to tasks
-  $resourcesRootNode = $doc->getElementsByTagName("resources"); $resourcesRootNode = $resourcesRootNode->item(0);
-  $allocationsRootNode = $doc->getElementsByTagName("allocations"); $allocationsRootNode = $allocationsRootNode->item(0);
+    $resourcesRootNode = $doc->getElementsByTagName("resources");
+    $resourcesRootNode = $resourcesRootNode->item(0);
+    $allocationsRootNode = $doc->getElementsByTagName("allocations");
+    $allocationsRootNode = $allocationsRootNode->item(0);
 
-  $resources = array();       //Store the users that need to be added to <resources>
+    $resources = array();       //Store the users that need to be added to <resources>
 
-  foreach($resourcesUsed as $taskID => $resourceID ) {
-    if(isset($resources[$resourceID])) {
-      $person = $resources[$resourceID];
-    } else {
-      $person = new person();
-      $person->set_id($resourceID);
-      $person->select();
+    foreach ($resourcesUsed as $taskID => $resourceID) {
+        if (isset($resources[$resourceID])) {
+            $person = $resources[$resourceID];
+        } else {
+            $person = new person();
+            $person->set_id($resourceID);
+            $person->select();
 
-      $resources[$resourceID] = $person;
+            $resources[$resourceID] = $person;
 
-      // Add this person to <resources>
-      $resourceNode = $doc->createElement("resource");
-      $resourceNode->setAttribute("id", $person->get_id());
-      $resourceNode->setAttribute("name", $person->get_value("firstName") . " " . $person->get_value("surname"));
-      $resourceNode->setAttribute("short-name", $person->get_value("username"));
-      $resourceNode->setAttribute("email", $person->get_value("emailAddress"));
-      $resourceNode->setAttribute("units", "0");
-      $resourceNode->setAttribute("type", "1");       //1 means "Work" (the other option being Materials)
-      $resourcesRootNode->appendChild($resourceNode);
+          // Add this person to <resources>
+            $resourceNode = $doc->createElement("resource");
+            $resourceNode->setAttribute("id", $person->get_id());
+            $resourceNode->setAttribute("name", $person->get_value("firstName") . " " . $person->get_value("surname"));
+            $resourceNode->setAttribute("short-name", $person->get_value("username"));
+            $resourceNode->setAttribute("email", $person->get_value("emailAddress"));
+            $resourceNode->setAttribute("units", "0");
+            $resourceNode->setAttribute("type", "1");       //1 means "Work" (the other option being Materials)
+            $resourcesRootNode->appendChild($resourceNode);
+        }
+
+      //Now the actual allocation
+        $allocationNode = $doc->createElement("allocation");
+      //Units means "percentage working on this" for which alloc has no analgoue
+        $allocationNode->setAttribute("units", "100");
+        $allocationNode->setAttribute("task-id", $taskID);
+        $allocationNode->setAttribute("resource-id", $resourceID);
+        $allocationsRootNode->appendChild($allocationNode);
     }
 
-    //Now the actual allocation
-    $allocationNode = $doc->createElement("allocation");
-    //Units means "percentage working on this" for which alloc has no analgoue
-    $allocationNode->setAttribute("units", "100");
-    $allocationNode->setAttribute("task-id", $taskID);
-    $allocationNode->setAttribute("resource-id", $resourceID);
-    $allocationsRootNode->appendChild($allocationNode);
-  }
-
-  return $doc->saveXML();
+    return $doc->saveXML();
 }
 
-function export_csv($projectID) {
-  $project = new project();
-  $project->set_id($projectID);
-  $project->select();
+function export_csv($projectID)
+{
+    $project = new project();
+    $project->set_id($projectID);
+    $project->select();
 
-  $retstr = '"Task Name","Estimated Time","Assignee"';
+    $retstr = '"Task Name","Estimated Time","Assignee"';
   // Export all tasks in the project
-  $taskOptions["projectIDs"] = array($project->get_id());
-  $taskOptions["return"] = "array";
-  $taskOptions["taskView"] = "byProject";
-  $tasks = task::get_list($taskOptions);
+    $taskOptions["projectIDs"] = array($project->get_id());
+    $taskOptions["return"] = "array";
+    $taskOptions["taskView"] = "byProject";
+    $tasks = task::get_list($taskOptions);
 
   // Sort by taskID--we assume taskIDs were assigned linearly on import/creation--so as to produce an identical file
-  foreach($tasks as $task) {
-    $taskIDs[] = $task['taskID'];
-  }
-  array_multisort($taskIDs, $tasks);
-  foreach($tasks as $task) {
-    $assignee = new person();
-    $assignee->set_id($task['personID']);
-    $assignee->select();
+    foreach ($tasks as $task) {
+        $taskIDs[] = $task['taskID'];
+    }
+    array_multisort($taskIDs, $tasks);
+    foreach ($tasks as $task) {
+        $assignee = new person();
+        $assignee->set_id($task['personID']);
+        $assignee->select();
 
-    $estimatedHours = $task['timeExpected'];
-    is_numeric($estimatedHours) or $estimatedHours = 0;
+        $estimatedHours = $task['timeExpected'];
+        is_numeric($estimatedHours) or $estimatedHours = 0;
 
-    $retstr .= "\n" . export_escape_csv($task['taskName']) . ',' . export_escape_csv($estimatedHours) . ',' . export_escape_csv($assignee->get_name(array("format"=>"nick")));
-  }
+        $retstr .= "\n" . export_escape_csv($task['taskName']) . ',' . export_escape_csv($estimatedHours) . ',' . export_escape_csv($assignee->get_name(array("format"=>"nick")));
+    }
 
-  return $retstr;
+    return $retstr;
 }
 
 ////GENERAL HELPER FUNCTIONS
-function import_planner_date($indate) {
+function import_planner_date($indate)
+{
   //Takes a GNOME Planner formatted date (YYYYMMDDTHHMMSSZ, where "T" and "Z" are literal) and converts it into a MySQL formatted date (Y-m-d H:i:s)
-  $year = substr($indate, 0, 4);
-  $month = substr($indate, 4, 2);
-  $day = substr($indate, 6, 2);
+    $year = substr($indate, 0, 4);
+    $month = substr($indate, 4, 2);
+    $day = substr($indate, 6, 2);
   // skip the literal "T"
-  $hour = substr($indate, 9, 2);
-  $minute = substr($indate, 11, 2);
-  $second = substr($indate, 13, 2);
-  return $year . "-" . $month . "-" . $day . " " . $hour . ":" . $minute . ":" . $second;
+    $hour = substr($indate, 9, 2);
+    $minute = substr($indate, 11, 2);
+    $second = substr($indate, 13, 2);
+    return $year . "-" . $month . "-" . $day . " " . $hour . ":" . $minute . ":" . $second;
 }
 
-function planner_date_timestamp($indate) {
+function planner_date_timestamp($indate)
+{
   //Takes a MySQL formatted date (YYYY-MM-DD HH:MM:SS) and converts it into a Unix timestamp
-  $parts = explode(" ", $indate);
-  list($year, $month, $day) = explode("-", $parts[0]);
-  if(count($parts) > 0) {
-    list($hour, $minute, $second) = explode(":", $parts[1]);
-  } else {
-    $hour = 0;
-    $minute = 0;
-    $second = 0;
-  }
-  return mktime(intval($hour), intval($minute), intval($second), intval($month), intval($day), intval($year));
-}
-
-function export_planner_date($timestamp) {
-  //Takes unix timestamp and returns a GNOME Planner formatted date (YYYYMMDDTHHMMSSZ)
-  return date("Ymd\\THis\\Z", $timestamp);
-}
-
-function import_find_username($candidates) {
-  //Attempts to find a Person record that corresponds to one of the names specified in the $candidates array. Returns false on failure.
-  global $db;
-  //Our aim is just to find one record that matches the username
-  foreach($candidates as $candidate) {
-    $query = prepare("SELECT * FROM person WHERE username = '%s'", $candidate);
-    $db->query($query);
-    if($db->next_record()) {
-      $person = new person();
-      $person->read_db_record($db);
-      $person->select();
-      return $person;
+    $parts = explode(" ", $indate);
+    list($year, $month, $day) = explode("-", $parts[0]);
+    if (count($parts) > 0) {
+        list($hour, $minute, $second) = explode(":", $parts[1]);
+    } else {
+        $hour = 0;
+        $minute = 0;
+        $second = 0;
     }
-  }
+    return mktime(intval($hour), intval($minute), intval($second), intval($month), intval($day), intval($year));
+}
+
+function export_planner_date($timestamp)
+{
+  //Takes unix timestamp and returns a GNOME Planner formatted date (YYYYMMDDTHHMMSSZ)
+    return date("Ymd\\THis\\Z", $timestamp);
+}
+
+function import_find_username($candidates)
+{
+  //Attempts to find a Person record that corresponds to one of the names specified in the $candidates array. Returns false on failure.
+    global $db;
+  //Our aim is just to find one record that matches the username
+    foreach ($candidates as $candidate) {
+        $query = prepare("SELECT * FROM person WHERE username = '%s'", $candidate);
+        $db->query($query);
+        if ($db->next_record()) {
+            $person = new person();
+            $person->read_db_record($db);
+            $person->select();
+            return $person;
+        }
+    }
 
   //No such user
-  return false;
+    return false;
 }
 
-function export_escape_csv($str) {
+function export_escape_csv($str)
+{
   // Escapes the string suitably for CSV
-  $str = str_replace('"', '""', $str);
-  return '"' . $str . '"';
+    $str = str_replace('"', '""', $str);
+    return '"' . $str . '"';
 }
 
 //// XML WRAPPER FUNCTIONS and CLASSES
-function get_xml_document() {
+function get_xml_document()
+{
   //construct an appropriate XMLDocument class
-  if(version_compare(PHP_VERSION, '5.0.0', '<')) {
-    // DOM_XML_Wrapper_Document is a wrapper that wraps PHP 4's DomDocument
-    echo "using php 4 compat";
-    return new DOM_XML_Wrapper_Document();
-  } else {
-    return new DOMDocument();
-  }
+    if (version_compare(PHP_VERSION, '5.0.0', '<')) {
+      // DOM_XML_Wrapper_Document is a wrapper that wraps PHP 4's DomDocument
+        echo "using php 4 compat";
+        return new DOM_XML_Wrapper_Document();
+    } else {
+        return new DOMDocument();
+    }
 }
 
-class DOM_XML_Wrapper_Document {
-  function load($filename) {
-    $this->dom_xml_doc = domxml_open_file($filename);
-    return !($this->dom_xml_doc === FALSE);
-  }
+class DOM_XML_Wrapper_Document
+{
+    function load($filename)
+    {
+        $this->dom_xml_doc = domxml_open_file($filename);
+        return !($this->dom_xml_doc === false);
+    }
 
-  function getElementsByTagName($tagname) {
-    return new DOM_XML_Wrapper_NodeList($this->dom_xml_doc->get_elements_by_tagname($tagname));
-  }
+    function getElementsByTagName($tagname)
+    {
+        return new DOM_XML_Wrapper_NodeList($this->dom_xml_doc->get_elements_by_tagname($tagname));
+    }
 
-  function createElement($element_name) {
-    return $this->dom_xml_doc->create_element($element_name);
-  }
+    function createElement($element_name)
+    {
+        return $this->dom_xml_doc->create_element($element_name);
+    }
 
-  function saveXML() {
-    return $this->dom_xml_doc->dump_mem();
-  }
+    function saveXML()
+    {
+        return $this->dom_xml_doc->dump_mem();
+    }
 }
 
-class DOM_XML_Wrapper_Node {
+class DOM_XML_Wrapper_Node
+{
   // Technically this class implements the functionality of both DOMNode and DOMElement
   // For simplicity of the wrapper we have the function as part of one object
-  function DOM_XML_Wrapper_Node($original_node) {
-    $this->node = $original_node;
+    function DOM_XML_Wrapper_Node($original_node)
+    {
+        $this->node = $original_node;
 
-    $this->childNodes = new DOM_XML_Wrapper_NodeList($this->node->child_nodes());
-    $this->nodeType = $this->node->node_type();
-    if($this->nodeType == XML_ELEMENT_NODE) {
-      $this->tagName = $this->node->tagname();
+        $this->childNodes = new DOM_XML_Wrapper_NodeList($this->node->child_nodes());
+        $this->nodeType = $this->node->node_type();
+        if ($this->nodeType == XML_ELEMENT_NODE) {
+            $this->tagName = $this->node->tagname();
+        }
     }
-  }
 
-  function setAttribute($attr_name, $attr_value) {
-    $this->node->set_attribute($attr_name, $attr_value);
-  }
+    function setAttribute($attr_name, $attr_value)
+    {
+        $this->node->set_attribute($attr_name, $attr_value);
+    }
 
-  function getAttribute($attr_name) {
-    return $this->node->get_attribute($attr_name);
-  }
+    function getAttribute($attr_name)
+    {
+        return $this->node->get_attribute($attr_name);
+    }
 
-  function hasAttribute($attr_name) {
-    return $this->node->has_attribute($attr_name);
-  }
+    function hasAttribute($attr_name)
+    {
+        return $this->node->has_attribute($attr_name);
+    }
 
-  function hasChildNodes() {
-    return $this->node->has_child_nodes();
-  }
+    function hasChildNodes()
+    {
+        return $this->node->has_child_nodes();
+    }
 
-  function appendChild($newNode) {
-    return $this->node->append_child($newNode);
-  }
-
+    function appendChild($newNode)
+    {
+        return $this->node->append_child($newNode);
+    }
 }
 
-function DOMNodeWrapper($node) {
-  return new DOM_XML_Wrapper_Node($node);
+function DOMNodeWrapper($node)
+{
+    return new DOM_XML_Wrapper_Node($node);
 }
 
-class DOM_XML_Wrapper_NodeList {
-  function DOM_XML_Wrapper_NodeList($in_array) {
-    $this->items = array_map("DOMNodeWrapper", $in_array);
-    $this->length = count($in_array);
-  }
+class DOM_XML_Wrapper_NodeList
+{
+    function DOM_XML_Wrapper_NodeList($in_array)
+    {
+        $this->items = array_map("DOMNodeWrapper", $in_array);
+        $this->length = count($in_array);
+    }
 
-  function item($index) {
-    return $this->items[$index];
-  }
+    function item($index)
+    {
+        return $this->items[$index];
+    }
 }
-
-
-?>

--- a/project/lib/init.php
+++ b/project/lib/init.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,12 +23,12 @@
 
 require_once(dirname(__FILE__)."/import_export.inc.php");
 
-class project_module extends module {
-  var $module = "project";
-  var $db_entities = array("project"
+class project_module extends module
+{
+    var $module = "project";
+    var $db_entities = array("project"
                          , "projectPerson"
                          , "projectCommissionPerson"
                          );
-  var $home_items = array("project_list_home_item");
+    var $home_items = array("project_list_home_item");
 }
-?>

--- a/project/lib/project.inc.php
+++ b/project/lib/project.inc.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,12 +23,13 @@
 define("PERM_PROJECT_VIEW_TASK_ALLOCS", 256);
 define("PERM_PROJECT_ADD_TASKS", 512);
 
-class project extends db_entity {
-  public $classname = "project";
-  public $data_table = "project";
-  public $display_field_name = "projectName";
-  public $key_field = "projectID";
-  public $data_fields = array("projectName"
+class project extends db_entity
+{
+    public $classname = "project";
+    public $data_table = "project";
+    public $display_field_name = "projectName";
+    public $key_field = "projectID";
+    public $data_fields = array("projectName"
                              ,"projectShortName"
                              ,"projectComments"
                              ,"clientID"
@@ -58,420 +59,451 @@ class project extends db_entity {
                              ,"defaultTimeSheetRateUnitID"
                              );
 
-  public $permissions = array(PERM_PROJECT_VIEW_TASK_ALLOCS => "view task allocations"
+    public $permissions = array(PERM_PROJECT_VIEW_TASK_ALLOCS => "view task allocations"
                              ,PERM_PROJECT_ADD_TASKS => "add tasks");
 
-  function save() {
-    global $TPL;
-    // The data prior to the save
-    $old = $this->all_row_fields;
-    $ids = '';$commar = '';
-    $db = new db_alloc();
+    function save()
+    {
+        global $TPL;
+      // The data prior to the save
+        $old = $this->all_row_fields;
+        $ids = '';
+        $commar = '';
+        $db = new db_alloc();
 
-    // If we're archiving the project, then archive the tasks.
-    if ($old["projectStatus"] != "Archived" && $this->get_value("projectStatus") == "Archived") {
-      $q = prepare("SELECT taskID FROM task WHERE projectID = %d AND SUBSTRING(taskStatus,1,6) != 'closed'",$this->get_id());
-      $q1 = $db->query($q);
-      while ($row = $db->row($q1)) {
-        $q = prepare("call change_task_status(%d,'closed_archived')",$row["taskID"]);
+      // If we're archiving the project, then archive the tasks.
+        if ($old["projectStatus"] != "Archived" && $this->get_value("projectStatus") == "Archived") {
+            $q = prepare("SELECT taskID FROM task WHERE projectID = %d AND SUBSTRING(taskStatus,1,6) != 'closed'", $this->get_id());
+            $q1 = $db->query($q);
+            while ($row = $db->row($q1)) {
+                $q = prepare("call change_task_status(%d,'closed_archived')", $row["taskID"]);
+                $db->query($q);
+                $ids.= $commar.$row["taskID"];
+                $commar = ", ";
+            }
+            $ids and $TPL["message_good"][] = "All open and pending tasks (".$ids.") have had their status changed to Closed: Archived.";
+
+        // Else if we're un-archiving the project, then un-archive the tasks.
+        } else if ($old["projectStatus"] == "Archived" && $this->get_value("projectStatus") != "Archived") {
+            $q = prepare("SELECT taskID FROM task WHERE projectID = %d AND taskStatus = 'closed_archived'", $this->get_id());
+            $q1 = $db->query($q);
+            while ($row = $db->row($q1)) {
+                $q = prepare("call change_task_status(%d,get_most_recent_non_archived_taskStatus(%d))", $row["taskID"], $row["taskID"]);
+                $db->query($q);
+                $ids.= $commar.$row["taskID"];
+                $commar = ", ";
+            }
+            $ids and $TPL["message_good"][] = "All archived tasks (".$ids.") have been set back to their former task status.";
+        }
+
+        $TPL["message"] or $TPL["message_good"][] = "Project saved.";
+        return parent::save();
+    }
+
+    function delete()
+    {
+        $q = prepare("DELETE from projectPerson WHERE projectID = %d", $this->get_id());
+        $db = new db_alloc();
         $db->query($q);
-        $ids.= $commar.$row["taskID"];
-        $commar = ", ";
-      }
-      $ids and $TPL["message_good"][] = "All open and pending tasks (".$ids.") have had their status changed to Closed: Archived.";
-
-    // Else if we're un-archiving the project, then un-archive the tasks.
-    } else if ($old["projectStatus"] == "Archived" && $this->get_value("projectStatus") != "Archived") {
-      $q = prepare("SELECT taskID FROM task WHERE projectID = %d AND taskStatus = 'closed_archived'",$this->get_id());
-      $q1 = $db->query($q);
-      while ($row = $db->row($q1)) {
-        $q = prepare("call change_task_status(%d,get_most_recent_non_archived_taskStatus(%d))",$row["taskID"],$row["taskID"]);
-        $db->query($q);
-        $ids.= $commar.$row["taskID"];
-        $commar = ", ";
-      }
-      $ids and $TPL["message_good"][] = "All archived tasks (".$ids.") have been set back to their former task status.";
+        return parent::delete();
     }
 
-    $TPL["message"] or $TPL["message_good"][] = "Project saved.";
-    return parent::save();
-  }
+    function get_url()
+    {
+        global $sess;
+        $sess or $sess = new session();
 
-  function delete() { 
-    $q = prepare("DELETE from projectPerson WHERE projectID = %d",$this->get_id()); 
-    $db = new db_alloc();
-    $db->query($q);
-    return parent::delete();
-  }
+        $url = "project/project.php?projectID=".$this->get_id();
 
-  function get_url() {
-    global $sess;
-    $sess or $sess = new session();
+        if ($sess->Started()) {
+            $url = $sess->url(SCRIPT_PATH.$url);
 
-    $url = "project/project.php?projectID=".$this->get_id();
-
-    if ($sess->Started()) {
-      $url = $sess->url(SCRIPT_PATH.$url);
-
-    // This for urls that are emailed
-    } else {
-      static $prefix;
-      $prefix or $prefix = config::get_config_item("allocURL");
-      $url = $prefix.$url;
-    }
-    return $url;
-  }
-
-  function get_name($_FORM=array()) {
-    if ($_FORM["showShortProjectLink"] && $this->get_value("projectShortName")) {
-      $field = "projectShortName";
-    } else {
-      $field = "projectName";
+        // This for urls that are emailed
+        } else {
+            static $prefix;
+            $prefix or $prefix = config::get_config_item("allocURL");
+            $url = $prefix.$url;
+        }
+        return $url;
     }
 
-    if ($_FORM["return"] == "html") {
-      return $this->get_value($field,DST_HTML_DISPLAY);
-    } else {
-      return $this->get_value($field);
+    function get_name($_FORM = array())
+    {
+        if ($_FORM["showShortProjectLink"] && $this->get_value("projectShortName")) {
+            $field = "projectShortName";
+        } else {
+            $field = "projectName";
+        }
+
+        if ($_FORM["return"] == "html") {
+            return $this->get_value($field, DST_HTML_DISPLAY);
+        } else {
+            return $this->get_value($field);
+        }
     }
-  }
 
-  function get_project_link($_FORM=array()) {
-    global $TPL;
-    $_FORM["return"] or $_FORM["return"] = "html";
-    return "<a href=\"".$TPL["url_alloc_project"]."projectID=".$this->get_id()."\">".$this->get_name($_FORM)."</a>";
-  }
+    function get_project_link($_FORM = array())
+    {
+        global $TPL;
+        $_FORM["return"] or $_FORM["return"] = "html";
+        return "<a href=\"".$TPL["url_alloc_project"]."projectID=".$this->get_id()."\">".$this->get_name($_FORM)."</a>";
+    }
 
-  function is_owner($person = "") {
-    $current_user = &singleton("current_user");
-    $person or $person = $current_user;
+    function is_owner($person = "")
+    {
+        $current_user = &singleton("current_user");
+        $person or $person = $current_user;
 
-    // If brand new record then let it be created.
-    if (!$this->get_id())
-      return true;
+      // If brand new record then let it be created.
+        if (!$this->get_id()) {
+            return true;
+        }
 
-    // Else check that user has isManager or timeSheetRecipient permission for this project
-    return is_object($person) && ($person->have_role("manage") || $this->has_project_permission($person, array("isManager","timeSheetRecipient")));
-  }
+      // Else check that user has isManager or timeSheetRecipient permission for this project
+        return is_object($person) && ($person->have_role("manage") || $this->has_project_permission($person, array("isManager","timeSheetRecipient")));
+    }
 
-  function has_project_permission($person = "", $permissions = array()) {
-    // Check that user has permission for this project
-    $current_user = &singleton("current_user");
-    $person or $person = $current_user;
-    if (is_object($person)) {
-      $permissions and $p = " AND ".sprintf_implode("ppr.roleHandle = '%s'",$permissions);
+    function has_project_permission($person = "", $permissions = array())
+    {
+      // Check that user has permission for this project
+        $current_user = &singleton("current_user");
+        $person or $person = $current_user;
+        if (is_object($person)) {
+            $permissions and $p = " AND ".sprintf_implode("ppr.roleHandle = '%s'", $permissions);
 
-      $query = prepare("SELECT personID, projectID, pp.roleID, ppr.roleName, ppr.roleHandle 
+            $query = prepare(
+                "SELECT personID, projectID, pp.roleID, ppr.roleName, ppr.roleHandle 
                           FROM projectPerson pp 
                      LEFT JOIN role ppr ON ppr.roleID = pp.roleID 
-                         WHERE projectID = '%d' and personID = '%d' ".$p
-                      ,$this->get_id(), $person->get_id());
-      #echo "<br><br>".$query;
+                         WHERE projectID = '%d' and personID = '%d' ".$p,
+                $this->get_id(),
+                $person->get_id()
+            );
+          #echo "<br><br>".$query;
 
-      $db = new db_alloc();
-      $db->query($query);
-      return $db->next_record();
+            $db = new db_alloc();
+            $db->query($query);
+            return $db->next_record();
+        }
     }
-  }
 
-  function get_timeSheetRecipients() {
-    $rows = $this->get_project_people_by_role("timeSheetRecipient");
+    function get_timeSheetRecipients()
+    {
+        $rows = $this->get_project_people_by_role("timeSheetRecipient");
 
-    // Fallback time sheet manager person
-    if (!$rows) {
-      $people = config::get_config_item("defaultTimeSheetManagerList");
-      $people and $rows = $people;
+      // Fallback time sheet manager person
+        if (!$rows) {
+            $people = config::get_config_item("defaultTimeSheetManagerList");
+            $people and $rows = $people;
+        }
+        return $rows;
     }
-    return $rows;
-  }
 
-  function get_project_people_by_role($role="") {
-    $rows = array();
-    $q = prepare("SELECT projectPerson.personID as personID
+    function get_project_people_by_role($role = "")
+    {
+        $rows = array();
+        $q = prepare("SELECT projectPerson.personID as personID
                     FROM projectPerson
                LEFT JOIN role ON projectPerson.roleID = role.roleID 
-                   WHERE projectPerson.projectID = %d AND role.roleHandle = '%s'",$this->get_id(),$role);
-    $db = new db_alloc();
-    $db->query($q);
-    while ($db->next_record()) {
-      $rows[] = $db->f("personID");
-    }
-    return $rows;
-  }
-
-  function get_project_manager() {
-    // Finds either the time sheet recipient or the project manager
-    $projectManager = $this->get_project_people_by_role("timeSheetRecipient");
-    if(!count($projectManager)) {
-      $projectManager = $this->get_project_people_by_role("isManager");
-    }
-    if(!count($projectManager)) {
-      return false;
-    } else {
-      return $projectManager[0];
-    }
-  }
-
-  function get_navigation_links($ops=array()) {
-    global $taskID;
-    global $TPL;
-    $current_user = &singleton("current_user");
-
-    // Client 
-    if ($this->get_value("clientID")) {  
-      $url = $TPL["url_alloc_client"]."clientID=".$this->get_value("clientID");
-      $links[] = "<a href=\"$url\" class=\"nobr noprint\">Client</a>";
+                   WHERE projectPerson.projectID = %d AND role.roleHandle = '%s'", $this->get_id(), $role);
+        $db = new db_alloc();
+        $db->query($q);
+        while ($db->next_record()) {
+            $rows[] = $db->f("personID");
+        }
+        return $rows;
     }
 
-    // Project
-    if ($ops["showProject"]) {
-      $url = $TPL["url_alloc_project"]."projectID=".$this->get_id();
-      $links[] = "<a href=\"$url\" class=\"nobr noprint\">Project</a>";
+    function get_project_manager()
+    {
+      // Finds either the time sheet recipient or the project manager
+        $projectManager = $this->get_project_people_by_role("timeSheetRecipient");
+        if (!count($projectManager)) {
+            $projectManager = $this->get_project_people_by_role("isManager");
+        }
+        if (!count($projectManager)) {
+            return false;
+        } else {
+            return $projectManager[0];
+        }
     }
 
-    // Tasks
-    if ($this->have_perm()) {
-      $url = $TPL["url_alloc_taskList"]."applyFilter=1&amp;taskStatus=open&amp;taskView=byProject&amp;projectID=".$this->get_id();
-      $links[] = "<a href=\"$url\" class=\"nobr noprint\">Tasks</a>";
-    } 
+    function get_navigation_links($ops = array())
+    {
+        global $taskID;
+        global $TPL;
+        $current_user = &singleton("current_user");
 
-    // Graph
-    if ($this->have_perm()) {
-      $url = $TPL["url_alloc_projectGraph"]."applyFilter=1&projectID=".$this->get_id()."&taskStatus=open&showTaskID=true";
-      $links[] = "<a href=\"$url\" class=\"nobr noprint\">Graph</a>";
+      // Client
+        if ($this->get_value("clientID")) {
+            $url = $TPL["url_alloc_client"]."clientID=".$this->get_value("clientID");
+            $links[] = "<a href=\"$url\" class=\"nobr noprint\">Client</a>";
+        }
+
+      // Project
+        if ($ops["showProject"]) {
+            $url = $TPL["url_alloc_project"]."projectID=".$this->get_id();
+            $links[] = "<a href=\"$url\" class=\"nobr noprint\">Project</a>";
+        }
+
+      // Tasks
+        if ($this->have_perm()) {
+            $url = $TPL["url_alloc_taskList"]."applyFilter=1&amp;taskStatus=open&amp;taskView=byProject&amp;projectID=".$this->get_id();
+            $links[] = "<a href=\"$url\" class=\"nobr noprint\">Tasks</a>";
+        }
+
+      // Graph
+        if ($this->have_perm()) {
+            $url = $TPL["url_alloc_projectGraph"]."applyFilter=1&projectID=".$this->get_id()."&taskStatus=open&showTaskID=true";
+            $links[] = "<a href=\"$url\" class=\"nobr noprint\">Graph</a>";
+        }
+
+      // Allocation
+        if ($this->have_perm(PERM_PROJECT_VIEW_TASK_ALLOCS)) {
+            $url = $TPL["url_alloc_personGraph"]."projectID=".$this->get_id();
+            $links[] = "<a href=\"$url\" class=\"nobr noprint\">Allocation</a>";
+        }
+
+      // To Time Sheet
+        if ($this->have_perm(PERM_PROJECT_ADD_TASKS)) {
+            if ($ops["taskID"]) {
+                $extra = "&taskID=".$ops["taskID"];
+            }
+            $url = $TPL["url_alloc_timeSheet"]."newTimeSheet_projectID=".$this->get_id().$extra;
+            $links[] = "<a href=\"$url\" class=\"nobr noprint\">Time Sheet</a>";
+        }
+
+      // New Task
+        if ($this->have_perm(PERM_PROJECT_ADD_TASKS)) {
+            $url = $TPL["url_alloc_task"]."projectID=".$this->get_id();
+            $links[] = "<a href=\"$url\" class=\"nobr noprint\">New Task</a>";
+        }
+
+      // Join links up with space
+        if (is_array($links)) {
+            return implode(" ", $links);
+        }
     }
 
-    // Allocation
-    if ($this->have_perm(PERM_PROJECT_VIEW_TASK_ALLOCS)) {
-      $url = $TPL["url_alloc_personGraph"]."projectID=".$this->get_id();
-      $links[] = "<a href=\"$url\" class=\"nobr noprint\">Allocation</a>";
-    } 
+    public static function get_project_type_query($type = "mine", $personID = false, $projectStatus = false)
+    {
+        $current_user = &singleton("current_user");
+        $type or $type = "mine";
+        $personID or $personID = $current_user->get_id();
+        $projectStatus and $projectStatus_sql = prepare(" AND project.projectStatus = '%s' ", $projectStatus);
 
-    // To Time Sheet
-    if ($this->have_perm(PERM_PROJECT_ADD_TASKS)) {
-      if ($ops["taskID"]) {
-        $extra = "&taskID=".$ops["taskID"];
-      }
-      $url = $TPL["url_alloc_timeSheet"]."newTimeSheet_projectID=".$this->get_id().$extra;
-      $links[] = "<a href=\"$url\" class=\"nobr noprint\">Time Sheet</a>";
-    }
-
-    // New Task
-    if ($this->have_perm(PERM_PROJECT_ADD_TASKS)) {
-      $url = $TPL["url_alloc_task"]."projectID=".$this->get_id();
-      $links[] = "<a href=\"$url\" class=\"nobr noprint\">New Task</a>";
-    }
-
-    // Join links up with space
-    if (is_array($links)) {
-      return implode(" ",$links);
-    }
-  }
-
-  public static function get_project_type_query($type="mine",$personID=false,$projectStatus=false) {
-    $current_user = &singleton("current_user");
-    $type or $type = "mine";
-    $personID or $personID = $current_user->get_id();
-    $projectStatus and $projectStatus_sql = prepare(" AND project.projectStatus = '%s' ",$projectStatus);
-
-    if ($type == "mine") {
-      $q = prepare("SELECT project.projectID, project.projectName
+        if ($type == "mine") {
+            $q = prepare(
+                "SELECT project.projectID, project.projectName
                       FROM project
                  LEFT JOIN projectPerson ON project.projectID = projectPerson.projectID
                  LEFT JOIN role ON projectPerson.roleID = role.roleID
                      WHERE projectPerson.personID = '%d' ".$projectStatus_sql."
                   GROUP BY projectID 
-                  ORDER BY project.projectName"
-                  ,$personID);
-
-    } else if ($type == "pm") {
-      $q = prepare("SELECT project.projectID, project.projectName
+                  ORDER BY project.projectName",
+                $personID
+            );
+        } else if ($type == "pm") {
+            $q = prepare(
+                "SELECT project.projectID, project.projectName
                       FROM project
                  LEFT JOIN projectPerson ON project.projectID = projectPerson.projectID
                  LEFT JOIN role ON projectPerson.roleID = role.roleID
                      WHERE projectPerson.personID = '%d' ".$projectStatus_sql."
                        AND role.roleHandle = 'isManager' 
                   GROUP BY projectID 
-                  ORDER BY project.projectName"
-                  ,$personID);
-
-    } else if ($type == "tsm") {
-      $q = prepare("SELECT project.projectID, project.projectName
+                  ORDER BY project.projectName",
+                $personID
+            );
+        } else if ($type == "tsm") {
+            $q = prepare(
+                "SELECT project.projectID, project.projectName
                       FROM project
                  LEFT JOIN projectPerson ON project.projectID = projectPerson.projectID
                  LEFT JOIN role ON projectPerson.roleID = role.roleID
                      WHERE projectPerson.personID = '%d' ".$projectStatus_sql."
                        AND role.roleHandle = 'timeSheetRecipient' 
                   GROUP BY projectID 
-                  ORDER BY project.projectName"
-                  ,$personID);
-
-   } else if ($type == "pmORtsm") {
-      $q = prepare("SELECT project.projectID, project.projectName
+                  ORDER BY project.projectName",
+                $personID
+            );
+        } else if ($type == "pmORtsm") {
+            $q = prepare(
+                "SELECT project.projectID, project.projectName
                       FROM project
                  LEFT JOIN projectPerson ON project.projectID = projectPerson.projectID
                  LEFT JOIN role ON projectPerson.roleID = role.roleID
                      WHERE projectPerson.personID = '%d' ".$projectStatus_sql."
                        AND (role.roleHandle = 'isManager' or role.roleHandle = 'timeSheetRecipient')
                   GROUP BY projectID 
-                  ORDER BY project.projectName"
-                  ,$personID);
-
-    } else if ($type == "all") {
-      $q = prepare("SELECT projectID,projectName FROM project ORDER BY projectName");
-
-    } else if ($type) {
-      $q = prepare("SELECT projectID,projectName FROM project WHERE project.projectStatus = '%s' ORDER BY projectName",$type);
-    }
-    return $q;
-  }
-
-  function get_list_by_client($clientID=false,$onlymine=false) {
-    $current_user = &singleton("current_user");
-    $clientID and $options["clientID"] = $clientID;
-    $options["projectStatus"] = "Current";
-    $options["showProjectType"] = true;
-    if ($onlymine) {
-      $options["personID"] = $current_user->get_id();
-    }
-    $ops = project::get_list($options);
-    return array_kv($ops,"projectID","label");
-  }
-
-  function get_list_dropdown($type="mine",$projectIDs=array()) {
-    $options = project::get_list_dropdown_options($type,$projectIDs);
-    return "<select name=\"projectID[]\" size=\"9\" style=\"width:275px;\" multiple=\"true\">".$options."</select>";
-  }
-
-  function get_list_dropdown_options($type="mine",$projectIDs=array(), $maxlength=35) {
-    $db = new db_alloc();
-    $q = project::get_project_type_query($type);
-    // Project dropdown
-    $db->query($q);
-    while ($db->next_record()) {
-      $ops[$db->f("projectID")] = $db->f("projectName");
-    }
-    return page::select_options($ops, $projectIDs, $maxlength);
-  }
-
-  function get_dropdown_by_client($clientID=false,$onlymine=false) {
-    if ($clientID) {
-      $ops = "<select id=\"projectID\" name=\"projectID\"><option></option>";
-      $o = project::get_list_by_client($clientID,$onlymine);
-      is_object($this) && $this->get_id() and $o[$this->get_id()] = $this->get_value("projectName");
-      $ops.= page::select_options($o,$this->get_id())."</select>";
-    } else {
-      $ops = "<select id=\"projectID\" name=\"projectID\"><option></option>";
-      $o = project::get_list_by_client(null,$onlymine);
-      is_object($this) and $this->get_id() and $o[$this->get_id()] = $this->get_value("projectName");
-      $ops.= page::select_options($o,$this->get_id())."</select>";
-      #$ops.= project::get_list_dropdown_options("curr",$this->get_id(),100)."</select>";
-    }
-    return $ops;
-  }
-
-  function has_attachment_permission($person) {
-    return $this->has_project_permission($person);
-  }
-
-  function has_attachment_permission_delete($person) {
-    return $this->has_project_permission($person,array("isManager"));
-  }
-
-  public static function get_list_filter($filter=array()) {
-    $current_user = &singleton("current_user");
-
-    // If they want starred, load up the projectID filter element
-    if ($filter["starred"]) {
-      foreach ((array)$current_user->prefs["stars"]["project"] as $k=>$v) {
-        $filter["projectID"][] = $k;
-      }
-      is_array($filter["projectID"]) or $filter["projectID"][] = -1;
+                  ORDER BY project.projectName",
+                $personID
+            );
+        } else if ($type == "all") {
+            $q = prepare("SELECT projectID,projectName FROM project ORDER BY projectName");
+        } else if ($type) {
+            $q = prepare("SELECT projectID,projectName FROM project WHERE project.projectStatus = '%s' ORDER BY projectName", $type);
+        }
+        return $q;
     }
 
-    // Filter on projectID
-    $filter["projectID"] and $sql[] = sprintf_implode("IFNULL(project.projectID,0) = %d",$filter["projectID"]);
-
-    // No point continuing if primary key specified, so return
-    if ($filter["projectID"] || $filter["starred"]) {
-      return $sql;
+    function get_list_by_client($clientID = false, $onlymine = false)
+    {
+        $current_user = &singleton("current_user");
+        $clientID and $options["clientID"] = $clientID;
+        $options["projectStatus"] = "Current";
+        $options["showProjectType"] = true;
+        if ($onlymine) {
+            $options["personID"] = $current_user->get_id();
+        }
+        $ops = project::get_list($options);
+        return array_kv($ops, "projectID", "label");
     }
 
-    $filter["clientID"]         and $sql[] = sprintf_implode("IFNULL(project.clientID,0) = %d",$filter["clientID"]);
-    $filter["personID"]         and $sql[] = sprintf_implode("IFNULL(projectPerson.personID,0) = %d",$filter["personID"]);
-    $filter["projectStatus"]    and $sql[] = sprintf_implode("IFNULL(project.projectStatus,'') = '%s'",$filter["projectStatus"]);
-    $filter["projectType"]      and $sql[] = sprintf_implode("IFNULL(project.projectType,0) = %d",$filter["projectType"]);
-    $filter["projectName"]      and $sql[] = sprintf_implode("IFNULL(project.projectName,'') LIKE '%%%s%%'",$filter["projectName"]);
-    $filter["projectShortName"] and $sql[] = sprintf_implode("IFNULL(project.projectShortName,'') LIKE '%%%s%%'",$filter["projectShortName"]);
+    function get_list_dropdown($type = "mine", $projectIDs = array())
+    {
+        $options = project::get_list_dropdown_options($type, $projectIDs);
+        return "<select name=\"projectID[]\" size=\"9\" style=\"width:275px;\" multiple=\"true\">".$options."</select>";
+    }
 
-    // project name or project nick name or project id
-    $filter["projectNameMatches"] and $sql[] = sprintf_implode("project.projectName LIKE '%%%s%%'
+    function get_list_dropdown_options($type = "mine", $projectIDs = array(), $maxlength = 35)
+    {
+        $db = new db_alloc();
+        $q = project::get_project_type_query($type);
+      // Project dropdown
+        $db->query($q);
+        while ($db->next_record()) {
+            $ops[$db->f("projectID")] = $db->f("projectName");
+        }
+        return page::select_options($ops, $projectIDs, $maxlength);
+    }
+
+    function get_dropdown_by_client($clientID = false, $onlymine = false)
+    {
+        if ($clientID) {
+            $ops = "<select id=\"projectID\" name=\"projectID\"><option></option>";
+            $o = project::get_list_by_client($clientID, $onlymine);
+            is_object($this) && $this->get_id() and $o[$this->get_id()] = $this->get_value("projectName");
+            $ops.= page::select_options($o, $this->get_id())."</select>";
+        } else {
+            $ops = "<select id=\"projectID\" name=\"projectID\"><option></option>";
+            $o = project::get_list_by_client(null, $onlymine);
+            is_object($this) and $this->get_id() and $o[$this->get_id()] = $this->get_value("projectName");
+            $ops.= page::select_options($o, $this->get_id())."</select>";
+          #$ops.= project::get_list_dropdown_options("curr",$this->get_id(),100)."</select>";
+        }
+        return $ops;
+    }
+
+    function has_attachment_permission($person)
+    {
+        return $this->has_project_permission($person);
+    }
+
+    function has_attachment_permission_delete($person)
+    {
+        return $this->has_project_permission($person, array("isManager"));
+    }
+
+    public static function get_list_filter($filter = array())
+    {
+        $current_user = &singleton("current_user");
+
+      // If they want starred, load up the projectID filter element
+        if ($filter["starred"]) {
+            foreach ((array)$current_user->prefs["stars"]["project"] as $k => $v) {
+                $filter["projectID"][] = $k;
+            }
+            is_array($filter["projectID"]) or $filter["projectID"][] = -1;
+        }
+
+      // Filter on projectID
+        $filter["projectID"] and $sql[] = sprintf_implode("IFNULL(project.projectID,0) = %d", $filter["projectID"]);
+
+      // No point continuing if primary key specified, so return
+        if ($filter["projectID"] || $filter["starred"]) {
+            return $sql;
+        }
+
+        $filter["clientID"]         and $sql[] = sprintf_implode("IFNULL(project.clientID,0) = %d", $filter["clientID"]);
+        $filter["personID"]         and $sql[] = sprintf_implode("IFNULL(projectPerson.personID,0) = %d", $filter["personID"]);
+        $filter["projectStatus"]    and $sql[] = sprintf_implode("IFNULL(project.projectStatus,'') = '%s'", $filter["projectStatus"]);
+        $filter["projectType"]      and $sql[] = sprintf_implode("IFNULL(project.projectType,0) = %d", $filter["projectType"]);
+        $filter["projectName"]      and $sql[] = sprintf_implode("IFNULL(project.projectName,'') LIKE '%%%s%%'", $filter["projectName"]);
+        $filter["projectShortName"] and $sql[] = sprintf_implode("IFNULL(project.projectShortName,'') LIKE '%%%s%%'", $filter["projectShortName"]);
+
+      // project name or project nick name or project id
+        $filter["projectNameMatches"] and $sql[] = sprintf_implode(
+            "project.projectName LIKE '%%%s%%'
                                                                OR project.projectShortName LIKE '%%%s%%'
-                                                               OR project.projectID = %d"
-                                                              ,$filter["projectNameMatches"]
-                                                              ,$filter["projectNameMatches"]
-                                                              ,$filter["projectNameMatches"]);
-    return $sql;
-  }
+                                                               OR project.projectID = %d",
+            $filter["projectNameMatches"],
+            $filter["projectNameMatches"],
+            $filter["projectNameMatches"]
+        );
+        return $sql;
+    }
 
-  public static function get_list($_FORM) {
-    /*
-     * This is the definitive method of getting a list of projects that need a sophisticated level of filtering
-     *
-     */
+    public static function get_list($_FORM)
+    {
+      /*
+       * This is the definitive method of getting a list of projects that need a sophisticated level of filtering
+       *
+       */
 
-    global $TPL;
-    $filter = project::get_list_filter($_FORM);
+        global $TPL;
+        $filter = project::get_list_filter($_FORM);
 
-    $debug = $_FORM["debug"];
-    $debug and print "<pre>_FORM: ".print_r($_FORM,1)."</pre>";
-    $debug and print "<pre>filter: ".print_r($filter,1)."</pre>";
+        $debug = $_FORM["debug"];
+        $debug and print "<pre>_FORM: ".print_r($_FORM, 1)."</pre>";
+        $debug and print "<pre>filter: ".print_r($filter, 1)."</pre>";
   
-    $_FORM["return"] or $_FORM["return"] = "html";
+        $_FORM["return"] or $_FORM["return"] = "html";
 
-    if ($_FORM["personID"]) { 
-      $from.= " LEFT JOIN projectPerson on projectPerson.projectID = project.projectID ";
-    }
+        if ($_FORM["personID"]) {
+            $from.= " LEFT JOIN projectPerson on projectPerson.projectID = project.projectID ";
+        }
 
-    if (is_array($filter) && count($filter)) {
-      $filter = " WHERE ".implode(" AND ",$filter);
-    }
+        if (is_array($filter) && count($filter)) {
+            $filter = " WHERE ".implode(" AND ", $filter);
+        }
 
-    $q = "SELECT project.*, client.* 
+        $q = "SELECT project.*, client.* 
             FROM project".$from."
        LEFT JOIN client ON project.clientID = client.clientID 
                  ".$filter." 
         GROUP BY project.projectID 
         ORDER BY projectName";
 
-    // Zero is a valid limit
-    if ($_FORM["limit"] || $_FORM["limit"] === 0 || $_FORM["limit"] === "0") {
-      $q.= prepare(" LIMIT %d",$_FORM["limit"]);
-    }
+      // Zero is a valid limit
+        if ($_FORM["limit"] || $_FORM["limit"] === 0 || $_FORM["limit"] === "0") {
+            $q.= prepare(" LIMIT %d", $_FORM["limit"]);
+        }
 
-    $debug and print "Query: ".$q;
-    $db = new db_alloc();
-    $db->query($q);
+        $debug and print "Query: ".$q;
+        $db = new db_alloc();
+        $db->query($q);
     
-    while ($row = $db->next_record()) {
-      $print = true;
-      $p = new project();
-      $p->read_db_record($db);
-      $row["projectName"] = $p->get_name($_FORM);
-      $row["projectLink"] = $p->get_project_link($_FORM);
-      $row["navLinks"] = $p->get_navigation_links();
-      $label = $p->get_name($_FORM);
-      $_FORM["showProjectType"] and $label.= " [".$p->get_project_type()."]";
-      $row["label"] = $label;
-      $rows[$row["projectID"]] = $row;
+        while ($row = $db->next_record()) {
+            $print = true;
+            $p = new project();
+            $p->read_db_record($db);
+            $row["projectName"] = $p->get_name($_FORM);
+            $row["projectLink"] = $p->get_project_link($_FORM);
+            $row["navLinks"] = $p->get_navigation_links();
+            $label = $p->get_name($_FORM);
+            $_FORM["showProjectType"] and $label.= " [".$p->get_project_type()."]";
+            $row["label"] = $label;
+            $rows[$row["projectID"]] = $row;
+        }
+
+        return (array)$rows;
     }
 
-    return (array)$rows;
-  }
-
-  function get_list_vars() {
+    function get_list_vars()
+    {
    
-    return array("projectID"          => "The Project ID"
+        return array("projectID"          => "The Project ID"
                 ,"projectStatus"      => "Status of the project eg: Current | Potential | Archived"
                 ,"clientID"           => "Show projects that are owned by this Client"
                 ,"projectType"        => "Type of project eg: Contract | Job | Project | Prepaid"
@@ -484,385 +516,401 @@ class project extends db_entity {
                 ,"applyFilter"        => "Saves this filter as the persons preference"
                 ,"showProjectType"    => "Show the project type"
                 );
-  }
+    }
 
-  function load_form_data($defaults=array()) {
-    $current_user = &singleton("current_user");
+    function load_form_data($defaults = array())
+    {
+        $current_user = &singleton("current_user");
 
-    $page_vars = array_keys(project::get_list_vars());
+        $page_vars = array_keys(project::get_list_vars());
   
-    $_FORM = get_all_form_data($page_vars,$defaults);
+        $_FORM = get_all_form_data($page_vars, $defaults);
 
-    if (!$_FORM["applyFilter"]) {
-      $_FORM = $current_user->prefs[$_FORM["form_name"]];
-      if (!isset($current_user->prefs[$_FORM["form_name"]])) {
-        $_FORM["projectStatus"] = "Current";
-        $_FORM["personID"] = $current_user->get_id();
-      }
+        if (!$_FORM["applyFilter"]) {
+            $_FORM = $current_user->prefs[$_FORM["form_name"]];
+            if (!isset($current_user->prefs[$_FORM["form_name"]])) {
+                $_FORM["projectStatus"] = "Current";
+                $_FORM["personID"] = $current_user->get_id();
+            }
+        } else if ($_FORM["applyFilter"] && is_object($current_user) && !$_FORM["dontSave"]) {
+            $url = $_FORM["url_form_action"];
+            unset($_FORM["url_form_action"]);
+            $current_user->prefs[$_FORM["form_name"]] = $_FORM;
+            $_FORM["url_form_action"] = $url;
+        }
 
-    } else if ($_FORM["applyFilter"] && is_object($current_user) && !$_FORM["dontSave"]) {
-      $url = $_FORM["url_form_action"];
-      unset($_FORM["url_form_action"]);
-      $current_user->prefs[$_FORM["form_name"]] = $_FORM;
-      $_FORM["url_form_action"] = $url;
+        return $_FORM;
     }
 
-    return $_FORM;
-  }
+    function load_project_filter($_FORM)
+    {
 
-  function load_project_filter($_FORM) {
+        global $TPL;
+        $current_user = &singleton("current_user");
 
-    global $TPL;
-    $current_user = &singleton("current_user");
+        $personSelect= "<select name=\"personID[]\" multiple=\"true\">";
+        $personSelect.= page::select_options(person::get_username_list($_FORM["personID"]), $_FORM["personID"]);
+        $personSelect.= "</select>";
 
-    $personSelect= "<select name=\"personID[]\" multiple=\"true\">";
-    $personSelect.= page::select_options(person::get_username_list($_FORM["personID"]), $_FORM["personID"]);
-    $personSelect.= "</select>";
-
-    $rtn["personSelect"] = $personSelect;
-    $m = new meta("projectStatus");
-    $projectStatus_array = $m->get_assoc_array("projectStatusID","projectStatusID");
-    $rtn["projectStatusOptions"] = page::select_options($projectStatus_array, $_FORM["projectStatus"]);
-    $rtn["projectTypeOptions"] = page::select_options(project::get_project_type_array(), $_FORM["projectType"]);
-    $rtn["projectName"] = $_FORM["projectName"];
+        $rtn["personSelect"] = $personSelect;
+        $m = new meta("projectStatus");
+        $projectStatus_array = $m->get_assoc_array("projectStatusID", "projectStatusID");
+        $rtn["projectStatusOptions"] = page::select_options($projectStatus_array, $_FORM["projectStatus"]);
+        $rtn["projectTypeOptions"] = page::select_options(project::get_project_type_array(), $_FORM["projectType"]);
+        $rtn["projectName"] = $_FORM["projectName"];
 
 
-    // Get
-    $rtn["FORM"] = "FORM=".urlencode(serialize($_FORM));
+      // Get
+        $rtn["FORM"] = "FORM=".urlencode(serialize($_FORM));
 
-    return $rtn;
-  }
-
-  function get_project_type_array() {
-    // optimization
-    static $rows;
-    if (!$rows) {
-      $m = new meta("projectType");
-      $rows = $m->get_assoc_array("projectTypeID","projectTypeID");
+        return $rtn;
     }
-    return $rows;
-  }
 
-  function get_project_type() {
-    $ops = $this->get_project_type_array();
-    return $ops[$this->get_value("projectType")];
-  }
+    function get_project_type_array()
+    {
+      // optimization
+        static $rows;
+        if (!$rows) {
+            $m = new meta("projectType");
+            $rows = $m->get_assoc_array("projectTypeID", "projectTypeID");
+        }
+        return $rows;
+    }
 
-  function get_prepaid_invoice() {
-    $db = new db_alloc();
+    function get_project_type()
+    {
+        $ops = $this->get_project_type_array();
+        return $ops[$this->get_value("projectType")];
+    }
 
-    $q = prepare("SELECT *
+    function get_prepaid_invoice()
+    {
+        $db = new db_alloc();
+
+        $q = prepare(
+            "SELECT *
                     FROM invoice 
                    WHERE projectID = %d
                      AND invoiceStatus != 'finished' 
                 ORDER BY invoiceDateFrom ASC 
-                   LIMIT 1"
-                 ,$this->get_id());
-    $db->query($q);
+                   LIMIT 1",
+            $this->get_id()
+        );
+        $db->query($q);
 
-    if ($row = $db->row()) {
-      $invoiceID = $row["invoiceID"];
-
-    } else if ($this->get_value("clientID")) {
-      $q = prepare("SELECT *
+        if ($row = $db->row()) {
+            $invoiceID = $row["invoiceID"];
+        } else if ($this->get_value("clientID")) {
+            $q = prepare(
+                "SELECT *
                       FROM invoice 
                      WHERE clientID = %d 
                        AND (projectID IS NULL OR projectID = 0 OR projectID = '')
                        AND invoiceStatus != 'finished' 
                   ORDER BY invoiceDateFrom ASC 
-                     LIMIT 1"
-                   ,$this->get_value("clientID"));
-      $db->query($q);
+                     LIMIT 1",
+                $this->get_value("clientID")
+            );
+            $db->query($q);
 
-      if ($row = $db->row()) {
-        $invoiceID = $row["invoiceID"];
-      }
-    } 
-    return $invoiceID;
-  }
-
-  function update_search_index_doc(&$index) {
-    $p =& get_cached_table("person");
-    $projectModifiedUser = $this->get_value("projectModifiedUser");
-    $projectModifiedUser_field = $projectModifiedUser." ".$p[$projectModifiedUser]["username"]." ".$p[$projectModifiedUser]["name"];
-    $projectName = $this->get_name();
-    $projectShortName = $this->get_name(array("showShortProjectLink"=>true));
-    $projectShortName && $projectShortName != $projectName and $projectName.= " ".$projectShortName;
-
-    if ($this->get_value("clientID")) {
-      $c = new client();
-      $c->set_id($this->get_value("clientID"));
-      $c->select();
-      $clientName = $c->get_name();
+            if ($row = $db->row()) {
+                $invoiceID = $row["invoiceID"];
+            }
+        }
+        return $invoiceID;
     }
 
-    $doc = new Zend_Search_Lucene_Document();
-    $doc->addField(Zend_Search_Lucene_Field::Keyword('id'   ,$this->get_id()));
-    $doc->addField(Zend_Search_Lucene_Field::Text('name'    ,$projectName,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('desc'    ,$this->get_value("projectComments"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('cid'     ,$this->get_value("clientID"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('client'  ,$clientName,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('modifier',$projectModifiedUser_field,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('type'    ,$this->get_value("projectType"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateTargetStart',str_replace("-","",$this->get_value("dateTargetStart")),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateTargetCompletion',str_replace("-","",$this->get_value("dateTargetCompletion")),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateStart',str_replace("-","",$this->get_value("dateActualStart")),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateCompletion',str_replace("-","",$this->get_value("dateActualCompletion")),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('status'   ,$this->get_value("projectStatus"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('priority' ,$this->get_value("projectPriority"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('tf'       ,$this->get_value("cost_centre_tfID"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('billed'   ,$this->get_value("customerBilledDollars"),"utf-8"));
-    $index->addDocument($doc);
-  }
+    function update_search_index_doc(&$index)
+    {
+        $p =& get_cached_table("person");
+        $projectModifiedUser = $this->get_value("projectModifiedUser");
+        $projectModifiedUser_field = $projectModifiedUser." ".$p[$projectModifiedUser]["username"]." ".$p[$projectModifiedUser]["name"];
+        $projectName = $this->get_name();
+        $projectShortName = $this->get_name(array("showShortProjectLink"=>true));
+        $projectShortName && $projectShortName != $projectName and $projectName.= " ".$projectShortName;
 
-  function format_client_old() {
-    $this->get_value("projectClientName")    and $str.= $this->get_value("projectClientName",DST_HTML_DISPLAY)."<br>";
-    $this->get_value("projectClientAddress") and $str.= $this->get_value("projectClientAddress",DST_HTML_DISPLAY)."<br>";
-    $this->get_value("projectClientPhone")   and $str.= $this->get_value("projectClientPhone",DST_HTML_DISPLAY)."<br>";
-    $this->get_value("projectClientMobile")  and $str.= $this->get_value("projectClientMobile",DST_HTML_DISPLAY)."<br>";
-    $this->get_value("projectClientEMail")   and $str.= $this->get_value("projectClientEMail",DST_HTML_DISPLAY)."<br>";
-    return $str;
-  }
-
-  public static function get_projectID_sql($filter, $table="project") {
-    
-    if (!$filter["projectID"] && $filter["projectType"] && $filter["projectType"] != "all") {
-      $db = new db_alloc();
-      $q = project::get_project_type_query($filter["projectType"],$filter["current_user"],"current");
-      $db->query($q);
-      while ($db->next_record()) {
-        $filter["projectIDs"][] = $db->f("projectID");
-      }
-
-      // Oi! What a pickle. Need this flag for when someone doesn't have entries loaded in the above while loop.
-      $firstOption = true;
-
-    // If projectID is an array
-    } else if ($filter["projectID"] && is_array($filter["projectID"])) {
-      $filter["projectIDs"] = $filter["projectID"];
-
-    // Else a project has been specified in the url
-    } else if ($filter["projectID"] && is_numeric($filter["projectID"])) {
-      $filter["projectIDs"][] = $filter["projectID"];
-    }
-
-    // If passed array projectIDs then join them up with commars and put them in an sql subset
-    if (is_array($filter["projectIDs"]) && count($filter["projectIDs"])) {
-      return sprintf_implode("(".$table.".projectID = %d)",$filter["projectIDs"]);
-
-    // If there are no projects in $filter["projectIDs"][] and we're attempting the first option..
-    } else if ($firstOption) {
-      return "(".$table.".projectID = 0)";
-    }
-  }
-
-  function get_cc_list_select($projectID="") {
-    $interestedParty = array();
-    $interestedPartyOptions = array();
-    
-    if (is_object($this)) {
-      $interestedPartyOptions = $this->get_all_parties($projectID);
-    } else {
-      $project = new project($projectID);
-      $interestedPartyOptions = $project->get_all_parties();
-    }
-
-    if (is_array($interestedPartyOptions)) {
-      foreach ($interestedPartyOptions as $email => $info) {
-        $name = $info["name"];
-        $identifier = $info["identifier"];
-
-        if ($info["role"] == "interested" && $info["selected"]) {
-          $interestedParty[] = $identifier;
+        if ($this->get_value("clientID")) {
+            $c = new client();
+            $c->set_id($this->get_value("clientID"));
+            $c->select();
+            $clientName = $c->get_name();
         }
 
-        if ($email) {
-          $name = trim($name);
-          $str = trim(page::htmlentities($name." <".$email.">"));
-          $options[$identifier] = $str;
+        $doc = new Zend_Search_Lucene_Document();
+        $doc->addField(Zend_Search_Lucene_Field::Keyword('id', $this->get_id()));
+        $doc->addField(Zend_Search_Lucene_Field::Text('name', $projectName, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('desc', $this->get_value("projectComments"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('cid', $this->get_value("clientID"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('client', $clientName, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('modifier', $projectModifiedUser_field, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('type', $this->get_value("projectType"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateTargetStart', str_replace("-", "", $this->get_value("dateTargetStart")), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateTargetCompletion', str_replace("-", "", $this->get_value("dateTargetCompletion")), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateStart', str_replace("-", "", $this->get_value("dateActualStart")), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateCompletion', str_replace("-", "", $this->get_value("dateActualCompletion")), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('status', $this->get_value("projectStatus"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('priority', $this->get_value("projectPriority"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('tf', $this->get_value("cost_centre_tfID"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('billed', $this->get_value("customerBilledDollars"), "utf-8"));
+        $index->addDocument($doc);
+    }
+
+    function format_client_old()
+    {
+        $this->get_value("projectClientName")    and $str.= $this->get_value("projectClientName", DST_HTML_DISPLAY)."<br>";
+        $this->get_value("projectClientAddress") and $str.= $this->get_value("projectClientAddress", DST_HTML_DISPLAY)."<br>";
+        $this->get_value("projectClientPhone")   and $str.= $this->get_value("projectClientPhone", DST_HTML_DISPLAY)."<br>";
+        $this->get_value("projectClientMobile")  and $str.= $this->get_value("projectClientMobile", DST_HTML_DISPLAY)."<br>";
+        $this->get_value("projectClientEMail")   and $str.= $this->get_value("projectClientEMail", DST_HTML_DISPLAY)."<br>";
+        return $str;
+    }
+
+    public static function get_projectID_sql($filter, $table = "project")
+    {
+    
+        if (!$filter["projectID"] && $filter["projectType"] && $filter["projectType"] != "all") {
+            $db = new db_alloc();
+            $q = project::get_project_type_query($filter["projectType"], $filter["current_user"], "current");
+            $db->query($q);
+            while ($db->next_record()) {
+                $filter["projectIDs"][] = $db->f("projectID");
+            }
+
+          // Oi! What a pickle. Need this flag for when someone doesn't have entries loaded in the above while loop.
+            $firstOption = true;
+
+        // If projectID is an array
+        } else if ($filter["projectID"] && is_array($filter["projectID"])) {
+            $filter["projectIDs"] = $filter["projectID"];
+
+        // Else a project has been specified in the url
+        } else if ($filter["projectID"] && is_numeric($filter["projectID"])) {
+            $filter["projectIDs"][] = $filter["projectID"];
         }
-      }
+
+      // If passed array projectIDs then join them up with commars and put them in an sql subset
+        if (is_array($filter["projectIDs"]) && count($filter["projectIDs"])) {
+            return sprintf_implode("(".$table.".projectID = %d)", $filter["projectIDs"]);
+
+        // If there are no projects in $filter["projectIDs"][] and we're attempting the first option..
+        } else if ($firstOption) {
+            return "(".$table.".projectID = 0)";
+        }
     }
-    $str = "<select name=\"interestedParty[]\" multiple=\"true\">".page::select_options($options,$interestedParty,100,false)."</select>";
-    return $str;
-  }
 
-  function get_all_parties($projectID=false, $task_exists=false) {
-    $current_user = &singleton("current_user");
-    if (!$projectID && is_object($this)) {
-      $projectID = $this->get_id();
+    function get_cc_list_select($projectID = "")
+    {
+        $interestedParty = array();
+        $interestedPartyOptions = array();
+    
+        if (is_object($this)) {
+            $interestedPartyOptions = $this->get_all_parties($projectID);
+        } else {
+            $project = new project($projectID);
+            $interestedPartyOptions = $project->get_all_parties();
+        }
+
+        if (is_array($interestedPartyOptions)) {
+            foreach ($interestedPartyOptions as $email => $info) {
+                $name = $info["name"];
+                $identifier = $info["identifier"];
+
+                if ($info["role"] == "interested" && $info["selected"]) {
+                    $interestedParty[] = $identifier;
+                }
+
+                if ($email) {
+                    $name = trim($name);
+                    $str = trim(page::htmlentities($name." <".$email.">"));
+                    $options[$identifier] = $str;
+                }
+            }
+        }
+        $str = "<select name=\"interestedParty[]\" multiple=\"true\">".page::select_options($options, $interestedParty, 100, false)."</select>";
+        return $str;
     }
-    if ($projectID) {
 
-      $extra_interested_parties = config::get_config_item("defaultInterestedParties");
-      foreach ((array)$extra_interested_parties as $name => $email) {
-        $interestedPartyOptions[$email]["name"] = $name;
-      }
+    function get_all_parties($projectID = false, $task_exists = false)
+    {
+        $current_user = &singleton("current_user");
+        if (!$projectID && is_object($this)) {
+            $projectID = $this->get_id();
+        }
+        if ($projectID) {
+            $extra_interested_parties = config::get_config_item("defaultInterestedParties");
+            foreach ((array)$extra_interested_parties as $name => $email) {
+                $interestedPartyOptions[$email]["name"] = $name;
+            }
 
-      // Get primary client contact from Project page
-      $db = new db_alloc();
-      $q = prepare("SELECT projectClientName,projectClientEMail FROM project WHERE projectID = %d",$projectID);
-      $db->query($q);
-      $db->next_record();
-      $interestedPartyOptions[$db->f("projectClientEMail")]["name"] = $db->f("projectClientName");
-      $interestedPartyOptions[$db->f("projectClientEMail")]["external"] = "1";
+          // Get primary client contact from Project page
+            $db = new db_alloc();
+            $q = prepare("SELECT projectClientName,projectClientEMail FROM project WHERE projectID = %d", $projectID);
+            $db->query($q);
+            $db->next_record();
+            $interestedPartyOptions[$db->f("projectClientEMail")]["name"] = $db->f("projectClientName");
+            $interestedPartyOptions[$db->f("projectClientEMail")]["external"] = "1";
   
-      // Get all other client contacts from the Client pages for this Project
-      $q = prepare("SELECT clientID FROM project WHERE projectID = %d",$projectID);
-      $db->query($q);
-      $db->next_record();
-      $clientID = $db->f("clientID");
-      if ($clientID) {
-        $client = new client($clientID);
-        $interestedPartyOptions = array_merge((array)$interestedPartyOptions, (array)$client->get_all_parties());
-      }
+          // Get all other client contacts from the Client pages for this Project
+            $q = prepare("SELECT clientID FROM project WHERE projectID = %d", $projectID);
+            $db->query($q);
+            $db->next_record();
+            $clientID = $db->f("clientID");
+            if ($clientID) {
+                $client = new client($clientID);
+                $interestedPartyOptions = array_merge((array)$interestedPartyOptions, (array)$client->get_all_parties());
+            }
 
-      // Get all the project people for this tasks project
-      $q = prepare("SELECT emailAddress, firstName, surname, person.personID, username
+          // Get all the project people for this tasks project
+            $q = prepare("SELECT emailAddress, firstName, surname, person.personID, username
                      FROM projectPerson 
                 LEFT JOIN person on projectPerson.personID = person.personID 
-                    WHERE projectPerson.projectID = %d AND person.personActive = 1 ",$projectID);
-      $db->query($q);
-      while ($db->next_record()) {
-        unset($name);
-        $db->f("firstName") && $db->f("surname") and $name = $db->f("firstName")." ".$db->f("surname");
-        $name or $name = $db->f("username");
-        $interestedPartyOptions[$db->f("emailAddress")]["name"] = $name;
-        $interestedPartyOptions[$db->f("emailAddress")]["personID"] = $db->f("personID");
-        $interestedPartyOptions[$db->f("emailAddress")]["internal"] = true; 
-      }
+                    WHERE projectPerson.projectID = %d AND person.personActive = 1 ", $projectID);
+            $db->query($q);
+            while ($db->next_record()) {
+                  unset($name);
+                  $db->f("firstName") && $db->f("surname") and $name = $db->f("firstName")." ".$db->f("surname");
+                  $name or $name = $db->f("username");
+                  $interestedPartyOptions[$db->f("emailAddress")]["name"] = $name;
+                  $interestedPartyOptions[$db->f("emailAddress")]["personID"] = $db->f("personID");
+                  $interestedPartyOptions[$db->f("emailAddress")]["internal"] = true;
+            }
+        }
+
+        if (is_object($current_user) && $current_user->get_id()) {
+            $interestedPartyOptions[$current_user->get_value("emailAddress")]["name"] = $current_user->get_name();
+            $interestedPartyOptions[$current_user->get_value("emailAddress")]["personID"] = $current_user->get_id();
+        }
+
+      // return an aggregation of the current task/proj/client parties + the existing interested parties
+        $interestedPartyOptions = interestedParty::get_interested_parties("project", $projectID, $interestedPartyOptions, $task_exists);
+        return (array)$interestedPartyOptions;
     }
 
-    if (is_object($current_user) && $current_user->get_id()) {
-      $interestedPartyOptions[$current_user->get_value("emailAddress")]["name"] = $current_user->get_name();
-      $interestedPartyOptions[$current_user->get_value("emailAddress")]["personID"] = $current_user->get_id();
+    public static function get_priority_label($p = "")
+    {
+        $projectPriorities = config::get_config_item("projectPriorities") or $projectPriorities = array();
+        $pp = array();
+        foreach ($projectPriorities as $key => $arr) {
+            $pp[$key] = $arr["label"];
+        }
+        return $pp[$p];
     }
 
-    // return an aggregation of the current task/proj/client parties + the existing interested parties
-    $interestedPartyOptions = interestedParty::get_interested_parties("project",$projectID,$interestedPartyOptions,$task_exists);
-    return (array)$interestedPartyOptions;
-  }
-
-  public static function get_priority_label($p="") {
-    $projectPriorities = config::get_config_item("projectPriorities") or $projectPriorities = array();
-    $pp = array();
-    foreach($projectPriorities as $key => $arr) {
-      $pp[$key] = $arr["label"];
-    }
-    return $pp[$p];
-  }
-
-  function get_list_html($rows=array(),$ops=array()) {
-    global $TPL;
-    $TPL["projectListRows"] = $rows;
-    $TPL["_FORM"] = $ops;
-    include_template(dirname(__FILE__)."/../templates/projectListS.tpl");
-  }
-
-  function get_changes_list() {
-    // This function returns HTML rows for the changes that have been made to this project
-    $rows = array();
-    $people_cache =& get_cached_table("person");
-    $timeUnit = new timeUnit();
-    $timeUnits = array_reverse($timeUnit->get_assoc_array("timeUnitID","timeUnitLabelA"),true);
-    $options = array("projectID" => $this->get_id());
-    $changes = audit::get_list($options);
-    foreach((array)$changes as $audit) {
-      $changeDescription = "";
-      $newValue = $audit['value'];
-      switch($audit['field']) {
-        case 'created':
-          $changeDescription = $newValue;
-          break;
-        case 'dip':
-          $changeDescription = "Default parties set to ".interestedParty::abbreviate($newValue);
-          break;
-        case 'projectShortName':
-          $changeDescription = "Project nickname set to '$newValue'.";
-          break;
-        case 'projectComments':
-          $changeDescription = "Project description set to <a class=\"magic\" href=\"#x\" onclick=\"$('#audit" . $audit["auditID"] . "').slideToggle('fast');\">Show</a> <div class=\"hidden\" id=\"audit" . $audit["auditID"] . "\"><div>" .$newValue. "</div></div>";
-          break;
-        case 'clientID':
-          $newClient = new client($newValue);
-          is_object($newClient) and $newClientLink = $newClient->get_link();
-          $newClientLink or $newClientLink = "&lt;empty&gt;";
-          $changeDescription = "Client set to ".$newClientLink.".";
-        break;
-        case 'clientContactID':
-          $newClientContact = new clientContact($newValue);
-          is_object($newClientContact) and $newClientContactLink = $newClientContact->get_link();
-          $newClientContactLink or $newClientContactLink = "&lt;empty&gt;";
-          $changeDescription = "Client contact set to ".$newClientContactLink.".";
-        break;
-        case 'projectType':
-          $changeDescription = "Project type set to " . $newValue . ".";
-        break;
-        case 'projectBudget':
-          $changeDescription = "Project budget set to " . page::money($this->get_value("currencyTypeID"),$newValue) . ".";
-        break;
-        case 'currencyTypeID':
-          $changeDescription = "Project currency set to " . $newValue . ".";
-        break;
-        case 'projectStatus':
-          $changeDescription = "Project status set to " . $newValue . ".";
-        break;
-        case 'projectName':
-          $changeDescription = "Project name set to '$newValue'.";
-          break;
-        case 'cost_centre_tfID':
-          $newCostCentre = new tf($newValue);
-          is_object($newCostCentre) and $newCostCentreLink = $newCostCentre->get_link();
-          $newCostCentreLink or $newCostCentreLink = "&lt;empty&gt;";
-          $changeDescription = "Cost centre TF set to " . $newCostCentreLink . ".";
-        break;
-        case 'customerBilledDollars':
-          $changeDescription = "Client billing set to " . page::money($this->get_value("currencyTypeID"),$newValue) . ".";
-        break;
-        case 'defaultTaskLimit':
-          $changeDescription = "Default task limit set to " . $newValue . ".";
-        break;
-        case 'defaultTimeSheetRate':
-          $changeDescription = "Default time sheet rate set to " . page::money($this->get_value("currencyTypeID"),$newValue) . ".";
-        break;
-        case 'defaultTimeSheetRateUnitID':
-          $changeDescription = "Default time sheet rate unit set to '" . $timeUnits[$newValue] . "'.";
-        break;
-        case 'projectPriority':
-          $priorities = config::get_config_item("projectPriorities");
-          $changeDescription = sprintf('Project priority set to <span style="color: %s;">%s</span>.'
-                                        , $priorities[$newValue]["colour"]
-                                        , $priorities[$newValue]["label"]);
-        break;
-        case 'dateActualCompletion':
-        case 'dateActualStart':
-        case 'dateTargetStart':
-        case 'dateTargetCompletion':
-          // these cases are more or less identical
-          switch($audit['field']) {
-            case 'dateActualCompletion': $fieldDesc = "actual completion date"; break;
-            case 'dateActualStart': $fieldDesc = "actual start date"; break;
-            case 'dateTargetStart': $fieldDesc = "estimate/target start date"; break;
-            case 'dateTargetCompletion': $fieldDesc = "estimate/target completion date"; break;
-          }
-          if(!$newValue) {
-            $changeDescription = "The $fieldDesc was removed.";
-          } else {
-            $changeDescription = "The $fieldDesc set to $newValue.";
-          }
-        break;
-      }
-      $rows[] = "<tr><td class=\"nobr\">" . $audit["dateChanged"] . "</td><td>$changeDescription</td><td>" . page::htmlentities($people_cache[$audit["personID"]]["name"]) . "</td></tr>";
+    function get_list_html($rows = array(), $ops = array())
+    {
+        global $TPL;
+        $TPL["projectListRows"] = $rows;
+        $TPL["_FORM"] = $ops;
+        include_template(dirname(__FILE__)."/../templates/projectListS.tpl");
     }
 
-    return implode("\n", $rows);
-  }
+    function get_changes_list()
+    {
+      // This function returns HTML rows for the changes that have been made to this project
+        $rows = array();
+        $people_cache =& get_cached_table("person");
+        $timeUnit = new timeUnit();
+        $timeUnits = array_reverse($timeUnit->get_assoc_array("timeUnitID", "timeUnitLabelA"), true);
+        $options = array("projectID" => $this->get_id());
+        $changes = audit::get_list($options);
+        foreach ((array)$changes as $audit) {
+            $changeDescription = "";
+            $newValue = $audit['value'];
+            switch ($audit['field']) {
+                case 'created':
+                    $changeDescription = $newValue;
+                    break;
+                case 'dip':
+                    $changeDescription = "Default parties set to ".interestedParty::abbreviate($newValue);
+                    break;
+                case 'projectShortName':
+                    $changeDescription = "Project nickname set to '$newValue'.";
+                    break;
+                case 'projectComments':
+                    $changeDescription = "Project description set to <a class=\"magic\" href=\"#x\" onclick=\"$('#audit" . $audit["auditID"] . "').slideToggle('fast');\">Show</a> <div class=\"hidden\" id=\"audit" . $audit["auditID"] . "\"><div>" .$newValue. "</div></div>";
+                    break;
+                case 'clientID':
+                    $newClient = new client($newValue);
+                    is_object($newClient) and $newClientLink = $newClient->get_link();
+                    $newClientLink or $newClientLink = "&lt;empty&gt;";
+                    $changeDescription = "Client set to ".$newClientLink.".";
+                    break;
+                case 'clientContactID':
+                    $newClientContact = new clientContact($newValue);
+                    is_object($newClientContact) and $newClientContactLink = $newClientContact->get_link();
+                    $newClientContactLink or $newClientContactLink = "&lt;empty&gt;";
+                    $changeDescription = "Client contact set to ".$newClientContactLink.".";
+                    break;
+                case 'projectType':
+                    $changeDescription = "Project type set to " . $newValue . ".";
+                    break;
+                case 'projectBudget':
+                    $changeDescription = "Project budget set to " . page::money($this->get_value("currencyTypeID"), $newValue) . ".";
+                    break;
+                case 'currencyTypeID':
+                    $changeDescription = "Project currency set to " . $newValue . ".";
+                    break;
+                case 'projectStatus':
+                    $changeDescription = "Project status set to " . $newValue . ".";
+                    break;
+                case 'projectName':
+                    $changeDescription = "Project name set to '$newValue'.";
+                    break;
+                case 'cost_centre_tfID':
+                    $newCostCentre = new tf($newValue);
+                    is_object($newCostCentre) and $newCostCentreLink = $newCostCentre->get_link();
+                    $newCostCentreLink or $newCostCentreLink = "&lt;empty&gt;";
+                    $changeDescription = "Cost centre TF set to " . $newCostCentreLink . ".";
+                    break;
+                case 'customerBilledDollars':
+                    $changeDescription = "Client billing set to " . page::money($this->get_value("currencyTypeID"), $newValue) . ".";
+                    break;
+                case 'defaultTaskLimit':
+                    $changeDescription = "Default task limit set to " . $newValue . ".";
+                    break;
+                case 'defaultTimeSheetRate':
+                    $changeDescription = "Default time sheet rate set to " . page::money($this->get_value("currencyTypeID"), $newValue) . ".";
+                    break;
+                case 'defaultTimeSheetRateUnitID':
+                    $changeDescription = "Default time sheet rate unit set to '" . $timeUnits[$newValue] . "'.";
+                    break;
+                case 'projectPriority':
+                    $priorities = config::get_config_item("projectPriorities");
+                    $changeDescription = sprintf(
+                        'Project priority set to <span style="color: %s;">%s</span>.',
+                        $priorities[$newValue]["colour"],
+                        $priorities[$newValue]["label"]
+                    );
+                    break;
+                case 'dateActualCompletion':
+                case 'dateActualStart':
+                case 'dateTargetStart':
+                case 'dateTargetCompletion':
+                  // these cases are more or less identical
+                    switch ($audit['field']) {
+                        case 'dateActualCompletion':
+                            $fieldDesc = "actual completion date";
+                            break;
+                        case 'dateActualStart':
+                            $fieldDesc = "actual start date";
+                            break;
+                        case 'dateTargetStart':
+                            $fieldDesc = "estimate/target start date";
+                            break;
+                        case 'dateTargetCompletion':
+                                  $fieldDesc = "estimate/target completion date";
+                            break;
+                    }
+                    if (!$newValue) {
+                        $changeDescription = "The $fieldDesc was removed.";
+                    } else {
+                        $changeDescription = "The $fieldDesc set to $newValue.";
+                    }
+                    break;
+            }
+            $rows[] = "<tr><td class=\"nobr\">" . $audit["dateChanged"] . "</td><td>$changeDescription</td><td>" . page::htmlentities($people_cache[$audit["personID"]]["name"]) . "</td></tr>";
+        }
 
-
+        return implode("\n", $rows);
+    }
 }
-
-
-
-
-
-?>

--- a/project/lib/projectCommissionPerson.inc.php
+++ b/project/lib/projectCommissionPerson.inc.php
@@ -3,58 +3,55 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class projectCommissionPerson extends db_entity {
-  public $data_table = "projectCommissionPerson";
-  public $display_field_name = "projectID";
-  public $key_field = "projectCommissionPersonID";
-  public $data_fields = array("projectID"
+class projectCommissionPerson extends db_entity
+{
+    public $data_table = "projectCommissionPerson";
+    public $display_field_name = "projectID";
+    public $key_field = "projectCommissionPersonID";
+    public $data_fields = array("projectID"
                              ,"tfID"
                              ,"commissionPercent"
                              );
 
-  function is_owner($person = "") {
-    $project = new project();
-    $project->set_id($this->get_value("projectID"));
-    $project->select();
-    return $project->is_owner($person);
-  }
-
-  function save() {
-    // Just ensure multiple 0 entries cannot be saved.
-    if ($this->get_value("commissionPercent") == 0) {
-      $q = prepare("SELECT * FROM projectCommissionPerson WHERE projectID = %d AND commissionPercent = 0 AND projectCommissionPersonID != %d",$this->get_value("projectID"), $this->get_id());
-      $db = new db_alloc();
-      $db->query($q);
-      if ($db->next_record()) { 
-        $fail = true;
-        alloc_error("Only one Time Sheet Commission is allowed to be set to 0%");
-      }
+    function is_owner($person = "")
+    {
+        $project = new project();
+        $project->set_id($this->get_value("projectID"));
+        $project->select();
+        return $project->is_owner($person);
     }
-    if (!$fail) {
-      parent::save();
+
+    function save()
+    {
+      // Just ensure multiple 0 entries cannot be saved.
+        if ($this->get_value("commissionPercent") == 0) {
+            $q = prepare("SELECT * FROM projectCommissionPerson WHERE projectID = %d AND commissionPercent = 0 AND projectCommissionPersonID != %d", $this->get_value("projectID"), $this->get_id());
+            $db = new db_alloc();
+            $db->query($q);
+            if ($db->next_record()) {
+                $fail = true;
+                alloc_error("Only one Time Sheet Commission is allowed to be set to 0%");
+            }
+        }
+        if (!$fail) {
+            parent::save();
+        }
     }
-  }
-
-
 }
-
-
-
-?>

--- a/project/lib/projectPerson.inc.php
+++ b/project/lib/projectPerson.inc.php
@@ -3,30 +3,31 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 define("PERM_PROJECT_PERSON_READ_DETAILS", 256);
 
-class projectPerson extends db_entity {
-  public $data_table = "projectPerson";
-  public $display_field_name = "projectID";
-  public $key_field = "projectPersonID";
-  public $data_fields = array("personID"
+class projectPerson extends db_entity
+{
+    public $data_table = "projectPerson";
+    public $display_field_name = "projectID";
+    public $key_field = "projectPersonID";
+    public $data_fields = array("personID"
                              ,"projectID"
                              ,"emailType"
                              ,"emailDateRegex"
@@ -36,83 +37,87 @@ class projectPerson extends db_entity {
                              ,"roleID"
                              );
 
-  function date_regex_matches() {
-    return eregi($this->get_value("emailDateRegex"), date("YmdD"));
-  }
-
-
-  function is_owner($person = "") {
-
-    if (!$this->get_id()) {
-      return true;
-    } else {
-      $project = new project();
-      $project->set_id($this->get_value("projectID"));
-      $project->select();
-      return $project->is_owner($person);
+    function date_regex_matches()
+    {
+        return eregi($this->get_value("emailDateRegex"), date("YmdD"));
     }
-  }
+
+
+    function is_owner($person = "")
+    {
+
+        if (!$this->get_id()) {
+            return true;
+        } else {
+            $project = new project();
+            $project->set_id($this->get_value("projectID"));
+            $project->select();
+            return $project->is_owner($person);
+        }
+    }
 
 
   // This is a wrapper to simplify inserts into the projectPerson table using the new
   // Role methodology.. role handle is canEditTasks, or isManager atm
-  function set_value_role($roleHandle) {
-    $db = new db_alloc();
-    $db->query(prepare("SELECT * FROM role WHERE roleHandle = '%s' AND roleLevel = 'project'",$roleHandle));
-    $db->next_record();
-    $this->set_value("roleID",$db->f("roleID"));
-  }
+    function set_value_role($roleHandle)
+    {
+        $db = new db_alloc();
+        $db->query(prepare("SELECT * FROM role WHERE roleHandle = '%s' AND roleLevel = 'project'", $roleHandle));
+        $db->next_record();
+        $this->set_value("roleID", $db->f("roleID"));
+    }
 
 
   //deprecated in favour of get_rate
-  function get_projectPerson_row($projectID, $personID) {
-    $q = prepare("SELECT * 
+    function get_projectPerson_row($projectID, $personID)
+    {
+        $q = prepare(
+            "SELECT * 
                     FROM projectPerson 
-                   WHERE projectID = %d AND personID = %d"
-                ,$projectID,$personID);
-    $db = new db_alloc();
-    $db->query($q);
-    return $db->row();
-  }
+                   WHERE projectID = %d AND personID = %d",
+            $projectID,
+            $personID
+        );
+        $db = new db_alloc();
+        $db->query($q);
+        return $db->row();
+    }
 
-  function get_rate($projectID, $personID) {
-    // Try to get the person's rate from the following sources:
-    // project.defaultTimeSheetRate
-    // person.defaultTimeSheetRate
-    // config.name == defaultTimeSheetRate
+    function get_rate($projectID, $personID)
+    {
+      // Try to get the person's rate from the following sources:
+      // project.defaultTimeSheetRate
+      // person.defaultTimeSheetRate
+      // config.name == defaultTimeSheetRate
 
-    // First check the project for a rate
-    $project = new project($projectID);
-    $row = array('rate' => $project->get_value("defaultTimeSheetRate"),
+      // First check the project for a rate
+        $project = new project($projectID);
+        $row = array('rate' => $project->get_value("defaultTimeSheetRate"),
                  'unit' => $project->get_value("defaultTimeSheetRateUnitID"));
-    if (imp($row['rate']) && $row['unit']) {
-      return $row;
-    }
+        if (imp($row['rate']) && $row['unit']) {
+            return $row;
+        }
 
-    // Next check person, which is in global currency rather than project currency - conversion required
-    $db = new db_alloc();
-    $q = prepare("SELECT defaultTimeSheetRate as rate, defaultTimeSheetRateUnitID as unit FROM person WHERE personID = %d", $personID);
-    $db->query($q);
-    $row = $db->row();
-    if (imp($row['rate']) && $row['unit']) {
-      if ($project->get_value("currencyTypeID") != config::get_config_item("currency")) {
-        $row['rate'] = exchangeRate::convert(config::get_config_item("currency"), $row["rate"], $project->get_value("currencyTypeID"));
-      }
-      return $row;
-    }
+      // Next check person, which is in global currency rather than project currency - conversion required
+        $db = new db_alloc();
+        $q = prepare("SELECT defaultTimeSheetRate as rate, defaultTimeSheetRateUnitID as unit FROM person WHERE personID = %d", $personID);
+        $db->query($q);
+        $row = $db->row();
+        if (imp($row['rate']) && $row['unit']) {
+            if ($project->get_value("currencyTypeID") != config::get_config_item("currency")) {
+                $row['rate'] = exchangeRate::convert(config::get_config_item("currency"), $row["rate"], $project->get_value("currencyTypeID"));
+            }
+            return $row;
+        }
 
-    // Lowest priority: global
-    $rate = config::get_config_item("defaultTimeSheetRate");
-    $unit = config::get_config_item("defaultTimeSheetUnit");
-    if (imp($rate) && $unit) {
-      if (config::get_config_item("currency") && $project->get_value("currencyTypeID")) {
-        $rate = exchangeRate::convert(config::get_config_item("currency"), $rate, $project->get_value("currencyTypeID"));
-      }
-      return array('rate'=>$rate, 'unit'=>$unit);
+      // Lowest priority: global
+        $rate = config::get_config_item("defaultTimeSheetRate");
+        $unit = config::get_config_item("defaultTimeSheetUnit");
+        if (imp($rate) && $unit) {
+            if (config::get_config_item("currency") && $project->get_value("currencyTypeID")) {
+                $rate = exchangeRate::convert(config::get_config_item("currency"), $rate, $project->get_value("currencyTypeID"));
+            }
+            return array('rate'=>$rate, 'unit'=>$unit);
+        }
     }
-  }
 }
-
-
-
-?>

--- a/project/lib/project_list_home_item.inc.php
+++ b/project/lib/project_list_home_item.inc.php
@@ -3,56 +3,56 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class project_list_home_item extends home_item {
+class project_list_home_item extends home_item
+{
 
-  function __construct() {
-    $this->has_config = true;
-    parent::__construct("project_list", "Project List", "project", "projectListH.tpl", "standard", 40);
-  }
-
-  function visible() {
-    $current_user = &singleton("current_user");
-
-    if (!isset($current_user->prefs["showProjectHome"])) {
-      $current_user->prefs["showProjectHome"] = 1;
-      $current_user->prefs["projectListNum"] = "10";
+    function __construct()
+    {
+        $this->has_config = true;
+        parent::__construct("project_list", "Project List", "project", "projectListH.tpl", "standard", 40);
     }
 
-    if ($current_user->prefs["showProjectHome"]) {
-      return true;
-    }
-  }
+    function visible()
+    {
+        $current_user = &singleton("current_user");
 
-  function render() {
-    $current_user = &singleton("current_user");
-    global $TPL;
-    if (isset($current_user->prefs["projectListNum"]) && $current_user->prefs["projectListNum"] != "all") {
-      $options["limit"] = sprintf("%d",$current_user->prefs["projectListNum"]);
+        if (!isset($current_user->prefs["showProjectHome"])) {
+            $current_user->prefs["showProjectHome"] = 1;
+            $current_user->prefs["projectListNum"] = "10";
+        }
+
+        if ($current_user->prefs["showProjectHome"]) {
+            return true;
+        }
     }
-    $options["projectStatus"] = "Current";
-    $options["personID"] = $current_user->get_id();
-    $TPL["projectListRows"] = project::get_list($options);
-    return true;
-  }
+
+    function render()
+    {
+        $current_user = &singleton("current_user");
+        global $TPL;
+        if (isset($current_user->prefs["projectListNum"]) && $current_user->prefs["projectListNum"] != "all") {
+            $options["limit"] = sprintf("%d", $current_user->prefs["projectListNum"]);
+        }
+        $options["projectStatus"] = "Current";
+        $options["personID"] = $current_user->get_id();
+        $TPL["projectListRows"] = project::get_list($options);
+        return true;
+    }
 }
-
-
-
-?>

--- a/project/lib/task_graph.inc.php
+++ b/project/lib/task_graph.inc.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,18 +23,20 @@
 define("TICK_SIZE", 7); // Days between tick marks along the axis
 define("LARGE_TICK_SIZE", 60);  // Days between tick marks along the axis
 define("MAX_TICKS", 20);        // Days between tick marks along the axis
-define("ALLOC_FONT",ALLOC_MOD_DIR."util/fonts/Vera.ttf");
-define("ALLOC_FONT_SIZE","8");
+define("ALLOC_FONT", ALLOC_MOD_DIR."util/fonts/Vera.ttf");
+define("ALLOC_FONT_SIZE", "8");
 
 // Set the enviroment variable for GD
 putenv('GDFONTPATH=' . realpath('../util'));
 
-  function echo_debug($s) {
+function echo_debug($s)
+{
   #echo $s;
-  }
+}
 
         // Outputs an image with an error message given by $s and then terminates the script
-  function image_die($s="") {
+function image_die($s = "")
+{
 
     $image = imageCreate(700, 40);
 
@@ -47,338 +49,354 @@ putenv('GDFONTPATH=' . realpath('../util'));
     imageFilledRectangle($image, 0, 0, 700, 40, $color_background);
     imagettftext($image, ALLOC_FONT_SIZE, 0, 6, 23, $color_text, ALLOC_FONT, $s);
 
-    imageRectangle($image,0,0,700-1, 40-1,$color_grid);
+    imageRectangle($image, 0, 0, 700-1, 40-1, $color_grid);
 
     if (ALLOC_GD_IMAGE_TYPE == "PNG") {
-      header("Content-type: image/png");
-      imagePNG($image);
+        header("Content-type: image/png");
+        imagePNG($image);
     } else {
-      header("Content-type: image/gif");
-      imageGIF($image);
+        header("Content-type: image/gif");
+        imageGIF($image);
     }
     exit();
-
-  }
+}
 
 class task_graph
 {
   // 'public' variables
 
   // size parameters (all in pixels)
-  var $width = 700;             // Width of the image
-  var $top_margin = 50;         // Distance of first bar from top of image
-  var $left_margin = 330;
-  var $right_margin = 20;
-  var $bottom_margin = 100;
-  var $task_padding = 2;        // Whitespace above and below each task bar
-  var $bar_height = 10;          // Height of each task bar
-  var $indent_increment = 20;   // Increase in whitespace to left of task for child tasks
-  var $title;
+    var $width = 700;             // Width of the image
+    var $top_margin = 50;         // Distance of first bar from top of image
+    var $left_margin = 330;
+    var $right_margin = 20;
+    var $bottom_margin = 100;
+    var $task_padding = 2;        // Whitespace above and below each task bar
+    var $bar_height = 10;          // Height of each task bar
+    var $indent_increment = 20;   // Increase in whitespace to left of task for child tasks
+    var $title;
 
   // 'private' variables
-  var $y;                       // current y position
-  var $image;                   // image handle
-  var $task_colors;             // color handles for task bars
-  var $height;                  // image height - set dynamically according to number of tasks and other variables such as bar_height
-  var $color_background;        // Background colour of image
-  var $color_text;              // Colour of text on image
-  var $color_grid;              // Colour of grid lines behind bars
-  var $color_milestone;         // Colour of milestone lines
-  var $color_today;             // Colour of current date line
-  var $milestones = array();    // Milestones are stored and then drawn over the top of the tasks
+    var $y;                       // current y position
+    var $image;                   // image handle
+    var $task_colors;             // color handles for task bars
+    var $height;                  // image height - set dynamically according to number of tasks and other variables such as bar_height
+    var $color_background;        // Background colour of image
+    var $color_text;              // Colour of text on image
+    var $color_grid;              // Colour of grid lines behind bars
+    var $color_milestone;         // Colour of milestone lines
+    var $color_today;             // Colour of current date line
+    var $milestones = array();    // Milestones are stored and then drawn over the top of the tasks
 
-  function init($tasks=array()) {
-    global $graph_start_date;
-    global $graph_completion_date;
-    global $graph_type;
+    function init($tasks = array())
+    {
+        global $graph_start_date;
+        global $graph_completion_date;
+        global $graph_type;
 
-    if (count($tasks) == 0) {
-      image_die("No Tasks Found for ".$this->title);
-    }
+        if (count($tasks) == 0) {
+            image_die("No Tasks Found for ".$this->title);
+        }
     
-    // Set the enviroment variable for GD
-    putenv('GDFONTPATH=' . realpath('../util'));
+      // Set the enviroment variable for GD
+        putenv('GDFONTPATH=' . realpath('../util'));
   
-    $this->height = count($tasks) * ($this->bar_height + $this->task_padding) * 2 + $this->top_margin + $this->bottom_margin;
+        $this->height = count($tasks) * ($this->bar_height + $this->task_padding) * 2 + $this->top_margin + $this->bottom_margin;
 
-    get_date_range($tasks);
+        get_date_range($tasks);
 
-    // create image
-    $this->image = imageCreate($this->width, $this->height);
+      // create image
+        $this->image = imageCreate($this->width, $this->height);
 
-    // 'Constant' colours for task types
-    $this->task_colors = array('Task'   => array("actual"=>imageColorAllocate($this->image, 133, 164, 241)
+      // 'Constant' colours for task types
+        $this->task_colors = array('Task'   => array("actual"=>imageColorAllocate($this->image, 133, 164, 241)
                                                 ,"target"=>imageColorAllocate($this->image, 190, 219, 255))
                               ,'Parent' => array("actual"=>imageColorAllocate($this->image, 153, 153, 153)
                                                 ,"target"=>imageColorAllocate($this->image, 204, 204, 204)));
 
-    // allocate all required colors
-    $this->color_background = imageColorAllocate($this->image, 255, 255, 255);
-    $this->color_text = imageColorAllocate($this->image, 0, 0, 0);
-    $this->color_grid = imageColorAllocate($this->image, 161, 202, 255);
-    $this->color_milestone = imageColorAllocate($this->image, 255, 128, 255);
-    $this->color_today = imageColorAllocate($this->image, 255, 192, 0);
+      // allocate all required colors
+        $this->color_background = imageColorAllocate($this->image, 255, 255, 255);
+        $this->color_text = imageColorAllocate($this->image, 0, 0, 0);
+        $this->color_grid = imageColorAllocate($this->image, 161, 202, 255);
+        $this->color_milestone = imageColorAllocate($this->image, 255, 128, 255);
+        $this->color_today = imageColorAllocate($this->image, 255, 192, 0);
 
-    // clear the image space with the background color
-    imageFilledRectangle($this->image, 0, 0, $this->width - 1, $this->height - 1, $this->color_background);
+      // clear the image space with the background color
+        imageFilledRectangle($this->image, 0, 0, $this->width - 1, $this->height - 1, $this->color_background);
 
-    imageRectangle($this->image,0,0,$this->width - 1,$this->height - 1,$this->color_grid);
+        imageRectangle($this->image, 0, 0, $this->width - 1, $this->height - 1, $this->color_grid);
 
-    imagettftext($this->image, ALLOC_FONT_SIZE+3, 0, 6, 28, $this->color_text, ALLOC_FONT, $this->title);
+        imagettftext($this->image, ALLOC_FONT_SIZE+3, 0, 6, 28, $this->color_text, ALLOC_FONT, $this->title);
 
-    $this->y = $this->top_margin;
-  }
-
-  function set_width($width) {
-    $width and $this->width = $width;
-  }
-
-  function set_title($title) {
-    $this->title = strip_tags(str_replace('\\','',$title));
-  }
-
-  function draw_task($t) {
-    $y = $this->y;              // Store y in local variable for quick access
-    $y += $this->task_padding;
-
-    $indent = $t["padding"];
-    $task = $t["object"];
-
-    // Text
-    $text = $t["taskName"];
-    echo_debug("task: $text<br>");
-    imagettftext($this->image, ALLOC_FONT_SIZE, 0,  6 + ($indent * $this->indent_increment), $y + 13, $this->color_text, ALLOC_FONT, $text);
-
-    // Get date values
-    $date_target_start = $t["dateTargetStart"];
-    $date_target_start == "0000-00-00" and $date_target_start = "";
-
-    $date_target_completion = $t["dateTargetCompletion"];
-    $date_target_completion == "0000-00-00" and $date_target_completion = "";
-
-    $date_actual_start = $t["dateActualStart"];
-    $date_actual_start == "0000-00-00" and $date_actual_start = "";
-
-    $date_actual_completion = $t["dateActualCompletion"];
-    $date_actual_completion == "0000-00-00" and $date_actual_completion = "";
-
-    // target bar
-    $color = $this->task_colors[$t["taskTypeID"]]["target"];
-    $this->draw_dates($date_target_start, $date_target_completion, $y, $color, true);
-    $y += $this->bar_height;
-
-    // actual bar
-    if ($date_actual_completion == "" && $date_actual_start != "") {
-      // Task isn't complete but we can forecast comlpetion using percent complete and start date - show forecast
-      $forecast = $task->get_forecast_completion();
-      $forecast and $date_forecast_completion = date("Y-m-d", $forecast);
-      $color = $this->task_colors[$t["taskTypeID"]]["actual"];
-      $forecast and $this->draw_dates($date_actual_start, $date_forecast_completion, $y, $color, false);      // Forecast bar
-      $this->draw_dates($date_actual_start, date("Y-m-d"), $y, $color, true);   // Solid bar for already completed portion
-    } else {
-      // Just show dates as usual
-      $color = $this->task_colors[$t["taskTypeID"]]["actual"];
-      $this->draw_dates($date_actual_start, $date_actual_completion, $y, $color, true);
-    }
-    $y += $this->bar_height;
-
-    $y += $this->task_padding;
-    // Grid line below current task
-    imageLine($this->image, 0, $y, $this->width, $y, $this->color_grid);
-
-    $this->y = $y;              // Store Y back in class variable for another time
-
-    // Register milestones
-    if ($t["taskTypeID"] == 'Milestone' && ($date_target_completion || $date_actual_completion)) {
-      if ($date_actual_completion) {
-        $date_milestone = $date_actual_completion;
-      } else {
-        $date_milestone = $date_target_completion;
-      }
-      $this->register_milestone($date_milestone);
+        $this->y = $this->top_margin;
     }
 
-  }
-
-  function register_milestone($date) {
-    $this->milestones[] = $date;
-  }
-
-  function draw_milestones() {
-    reset($this->milestones);
-    while (list(, $milestone) = each($this->milestones)) {
-      $x = $this->date_to_x($milestone);
-      imageDashedLine($this->image, $x, $this->top_margin, $x, $this->height - $this->bottom_margin, $this->color_milestone);
-      imageDashedLine($this->image, $x + 1, $this->top_margin, $x + 1, $this->height - $this->bottom_margin, $this->color_milestone);
-    }
-  }
-
-  function draw_today() {
-#$x = $this->date_stamp_to_x(mktime());
-    $x = $this->date_to_x(date("Y-m-d"));
-    imageDashedLine($this->image, $x, $this->top_margin, $x, $this->height - $this->bottom_margin, $this->color_today);
-    imageDashedLine($this->image, $x + 1, $this->top_margin, $x + 1, $this->height - $this->bottom_margin, $this->color_today);
-  }
-
-  function draw_dates($date_start, $date_completion, $y, $color, $filled) {
-    echo_debug("Drawing '$date_start' to '$date_completion'<br>");
-    #echo("Drawing '$date_start' to '$date_completion'<br>");
-    if ($date_start && $date_completion) {
-      // Task is complete - show full bar
-      echo_debug("Drawing date range<br>");
-      $x_start = $this->date_to_x($date_start);
-      $x_completion = $this->date_to_x($date_completion);
-      $this->draw_rectangle($x_start, $y, $x_completion, $y + $this->bar_height, $color, $filled);
-    } else if ($date_completion) {
-      // We can only show the completion date - draw a triangle
-      echo_debug("Drawing completion date<br>");
-      $x_completion = $this->date_to_x($date_completion);
-      echo_debug("Completion date x=$x_completion<br>");
-      $this->draw_polygon(array($x_completion, $y, $x_completion, $y + $this->bar_height, $x_completion - 4, $y + 4), 3, $color, $filled);
-    } else if ($date_start) {
-      // We can only show the start date - draw a triangle
-      echo_debug("Drawing start date<br>");
-      $x_start = $this->date_to_x($date_start);
-      $this->draw_polygon(array($x_start, $y, $x_start, $y + $this->bar_height, $x_start + 4, $y + 4), 3, $color, $filled);
-    }
-  }
-
-  function draw_grid() {
-    global $graph_start_date;
-    global $graph_completion_date;
-
-    $start_stamp = format_date("U",$graph_start_date);
-    $completion_stamp = format_date("U",$graph_completion_date);
-    $graph_time_width = $completion_stamp - $start_stamp;
-
-    // 7 Day increment
-    $time_increment = mktime(0, 0, 0, 0, TICK_SIZE) - mktime(0, 0, 0, 0, 0);
-    if ($time_increment * (MAX_TICKS + 1) < $graph_time_width) {
-      $time_increment = mktime(0, 0, 0, 0, LARGE_TICK_SIZE) - mktime(0, 0, 0, 0, 0);
+    function set_width($width)
+    {
+        $width and $this->width = $width;
     }
 
-    $current_stamp = $start_stamp;
+    function set_title($title)
+    {
+        $this->title = strip_tags(str_replace('\\', '', $title));
+    }
+
+    function draw_task($t)
+    {
+        $y = $this->y;              // Store y in local variable for quick access
+        $y += $this->task_padding;
+
+        $indent = $t["padding"];
+        $task = $t["object"];
+
+      // Text
+        $text = $t["taskName"];
+        echo_debug("task: $text<br>");
+        imagettftext($this->image, ALLOC_FONT_SIZE, 0, 6 + ($indent * $this->indent_increment), $y + 13, $this->color_text, ALLOC_FONT, $text);
+
+      // Get date values
+        $date_target_start = $t["dateTargetStart"];
+        $date_target_start == "0000-00-00" and $date_target_start = "";
+
+        $date_target_completion = $t["dateTargetCompletion"];
+        $date_target_completion == "0000-00-00" and $date_target_completion = "";
+
+        $date_actual_start = $t["dateActualStart"];
+        $date_actual_start == "0000-00-00" and $date_actual_start = "";
+
+        $date_actual_completion = $t["dateActualCompletion"];
+        $date_actual_completion == "0000-00-00" and $date_actual_completion = "";
+
+      // target bar
+        $color = $this->task_colors[$t["taskTypeID"]]["target"];
+        $this->draw_dates($date_target_start, $date_target_completion, $y, $color, true);
+        $y += $this->bar_height;
+
+      // actual bar
+        if ($date_actual_completion == "" && $date_actual_start != "") {
+          // Task isn't complete but we can forecast comlpetion using percent complete and start date - show forecast
+            $forecast = $task->get_forecast_completion();
+            $forecast and $date_forecast_completion = date("Y-m-d", $forecast);
+            $color = $this->task_colors[$t["taskTypeID"]]["actual"];
+            $forecast and $this->draw_dates($date_actual_start, $date_forecast_completion, $y, $color, false);      // Forecast bar
+            $this->draw_dates($date_actual_start, date("Y-m-d"), $y, $color, true);   // Solid bar for already completed portion
+        } else {
+          // Just show dates as usual
+            $color = $this->task_colors[$t["taskTypeID"]]["actual"];
+            $this->draw_dates($date_actual_start, $date_actual_completion, $y, $color, true);
+        }
+        $y += $this->bar_height;
+
+        $y += $this->task_padding;
+      // Grid line below current task
+        imageLine($this->image, 0, $y, $this->width, $y, $this->color_grid);
+
+        $this->y = $y;              // Store Y back in class variable for another time
+
+      // Register milestones
+        if ($t["taskTypeID"] == 'Milestone' && ($date_target_completion || $date_actual_completion)) {
+            if ($date_actual_completion) {
+                $date_milestone = $date_actual_completion;
+            } else {
+                $date_milestone = $date_target_completion;
+            }
+            $this->register_milestone($date_milestone);
+        }
+    }
+
+    function register_milestone($date)
+    {
+        $this->milestones[] = $date;
+    }
+
+    function draw_milestones()
+    {
+        reset($this->milestones);
+        while (list(, $milestone) = each($this->milestones)) {
+            $x = $this->date_to_x($milestone);
+            imageDashedLine($this->image, $x, $this->top_margin, $x, $this->height - $this->bottom_margin, $this->color_milestone);
+            imageDashedLine($this->image, $x + 1, $this->top_margin, $x + 1, $this->height - $this->bottom_margin, $this->color_milestone);
+        }
+    }
+
+    function draw_today()
+    {
+  #$x = $this->date_stamp_to_x(mktime());
+        $x = $this->date_to_x(date("Y-m-d"));
+        imageDashedLine($this->image, $x, $this->top_margin, $x, $this->height - $this->bottom_margin, $this->color_today);
+        imageDashedLine($this->image, $x + 1, $this->top_margin, $x + 1, $this->height - $this->bottom_margin, $this->color_today);
+    }
+
+    function draw_dates($date_start, $date_completion, $y, $color, $filled)
+    {
+        echo_debug("Drawing '$date_start' to '$date_completion'<br>");
+      #echo("Drawing '$date_start' to '$date_completion'<br>");
+        if ($date_start && $date_completion) {
+          // Task is complete - show full bar
+            echo_debug("Drawing date range<br>");
+            $x_start = $this->date_to_x($date_start);
+            $x_completion = $this->date_to_x($date_completion);
+            $this->draw_rectangle($x_start, $y, $x_completion, $y + $this->bar_height, $color, $filled);
+        } else if ($date_completion) {
+          // We can only show the completion date - draw a triangle
+            echo_debug("Drawing completion date<br>");
+            $x_completion = $this->date_to_x($date_completion);
+            echo_debug("Completion date x=$x_completion<br>");
+            $this->draw_polygon(array($x_completion, $y, $x_completion, $y + $this->bar_height, $x_completion - 4, $y + 4), 3, $color, $filled);
+        } else if ($date_start) {
+          // We can only show the start date - draw a triangle
+            echo_debug("Drawing start date<br>");
+            $x_start = $this->date_to_x($date_start);
+            $this->draw_polygon(array($x_start, $y, $x_start, $y + $this->bar_height, $x_start + 4, $y + 4), 3, $color, $filled);
+        }
+    }
+
+    function draw_grid()
+    {
+        global $graph_start_date;
+        global $graph_completion_date;
+
+        $start_stamp = format_date("U", $graph_start_date);
+        $completion_stamp = format_date("U", $graph_completion_date);
+        $graph_time_width = $completion_stamp - $start_stamp;
+
+      // 7 Day increment
+        $time_increment = mktime(0, 0, 0, 0, TICK_SIZE) - mktime(0, 0, 0, 0, 0);
+        if ($time_increment * (MAX_TICKS + 1) < $graph_time_width) {
+            $time_increment = mktime(0, 0, 0, 0, LARGE_TICK_SIZE) - mktime(0, 0, 0, 0, 0);
+        }
+
+        $current_stamp = $start_stamp;
     
 
-    while ($current_stamp < $completion_stamp) {
-      $x_pos = $this->date_stamp_to_x($current_stamp);
-      imageLine($this->image, $x_pos, $this->top_margin - 5, $x_pos, $this->height - $this->bottom_margin, $this->color_grid);
-      imagettftext($this->image, ALLOC_FONT_SIZE - 2, 45, $x_pos, $this->top_margin - 7, $this->color_text, ALLOC_FONT, date("M-d", $current_stamp));
-      $current_stamp += $time_increment;
+        while ($current_stamp < $completion_stamp) {
+            $x_pos = $this->date_stamp_to_x($current_stamp);
+            imageLine($this->image, $x_pos, $this->top_margin - 5, $x_pos, $this->height - $this->bottom_margin, $this->color_grid);
+            imagettftext($this->image, ALLOC_FONT_SIZE - 2, 45, $x_pos, $this->top_margin - 7, $this->color_text, ALLOC_FONT, date("M-d", $current_stamp));
+            $current_stamp += $time_increment;
+        }
+
+      // Horizontal line above tasks
+        imageLine($this->image, 0, $this->top_margin, $this->width, $this->top_margin, $this->color_grid);
     }
 
-    // Horizontal line above tasks
-    imageLine($this->image, 0, $this->top_margin, $this->width, $this->top_margin, $this->color_grid);
-  }
-
-  function draw_polygon($points, $num_points, $color, $filled) {
-    if ($filled) {
-      imageFilledPolygon($this->image, $points, $num_points, $color);
-    } else {
-      imagePolygon($this->image, $points, $num_points, $color);
+    function draw_polygon($points, $num_points, $color, $filled)
+    {
+        if ($filled) {
+            imageFilledPolygon($this->image, $points, $num_points, $color);
+        } else {
+            imagePolygon($this->image, $points, $num_points, $color);
+        }
     }
-  }
 
-  function draw_rectangle($x1, $y1, $x2, $y2, $color, $filled) {
-    if ($filled) {
-      imageFilledRectangle($this->image, $x1, $y1, $x2, $y2, $color);
-    } else {
-      imageRectangle($this->image, $x1, $y1, $x2, $y2, $color);
+    function draw_rectangle($x1, $y1, $x2, $y2, $color, $filled)
+    {
+        if ($filled) {
+            imageFilledRectangle($this->image, $x1, $y1, $x2, $y2, $color);
+        } else {
+            imageRectangle($this->image, $x1, $y1, $x2, $y2, $color);
+        }
     }
-  }
 
-  function draw_legend_bar($x, $y, $text, $color, $filled) {
-    $legend_bar_width = 30;
-    $x2 = $x + $legend_bar_width;
-    $this->draw_rectangle($x, $y, $x2, $y + 8, $color, $filled);
-    $x = $x2 + $this->task_padding;
-    imagettftext($this->image, ALLOC_FONT_SIZE, 0,  $x, $y + 10, $this->color_text, ALLOC_FONT, $text);
-  }
+    function draw_legend_bar($x, $y, $text, $color, $filled)
+    {
+        $legend_bar_width = 30;
+        $x2 = $x + $legend_bar_width;
+        $this->draw_rectangle($x, $y, $x2, $y + 8, $color, $filled);
+        $x = $x2 + $this->task_padding;
+        imagettftext($this->image, ALLOC_FONT_SIZE, 0, $x, $y + 10, $this->color_text, ALLOC_FONT, $text);
+    }
 
   // If $start == true draws a starting triangle, otherwise draws an ending triangle
-  function draw_legend_marker($x, $y, $text, $color, $start) {
-    $legend_bar_width = 30;
-    $x2 = $x + $legend_bar_width;
-    if ($start) {
-      $points = array($x, $y, $x, $y + 8, $x + 4, $y + 4);
-    } else {
-      $points = array($x + 4, $y, $x + 4, $y + 8, $x, $y + 4);
+    function draw_legend_marker($x, $y, $text, $color, $start)
+    {
+        $legend_bar_width = 30;
+        $x2 = $x + $legend_bar_width;
+        if ($start) {
+            $points = array($x, $y, $x, $y + 8, $x + 4, $y + 4);
+        } else {
+            $points = array($x + 4, $y, $x + 4, $y + 8, $x, $y + 4);
+        }
+        $this->draw_polygon($points, 3, $color, true);
+        $x = $x2 + $this->task_padding;
+        imagettftext($this->image, ALLOC_FONT_SIZE, 0, $x, $y +10, $this->color_text, ALLOC_FONT, $text);
     }
-    $this->draw_polygon($points, 3, $color, true);
-    $x = $x2 + $this->task_padding;
-    imagettftext($this->image, ALLOC_FONT_SIZE, 0, $x, $y +10, $this->color_text, ALLOC_FONT, $text);
-  }
 
-  function draw_legend() {
-    $y = $this->y;              // Store y in local variable for quick access
-    $left_x = 3;
-    $center_x = $this->width / 2;
+    function draw_legend()
+    {
+        $y = $this->y;              // Store y in local variable for quick access
+        $left_x = 3;
+        $center_x = $this->width / 2;
 
-    $y = $this->height - $this->bottom_margin + 20;
+        $y = $this->height - $this->bottom_margin + 20;
 
-    imagettftext($this->image, ALLOC_FONT_SIZE, 0,  $this->task_padding, $y+10, $this->color_text, ALLOC_FONT, "Legend:");
-    $y += 20;
+        imagettftext($this->image, ALLOC_FONT_SIZE, 0, $this->task_padding, $y+10, $this->color_text, ALLOC_FONT, "Legend:");
+        $y += 20;
 
-    $this->draw_legend_bar($left_x, $y, "Target task period", $this->task_colors['Task']["target"], true);
-    $this->draw_legend_bar($center_x, $y, "Target phase period", $this->task_colors['Parent']["target"], true);
-    $y += 12;
+        $this->draw_legend_bar($left_x, $y, "Target task period", $this->task_colors['Task']["target"], true);
+        $this->draw_legend_bar($center_x, $y, "Target phase period", $this->task_colors['Parent']["target"], true);
+        $y += 12;
 
-    $this->draw_legend_bar($left_x, $y, "Actual task period", $this->task_colors['Task']["actual"], true);
-    $this->draw_legend_bar($center_x, $y, "Actual phase period", $this->task_colors['Parent']["actual"], true);
-    $y += 12;
+        $this->draw_legend_bar($left_x, $y, "Actual task period", $this->task_colors['Task']["actual"], true);
+        $this->draw_legend_bar($center_x, $y, "Actual phase period", $this->task_colors['Parent']["actual"], true);
+        $y += 12;
 
-    $this->draw_legend_bar($left_x, $y, "Forecast task period", $this->task_colors['Task']["actual"], false);
-    $this->draw_legend_bar($center_x, $y, "Forecast phase period", $this->task_colors['Parent']["actual"], false);
-    $y += 12;
+        $this->draw_legend_bar($left_x, $y, "Forecast task period", $this->task_colors['Task']["actual"], false);
+        $this->draw_legend_bar($center_x, $y, "Forecast phase period", $this->task_colors['Parent']["actual"], false);
+        $y += 12;
 
-    $this->draw_legend_marker($left_x, $y, "Start date (completion date not known)", $this->task_colors['Task']["actual"], true);
-    $y += 12;
+        $this->draw_legend_marker($left_x, $y, "Start date (completion date not known)", $this->task_colors['Task']["actual"], true);
+        $y += 12;
 
-    $this->draw_legend_marker($left_x, $y, "Completion date (start date not known)", $this->task_colors['Parent']["actual"], false);
-    $y += 12;
+        $this->draw_legend_marker($left_x, $y, "Completion date (start date not known)", $this->task_colors['Parent']["actual"], false);
+        $y += 12;
 
-    $this->y = $y;              // Store Y back in class variable for another time
-  }
+        $this->y = $y;              // Store Y back in class variable for another time
+    }
 
   // Converts from a date string to an X coordinate
-  function date_to_x($date) {
-    echo_debug("Converting $date<br>");
-    return $this->date_stamp_to_x(format_date("U",$date));
-  }
+    function date_to_x($date)
+    {
+        echo_debug("Converting $date<br>");
+        return $this->date_stamp_to_x(format_date("U", $date));
+    }
 
   // Converts from a unix time stamp to an X coordinate
-  function date_stamp_to_x($date) {
-    global $graph_start_date;
-    global $graph_completion_date;
+    function date_stamp_to_x($date)
+    {
+        global $graph_start_date;
+        global $graph_completion_date;
 
-    $graph_time_width = format_date("U",$graph_completion_date) - format_date("U",$graph_start_date);
-    $time_offset = $date - format_date("U",$graph_start_date);
-    $graph_time_width and $decimal_pos = $time_offset / $graph_time_width;
-    $working_width = $this->width - $this->left_margin - $this->right_margin;
-    $x_pos = $this->left_margin + $decimal_pos * $working_width;
+        $graph_time_width = format_date("U", $graph_completion_date) - format_date("U", $graph_start_date);
+        $time_offset = $date - format_date("U", $graph_start_date);
+        $graph_time_width and $decimal_pos = $time_offset / $graph_time_width;
+        $working_width = $this->width - $this->left_margin - $this->right_margin;
+        $x_pos = $this->left_margin + $decimal_pos * $working_width;
 
-    return $x_pos;
-  }
+        return $x_pos;
+    }
 
   // Output the image
-  function output() {
+    function output()
+    {
 
-    if (ALLOC_GD_IMAGE_TYPE == "PNG") {
-      header("Content-type: image/png");
-      imagePNG($this->image);
-    } else {
-      header("Content-type: image/gif");
-      imageGIF($this->image);
+        if (ALLOC_GD_IMAGE_TYPE == "PNG") {
+            header("Content-type: image/png");
+            imagePNG($this->image);
+        } else {
+            header("Content-type: image/gif");
+            imageGIF($this->image);
+        }
     }
-  }
 }
 
-  function get_date_range($tasks=array()) {
+function get_date_range($tasks = array())
+{
     global $graph_start_date;
     global $graph_completion_date;
 
     if (count($tasks) == 0) {
-      return;
+        return;
     }
 
     $graph_start_date = "9999-00-00";
@@ -386,39 +404,34 @@ class task_graph
 
     reset($tasks);
     while (list(, $task) = each($tasks)) {
-      if ($task->get_value("dateTargetStart") != "" && $task->get_value("dateTargetStart") != "0000-00-00" && $task->get_value("dateTargetStart") < $graph_start_date) {
-        $graph_start_date = $task->get_value("dateTargetStart");
-  #echo "A: $graph_start_date<br>";
-      }
+        if ($task->get_value("dateTargetStart") != "" && $task->get_value("dateTargetStart") != "0000-00-00" && $task->get_value("dateTargetStart") < $graph_start_date) {
+            $graph_start_date = $task->get_value("dateTargetStart");
+    #echo "A: $graph_start_date<br>";
+        }
 
-      if ($task->get_value("dateTargetCompletion") > $graph_completion_date) {
-        $graph_completion_date = $task->get_value("dateTargetCompletion");
-      }
+        if ($task->get_value("dateTargetCompletion") > $graph_completion_date) {
+            $graph_completion_date = $task->get_value("dateTargetCompletion");
+        }
 
-      if ($task->get_value("dateActualStart") != "" && $task->get_value("dateActualStart") != "0000-00-00" && $task->get_value("dateActualStart") < $graph_start_date) {
-        $graph_start_date = $task->get_value("dateActualStart");
-  #echo "B: $graph_start_date<br>";
-      }
+        if ($task->get_value("dateActualStart") != "" && $task->get_value("dateActualStart") != "0000-00-00" && $task->get_value("dateActualStart") < $graph_start_date) {
+            $graph_start_date = $task->get_value("dateActualStart");
+    #echo "B: $graph_start_date<br>";
+        }
 
-      if ($task->get_value("dateActualCompletion") > $graph_completion_date) {
-        $graph_completion_date = $task->get_value("dateActualCompletion");
-      }
+        if ($task->get_value("dateActualCompletion") > $graph_completion_date) {
+            $graph_completion_date = $task->get_value("dateActualCompletion");
+        }
 
-      if (date("Y-m-d", $task->get_forecast_completion()) > $graph_completion_date) {
-        $graph_completion_date = date("Y-m-d", $task->get_forecast_completion());
-      }
-
+        if (date("Y-m-d", $task->get_forecast_completion()) > $graph_completion_date) {
+            $graph_completion_date = date("Y-m-d", $task->get_forecast_completion());
+        }
     }
 
     if ($graph_start_date == "9999-00-00") {
-      image_die("No Tasks with a Start Date set");
+        image_die("No Tasks with a Start Date set");
     }
 
     if ($graph_completion_date == "0000-00-00") {
-      image_die("No Tasks with a Completion Date set");
+        image_die("No Tasks with a Completion Date set");
     }
-  }
-
-
-
-?>
+}

--- a/project/parseCSV.php
+++ b/project/parseCSV.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,24 +23,25 @@
 require_once("../alloc.php");
 
 if ($_POST['import']) {
-  $projectID = $_POST["projectID"];
-  $result = import_csv($_POST["filename"], $_POST["columns"], $_POST["headerRow"]);
-  $TPL['result'] = $result;
-  $TPL['main_alloc_title'] = "CSV Import Results";
-  $TPL['projectID'] = $projectID;
-  include_template("templates/csvImportResultM.tpl");
-  exit;
+    $projectID = $_POST["projectID"];
+    $result = import_csv($_POST["filename"], $_POST["columns"], $_POST["headerRow"]);
+    $TPL['result'] = $result;
+    $TPL['main_alloc_title'] = "CSV Import Results";
+    $TPL['projectID'] = $projectID;
+    include_template("templates/csvImportResultM.tpl");
+    exit;
 }
 
 //$_GET["filename"] = "/var/local/alloc/tmp/test.csv";
 $basepath = ATTACHMENTS_DIR.'tmp'.DIRECTORY_SEPARATOR;
 $rp = realpath($basepath.$_GET['filename']);
-if ($rp === FALSE || strpos($rp, $basepath) !== 0)
-  alloc_error("Illegal path",true);
+if ($rp === false || strpos($rp, $basepath) !== 0) {
+    alloc_error("Illegal path", true);
+}
 
 $fh = fopen($rp, "r");
 if ($fh === false) {
-  alloc_error("File won't open.",true);
+    alloc_error("File won't open.", true);
 }
 
 $rows = array();
@@ -49,8 +50,8 @@ $header = fgetcsv($fh);
 $rows []= $header;
 
 // only displaying the first 3 rows so the user can assign fields
-for ($i = 0;$i < 2;$i++) {
-  $rows []= fgetcsv($fh);
+for ($i = 0; $i < 2; $i++) {
+    $rows []= fgetcsv($fh);
 }
 
 $columns = array();
@@ -58,9 +59,9 @@ $columns = array();
 // see if it's possible to make sense of the header row
 if (in_array("name", $header)) {
   // official-ish header row, try to pre-parse it
-  $TPL["headerRow"] = 'checked="checked"';
+    $TPL["headerRow"] = 'checked="checked"';
 } else {
-  $header = array();
+    $header = array();
 }
 
 $options = array('ignore' => 'Ignore',
@@ -80,12 +81,12 @@ $options = array('ignore' => 'Ignore',
 // Each row is <dropdown> <data> <data> <data>
 
 $TPL["rows"] = array();
-for ($i = 0; $i < min(11, count($rows[0]));$i++) {
-  $TPL["rows"] []= array(
+for ($i = 0; $i < min(11, count($rows[0])); $i++) {
+    $TPL["rows"] []= array(
     'name' => "row_$i",
     'dropdown' => page::select_options($options, $header[$i]),
     'cols' => array($rows[0][$i], $rows[1][$i], $rows[2][$i])
-  );
+    );
 }
 
 $TPL['message_help'] = "Use the dropdowns to indicate how each column should be interpreted.";
@@ -94,6 +95,3 @@ $TPL['filename'] = $_GET['filename'];
 $TPL['projectID'] = $_GET['projectID'];
 $TPL['main_alloc_title'] = "Process CSV upload";
 include_template("templates/csvImportM.tpl");
-
-?>
-

--- a/project/personGraph.php
+++ b/project/personGraph.php
@@ -3,61 +3,59 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function show_people($template_name) {
-  global $person_query;
-  global $project;
-  global $TPL;
+function show_people($template_name)
+{
+    global $person_query;
+    global $project;
+    global $TPL;
 
-  $db = new db_alloc();
-  $db->query($person_query);
-  while ($db->next_record()) {
-    $person = new person();
-    $person->read_db_record($db);
-    $person->set_values("person_");
-    $TPL["graphTitle"] = urlencode($person->get_name());
-    include_template($template_name);
-  }
+    $db = new db_alloc();
+    $db->query($person_query);
+    while ($db->next_record()) {
+        $person = new person();
+        $person->read_db_record($db);
+        $person->set_values("person_");
+        $TPL["graphTitle"] = urlencode($person->get_name());
+        include_template($template_name);
+    }
 }
 
 $projectID = $_POST["projectID"] or $projectID = $_GET["projectID"];
 
 if ($projectID) {
-  $project = new project();
-  $project->set_id($projectID);
-  $project->select();
-  $TPL["navigation_links"] = $project->get_navigation_links();
-  $person_query = prepare("SELECT person.*
+    $project = new project();
+    $project->set_id($projectID);
+    $project->select();
+    $TPL["navigation_links"] = $project->get_navigation_links();
+    $person_query = prepare("SELECT person.*
                              FROM person, projectPerson
                             WHERE person.personID = projectPerson.personID
                               AND projectPerson.projectID=%d", $project->get_id());
-
 } else if ($_GET["personID"]) {
-  $person_query = prepare("SELECT * FROM person WHERE personID = %d ORDER BY username",$_GET["personID"]);
+    $person_query = prepare("SELECT * FROM person WHERE personID = %d ORDER BY username", $_GET["personID"]);
 } else {
-  $person_query = prepare("SELECT * FROM person ORDER BY username");
+    $person_query = prepare("SELECT * FROM person ORDER BY username");
 }
 
 $TPL["projectID"] = $projectID;
 $TPL["main_alloc_title"] = "Allocation Graph - ".APPLICATION_NAME;
 include_template("templates/personGraphM.tpl");
-
-?>

--- a/project/personGraphImage.php
+++ b/project/personGraphImage.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -24,7 +24,7 @@ require_once("../alloc.php");
 include("lib/task_graph.inc.php");
 
 if ($_GET["projectID"]) {
-  $options["projectIDs"][] = $_GET["projectID"];
+    $options["projectIDs"][] = $_GET["projectID"];
 }
 
 $options["personID"] = $_GET["personID"];
@@ -34,7 +34,7 @@ $options["taskStatus"] = "open";
 $options["showTaskID"] = true;
 
 if ($_GET["graph_type"] == "phases") {
-  $options["taskTypeID"] = 'Parent';
+    $options["taskTypeID"] = 'Parent';
 }
 
 $task_graph = new task_graph();
@@ -45,19 +45,16 @@ $task_graph->bottom_margin = 20;
 $tasks = task::get_list($options) or $tasks = array();
 
 foreach ($tasks as $task) {
-  $objects[$task["taskID"]] = $task["object"];
+    $objects[$task["taskID"]] = $task["object"];
 }
 
 $task_graph->init($objects);
 $task_graph->draw_grid();
 
 foreach ($tasks as $task) {
-  $task_graph->draw_task($task);
+    $task_graph->draw_task($task);
 }
 
 $task_graph->draw_milestones();
 $task_graph->draw_today();
 $task_graph->output();
-
-
-?>

--- a/project/project.php
+++ b/project/project.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -25,25 +25,28 @@ require_once("../alloc.php");
 
 
 
-  function show_attachments() {
+function show_attachments()
+{
     global $projectID;
-    util_show_attachments("project",$projectID);
-  }
+    util_show_attachments("project", $projectID);
+}
 
-  function list_attachments($template_name) {
+function list_attachments($template_name)
+{
     global $TPL;
     global $projectID;
 
     if ($projectID) {
-      $rows = get_attachments("project",$projectID);
-      foreach ($rows as $row) {
-        $TPL = array_merge($TPL,$row);
-        include_template($template_name);
-      }
+        $rows = get_attachments("project", $projectID);
+        foreach ($rows as $row) {
+            $TPL = array_merge($TPL, $row);
+            include_template($template_name);
+        }
     }
-  }
+}
 
-  function show_transaction($template) {
+function show_transaction($template)
+{
     global $db;
     global $TPL;
     global $projectID;
@@ -52,34 +55,32 @@ require_once("../alloc.php");
     $transaction = new transaction();
 
     if (isset($projectID) && $projectID) {
-      $query = prepare("SELECT transaction.*
+        $query = prepare("SELECT transaction.*
                           FROM transaction
                           WHERE transaction.projectID = %d
                       ORDER BY transactionModifiedTime desc
                         ", $projectID);
-      $db->query($query);
-      while ($db->next_record()) {
-        $transaction = new transaction();
-        $transaction->read_db_record($db);
-        $transaction->set_values("transaction_");
+        $db->query($query);
+        while ($db->next_record()) {
+            $transaction = new transaction();
+            $transaction->read_db_record($db);
+            $transaction->set_values("transaction_");
 
-        $tf = $transaction->get_foreign_object("tf");
-        $tf->set_values();
-        $tf->set_values("tf_");
+            $tf = $transaction->get_foreign_object("tf");
+            $tf->set_values();
+            $tf->set_values("tf_");
 
-        $TPL["transaction_username"] = $db->f("username");
-        $TPL["transaction_amount"] = page::money($TPL["transaction_currenyTypeID"],$TPL["transaction_amount"],"%s%mo");
-        $TPL["transaction_type_link"] = $transaction->get_transaction_type_link() or $TPL["transaction_link"] = $transaction->get_value("transactionType");
+            $TPL["transaction_username"] = $db->f("username");
+            $TPL["transaction_amount"] = page::money($TPL["transaction_currenyTypeID"], $TPL["transaction_amount"], "%s%mo");
+            $TPL["transaction_type_link"] = $transaction->get_transaction_type_link() or $TPL["transaction_link"] = $transaction->get_value("transactionType");
 
-        include_template($template);
-
-      }
-
-
+            include_template($template);
+        }
     }
-  }
+}
 
-  function show_invoices() {
+function show_invoices()
+{
     $current_user = &singleton("current_user");
     global $project;
     $clientID = $project->get_value("clientID");
@@ -96,49 +97,52 @@ require_once("../alloc.php");
     $_FORM["clientID"] = $clientID;
     $_FORM["projectID"] = $projectID;
 
-    // Restrict non-admin users records  
+    // Restrict non-admin users records
     if (!$current_user->have_role("admin")) {
-      $_FORM["personID"] = $current_user->get_id();  
+        $_FORM["personID"] = $current_user->get_id();
     }
 
     $rows = invoice::get_list($_FORM);
-    echo invoice::get_list_html($rows,$_FORM);
-  }
+    echo invoice::get_list_html($rows, $_FORM);
+}
   
-  function show_projectHistory() {
+function show_projectHistory()
+{
     global $project;
     global $TPL;
     $TPL["changeHistory"] = $project->get_changes_list();
     include_template("templates/projectHistoryM.tpl");
-  }
+}
 
-  function show_commission_list($template_name) {
+function show_commission_list($template_name)
+{
     global $TPL;
     global $db;
     global $projectID;
 
     if ($projectID) {
-      $query = prepare("SELECT * from projectCommissionPerson WHERE projectID= %d", $projectID);
-      $db->query($query);
+        $query = prepare("SELECT * from projectCommissionPerson WHERE projectID= %d", $projectID);
+        $db->query($query);
 
-      while ($db->next_record()) {
-        $commission_item = new projectCommissionPerson();
-        $commission_item->read_db_record($db);
-        $commission_item->set_values("commission_");
-        $tf = $commission_item->get_foreign_object("tf");
-        $TPL["save_label"] = "Save";
-        include_template($template_name);
-      }
+        while ($db->next_record()) {
+            $commission_item = new projectCommissionPerson();
+            $commission_item->read_db_record($db);
+            $commission_item->set_values("commission_");
+            $tf = $commission_item->get_foreign_object("tf");
+            $TPL["save_label"] = "Save";
+            include_template($template_name);
+        }
     }
-  }
+}
 
-  function show_new_commission($template_name) {
+function show_new_commission($template_name)
+{
     global $TPL;
     global $projectID;
 
     // Don't show entry form for new projects
     if (!$projectID) {
-      return;
+        return;
     }
     $TPL["commission_new"] = true;
     $commission_item = new projectCommissionPerson();
@@ -146,9 +150,10 @@ require_once("../alloc.php");
     $TPL["commission_projectID"] = $projectID;
     $TPL["save_label"] = "Add Commission";
     include_template($template_name);
-  }
+}
 
-  function show_person_list($template) {
+function show_person_list($template)
+{
     global $db;
     global $TPL;
     global $projectID;
@@ -157,51 +162,53 @@ require_once("../alloc.php");
     global $project_person_role_array;
 
     if ($projectID) {
-      $query = prepare("SELECT projectPerson.*, roleSequence
+        $query = prepare("SELECT projectPerson.*, roleSequence
                           FROM projectPerson 
                      LEFT JOIN role ON role.roleID = projectPerson.roleID
                          WHERE projectID=%d ORDER BY roleSequence DESC,projectPersonID ASC", $projectID);
-      $db->query($query);
+        $db->query($query);
 
-      while ($db->next_record()) {
-        $projectPerson = new projectPerson();
-        $projectPerson->read_db_record($db);
-        $projectPerson->set_values("person_");
-        $person = $projectPerson->get_foreign_object("person");
-        $TPL["person_username"] = $person->get_value("username");
-        $TPL["person_emailType_options"] = page::select_options($email_type_array, $TPL["person_emailType"]);
-        $TPL["person_role_options"] = page::select_options($project_person_role_array, $TPL["person_roleID"]);
-        $TPL["rateType_options"] = page::select_options($rate_type_array, $TPL["person_rateUnitID"]);
-        include_template($template);
-      }
+        while ($db->next_record()) {
+            $projectPerson = new projectPerson();
+            $projectPerson->read_db_record($db);
+            $projectPerson->set_values("person_");
+            $person = $projectPerson->get_foreign_object("person");
+            $TPL["person_username"] = $person->get_value("username");
+            $TPL["person_emailType_options"] = page::select_options($email_type_array, $TPL["person_emailType"]);
+            $TPL["person_role_options"] = page::select_options($project_person_role_array, $TPL["person_roleID"]);
+            $TPL["rateType_options"] = page::select_options($rate_type_array, $TPL["person_rateUnitID"]);
+            include_template($template);
+        }
     }
-  }
+}
 
-  function show_projectPerson_list() {
+function show_projectPerson_list()
+{
     global $db;
     global $TPL;
     global $projectID;
     $template = "templates/projectPersonSummaryViewR.tpl";
 
     if ($projectID) {
-      $query = prepare("SELECT personID, roleName
+        $query = prepare("SELECT personID, roleName
                           FROM projectPerson
                      LEFT JOIN role ON role.roleID = projectPerson.roleID
                          WHERE projectID = %d 
                       GROUP BY projectPerson.personID
                       ORDER BY roleSequence DESC, personID ASC", $projectID);
-      $db->query($query);
-      while ($db->next_record()) {
-        $projectPerson = new projectPerson();
-        $projectPerson->read_db_record($db);
-        $TPL['person_roleName'] = $db->f("roleName");
-        $TPL['person_name'] = person::get_fullname($projectPerson->get_value('personID'));
-        include_template($template);
-      }
+        $db->query($query);
+        while ($db->next_record()) {
+            $projectPerson = new projectPerson();
+            $projectPerson->read_db_record($db);
+            $TPL['person_roleName'] = $db->f("roleName");
+            $TPL['person_name'] = person::get_fullname($projectPerson->get_value('personID'));
+            include_template($template);
+        }
     }
-  }
+}
 
-  function show_new_person($template) {
+function show_new_person($template)
+{
     global $TPL;
     global $email_type_array;
     global $rate_type_array;
@@ -210,63 +217,72 @@ require_once("../alloc.php");
 
     // Don't show entry form for new projects
     if (!$projectID) {
-      return;
+        return;
     }
     $project_person = new projectPerson();
     $project_person->set_values("person_");
     $TPL["person_emailType_options"] = page::select_options($email_type_array, $TPL["person_emailType"]);
-    $TPL["person_role_options"] = page::select_options($project_person_role_array,false);
+    $TPL["person_role_options"] = page::select_options($project_person_role_array, false);
     $TPL["rateType_options"] = page::select_options($rate_type_array);
     include_template($template);
-  }
+}
 
-  function show_time_sheets($template_name) {
+function show_time_sheets($template_name)
+{
     $current_user = &singleton("current_user");
 
     if ($current_user->is_employee()) {
-      include_template($template_name);
+        include_template($template_name);
     }
-  }
+}
 
-  function show_project_managers($template_name) {
+function show_project_managers($template_name)
+{
     include_template($template_name);
-  }
+}
 
-  function show_transactions($template_name) {
+function show_transactions($template_name)
+{
     $current_user = &singleton("current_user");
 
     if ($current_user->is_employee()) {
-      include_template($template_name);
+        include_template($template_name);
     }
-  }
+}
 
-  function show_person_options() {
+function show_person_options()
+{
     global $TPL;
-    echo page::select_options(person::get_username_list($TPL["person_personID"]),$TPL["person_personID"]);
-  }
+    echo page::select_options(person::get_username_list($TPL["person_personID"]), $TPL["person_personID"]);
+}
 
-  function show_tf_options($commission_tfID) {
+function show_tf_options($commission_tfID)
+{
     global $tf_array;
     global $TPL;
     echo page::select_options($tf_array, $TPL[$commission_tfID]);
-  }
+}
 
-  function show_comments() {
+function show_comments()
+{
     global $projectID;
     global $TPL;
     global $project;
-    $TPL["commentsR"] = comment::util_get_comments("project",$projectID);
+    $TPL["commentsR"] = comment::util_get_comments("project", $projectID);
     $TPL["commentsR"] and $TPL["class_new_comment"] = "hidden";
     $interestedPartyOptions = $project->get_all_parties();
-    $interestedPartyOptions = interestedParty::get_interested_parties("project",$project->get_id()
-                                                                     ,$interestedPartyOptions);
+    $interestedPartyOptions = interestedParty::get_interested_parties(
+        "project",
+        $project->get_id(),
+        $interestedPartyOptions
+    );
     $TPL["allParties"] = $interestedPartyOptions or $TPL["allParties"] = array();
     $TPL["entity"] = "project";
     $TPL["entityID"] = $project->get_id();
     $TPL["clientID"] = $project->get_value("clientID");
 
     $commentTemplate = new commentTemplate();
-    $ops = $commentTemplate->get_assoc_array("commentTemplateID","commentTemplateName","",array("commentTemplateType"=>"project"));
+    $ops = $commentTemplate->get_assoc_array("commentTemplateID", "commentTemplateName", "", array("commentTemplateType"=>"project"));
     $TPL["commentTemplateOptions"] = "<option value=\"\">Comment Templates</option>".page::select_options($ops);
 
     $ops = array(""=>"Format as...","pdf"=>"PDF","pdf_plus"=>"PDF+","html"=>"HTML","html_plus"=>"HTML+");
@@ -276,14 +292,15 @@ require_once("../alloc.php");
     $TPL["attach_extra_files"].= '<select name="attach_tasks">'.page::select_options($ops).'</select><br>';
 
     include_template("../comment/templates/commentM.tpl");
-  }
+}
 
-  function show_tasks() {
+function show_tasks()
+{
     global $TPL;
     global $project;
     $options["showHeader"] = true;
     $options["taskView"] = "byProject";
-    $options["projectIDs"] = array($project->get_id());   
+    $options["projectIDs"] = array($project->get_id());
     $options["taskStatus"] = array("open","pending");
     $options["showTaskID"] = true;
     $options["showAssigned"] = true;
@@ -293,15 +310,16 @@ require_once("../alloc.php");
     #$options["showTimes"] = true; // performance hit
     $options["return"] = "html";
     // $TPL["taskListRows"] is used for the budget estimatation outside of this function
-    $options = ace_augment("project_page_task_list_options",$options);
-    $TPL["taskListRows"] = task::get_list($options); 
+    $options = ace_augment("project_page_task_list_options", $options);
+    $TPL["taskListRows"] = task::get_list($options);
     $TPL["_FORM"] = $options;
-    include_template("templates/projectTaskS.tpl"); 
-  }
+    include_template("templates/projectTaskS.tpl");
+}
 
-  function show_import_export($template) {
+function show_import_export($template)
+{
     include_template($template);
-  }
+}
 
 
 // END FUNCTIONS
@@ -316,196 +334,188 @@ $projectID = $_POST["projectID"] or $projectID = $_GET["projectID"];
 $project = new project();
 
 if ($projectID) {
-  $project->set_id($projectID);
-  $project->select();
-  $new_project = false;
-  if (!$project->have_perm(PERM_UPDATE)) {
-    $TPL["message_help"][] = "Project is read-only for you.";
-  }
+    $project->set_id($projectID);
+    $project->select();
+    $new_project = false;
+    if (!$project->have_perm(PERM_UPDATE)) {
+        $TPL["message_help"][] = "Project is read-only for you.";
+    }
 } else {
-  $new_project = true;
+    $new_project = true;
 }
 
 
 
 if ($_POST["save"]) {
-  $project->read_globals();
+    $project->read_globals();
 
-  if (!$project->get_id()) {    // brand new project
-    $definitely_new_project = true;
-  }
+    if (!$project->get_id()) {    // brand new project
+        $definitely_new_project = true;
+    }
 
-  if (!$project->get_value("projectName")) {  
-    alloc_error("Please enter a name for the Project.");
-  }  
+    if (!$project->get_value("projectName")) {
+        alloc_error("Please enter a name for the Project.");
+    }
 
   // enforced at the database, but show a friendlier error here if possible
-  $query = prepare("SELECT COUNT(*) as count FROM project WHERE projectShortName = '%s'", $db->esc($project->get_value("projectShortName")));
-  if (!$definitely_new_project) {
-    $query .= prepare(" AND projectID != %d", $project->get_id());
-  }
-  $db->query($query);
-  $db->next_record();
-  if ($db->f('count') > 0) {
-    alloc_error("A project with that nickname already exists.");
-  }
-
-  if (!$TPL["message"]) {
-
-    $project->set_value("projectComments",rtrim($project->get_value("projectComments")));
-    $project->save();
-    $projectID = $project->get_id();
-    interestedParty::make_interested_parties("project",$project->get_id(),$_POST["interestedParty"]);
-
-    $client = new client();
-    $client->set_id($project->get_value("clientID"));
-    $client->select();
-    if ($client->get_value("clientStatus") == 'Potential') {
-      $client->set_value("clientStatus", "Current");
-      $client->save();
+    $query = prepare("SELECT COUNT(*) as count FROM project WHERE projectShortName = '%s'", $db->esc($project->get_value("projectShortName")));
+    if (!$definitely_new_project) {
+        $query .= prepare(" AND projectID != %d", $project->get_id());
     }
+    $db->query($query);
+    $db->next_record();
+    if ($db->f('count') > 0) {
+        alloc_error("A project with that nickname already exists.");
+    }
+
+    if (!$TPL["message"]) {
+        $project->set_value("projectComments", rtrim($project->get_value("projectComments")));
+        $project->save();
+        $projectID = $project->get_id();
+        interestedParty::make_interested_parties("project", $project->get_id(), $_POST["interestedParty"]);
+
+        $client = new client();
+        $client->set_id($project->get_value("clientID"));
+        $client->select();
+        if ($client->get_value("clientStatus") == 'Potential') {
+            $client->set_value("clientStatus", "Current");
+            $client->save();
+        }
    
-    if ($definitely_new_project) {
-      $projectPerson = new projectPerson();
-      $projectPerson->currency = $project->get_value("currencyTypeID");
-      $projectPerson->set_value("projectID", $projectID);
-      $projectPerson->set_value_role("isManager");
-      $projectPerson->set_value("personID", $current_user->get_id());
-      $projectPerson->save();
+        if ($definitely_new_project) {
+            $projectPerson = new projectPerson();
+            $projectPerson->currency = $project->get_value("currencyTypeID");
+            $projectPerson->set_value("projectID", $projectID);
+            $projectPerson->set_value_role("isManager");
+            $projectPerson->set_value("personID", $current_user->get_id());
+            $projectPerson->save();
+        }
+        alloc_redirect($TPL["url_alloc_project"]."projectID=".$project->get_id());
     }
-    alloc_redirect($TPL["url_alloc_project"]."projectID=".$project->get_id());
-  }
 } else if ($_POST["delete"]) {
-  $project->read_globals();
-  $project->delete();
-  alloc_redirect($TPL["url_alloc_projectList"]);
+    $project->read_globals();
+    $project->delete();
+    alloc_redirect($TPL["url_alloc_projectList"]);
 
 // If they are creating a new project that is based on an existing one
 } else if ($_POST["copy_project_save"] && $_POST["copy_projectID"] && $_POST["copy_project_name"]) {
-  
-  $p = new project();
-  $p->set_id($_POST["copy_projectID"]);
-  if ($p->select()) {
-    $p2 = new project();
-    $p2->read_row_record($p->row());
-    $p2->set_id("");
-    $p2->set_value("projectName",$_POST["copy_project_name"]);
-    $p2->set_value("projectShortName","");
-    $p2->save();
-    $TPL["message_good"][] = "Project details copied successfully.";
+    $p = new project();
+    $p->set_id($_POST["copy_projectID"]);
+    if ($p->select()) {
+        $p2 = new project();
+        $p2->read_row_record($p->row());
+        $p2->set_id("");
+        $p2->set_value("projectName", $_POST["copy_project_name"]);
+        $p2->set_value("projectShortName", "");
+        $p2->save();
+        $TPL["message_good"][] = "Project details copied successfully.";
 
-    // Copy project people
-    $q = prepare("SELECT * FROM projectPerson WHERE projectID = %d",$p->get_id());
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $projectPerson = new projectPerson();
-      $projectPerson->currency = $p->get_value("currencyTypeID");
-      $projectPerson->read_row_record($row);
-      $projectPerson->set_id("");
-      $projectPerson->set_value("projectID",$p2->get_id());
-      $projectPerson->save();
-      $TPL["message_good"]["projectPeople"] = "Project people copied successfully.";
+      // Copy project people
+        $q = prepare("SELECT * FROM projectPerson WHERE projectID = %d", $p->get_id());
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $projectPerson = new projectPerson();
+            $projectPerson->currency = $p->get_value("currencyTypeID");
+            $projectPerson->read_row_record($row);
+            $projectPerson->set_id("");
+            $projectPerson->set_value("projectID", $p2->get_id());
+            $projectPerson->save();
+            $TPL["message_good"]["projectPeople"] = "Project people copied successfully.";
+        }
+
+      // Copy commissions
+        $q = prepare("SELECT * FROM projectCommissionPerson WHERE projectID = %d", $p->get_id());
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $projectCommissionPerson = new projectCommissionPerson();
+            $projectCommissionPerson->read_row_record($row);
+            $projectCommissionPerson->set_id("");
+            $projectCommissionPerson->set_value("projectID", $p2->get_id());
+            $projectCommissionPerson->save();
+            $TPL["message_good"]["projectCommissions"] = "Project commissions copied successfully.";
+        }
+
+        alloc_redirect($TPL["url_alloc_project"]."projectID=".$p2->get_id());
     }
-
-    // Copy commissions
-    $q = prepare("SELECT * FROM projectCommissionPerson WHERE projectID = %d",$p->get_id());
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $projectCommissionPerson = new projectCommissionPerson();
-      $projectCommissionPerson->read_row_record($row);
-      $projectCommissionPerson->set_id("");
-      $projectCommissionPerson->set_value("projectID",$p2->get_id());
-      $projectCommissionPerson->save();
-      $TPL["message_good"]["projectCommissions"] = "Project commissions copied successfully.";
-    }
-
-    alloc_redirect($TPL["url_alloc_project"]."projectID=".$p2->get_id());
-  }
-
-
 }
 
 
 
 
 if ($projectID) {
-
-  if ($_POST["person_save"]) {
-    $q = prepare("SELECT * FROM projectPerson WHERE projectID = %d",$project->get_id());
-    $db = new db_alloc();
-    $db->query($q);
-    while ($db->next_record()) {
-      $pp = new projectPerson();
-      $pp->read_db_record($db);
-      $delete[] = $pp->get_id();
-      #$pp->delete(); // need to delete them after, cause we'll accidently wipe out the current user
-    }
-
-    if (is_array($_POST["person_personID"])) {
-      foreach ($_POST["person_personID"] as $k => $personID) {
-        if ($personID) {
-          $pp = new projectPerson();
-          $pp->currency = $project->get_value("currencyTypeID");
-          $pp->set_value("projectID",$project->get_id());
-          $pp->set_value("personID",$personID);
-          $pp->set_value("roleID",$_POST["person_roleID"][$k]);
-          $pp->set_value("rate",$_POST["person_rate"][$k]);
-          $pp->set_value("rateUnitID",$_POST["person_rateUnitID"][$k]);
-          $pp->set_value("projectPersonModifiedUser",$current_user->get_id());
-          $pp->save();
+    if ($_POST["person_save"]) {
+        $q = prepare("SELECT * FROM projectPerson WHERE projectID = %d", $project->get_id());
+        $db = new db_alloc();
+        $db->query($q);
+        while ($db->next_record()) {
+            $pp = new projectPerson();
+            $pp->read_db_record($db);
+            $delete[] = $pp->get_id();
+          #$pp->delete(); // need to delete them after, cause we'll accidently wipe out the current user
         }
-      }
-    }
 
-    if (is_array($delete)) {
-      foreach ($delete as $projectPersonID) {
-        $pp = new projectPerson();
-        $pp->set_id($projectPersonID);
-        $pp->delete();
-      }
-    }
+        if (is_array($_POST["person_personID"])) {
+            foreach ($_POST["person_personID"] as $k => $personID) {
+                if ($personID) {
+                    $pp = new projectPerson();
+                    $pp->currency = $project->get_value("currencyTypeID");
+                    $pp->set_value("projectID", $project->get_id());
+                    $pp->set_value("personID", $personID);
+                    $pp->set_value("roleID", $_POST["person_roleID"][$k]);
+                    $pp->set_value("rate", $_POST["person_rate"][$k]);
+                    $pp->set_value("rateUnitID", $_POST["person_rateUnitID"][$k]);
+                    $pp->set_value("projectPersonModifiedUser", $current_user->get_id());
+                    $pp->save();
+                }
+            }
+        }
 
-  
+        if (is_array($delete)) {
+            foreach ($delete as $projectPersonID) {
+                $pp = new projectPerson();
+                $pp->set_id($projectPersonID);
+                $pp->delete();
+            }
+        }
+    } else if ($_POST["commission_save"] || $_POST["commission_delete"]) {
+        $commission_item = new projectCommissionPerson();
+        $commission_item->read_globals();
+        $commission_item->read_globals("commission_");
 
-  } else if ($_POST["commission_save"] || $_POST["commission_delete"]) {
-    $commission_item = new projectCommissionPerson();
-    $commission_item->read_globals();
-    $commission_item->read_globals("commission_");
-
-    if ($_POST["commission_save"]) {
-      if (!$_POST["commission_tfID"]) {
-        alloc_error("No TF selected.");
-      } else {
-        $commission_item->save();
-      }
-    } else if ($_POST["commission_delete"]) {
-      $commission_item->delete();
+        if ($_POST["commission_save"]) {
+            if (!$_POST["commission_tfID"]) {
+                alloc_error("No TF selected.");
+            } else {
+                $commission_item->save();
+            }
+        } else if ($_POST["commission_delete"]) {
+            $commission_item->delete();
+        }
+    } else if ($_POST['do_import']) {
+      // Import from an uploaded file
+        switch ($_POST['import_type']) {
+            case 'planner':
+                import_gnome_planner('import');
+                break;
+            case 'csv':
+                $fn = store_csv($_FILES['import']['tmp_name']);
+                if ($fn) {
+                    alloc_redirect($TPL["url_alloc_importCSV"]."projectID=".$projectID."&filename=$fn");
+                }
+                $TPL['message'] = "There was an error processing the uploaded file.";
+                break;
+        }
     }
-  } else if ($_POST['do_import']) {
-    // Import from an uploaded file
-    switch($_POST['import_type']) {
-      case 'planner':
-        import_gnome_planner('import');
-      break;
-      case 'csv':
-	$fn = store_csv($_FILES['import']['tmp_name']);
-	if ($fn) {
-	  alloc_redirect($TPL["url_alloc_importCSV"]."projectID=".$projectID."&filename=$fn");
-	}
-	$TPL['message'] = "There was an error processing the uploaded file.";
-      break;
-    }
-  }
   // Displaying a record
-  $project->set_id($projectID);
-  $project->select() || alloc_error("Could not load project $projectID");
+    $project->set_id($projectID);
+    $project->select() || alloc_error("Could not load project $projectID");
 } else {
   // Creating a new record
-  $project->read_globals();
-  $projectID = $project->get_id();
-  $project->select();
+    $project->read_globals();
+    $projectID = $project->get_id();
+    $project->select();
 }
 
 // Comments
@@ -514,8 +524,8 @@ $TPL["comment_buttons"] = "<input type=\"submit\" name=\"comment_save\" value=\"
 
 // if someone uploads an attachment
 if ($_POST["save_attachment"]) {
-  move_attachment("project",$projectID);
-  alloc_redirect($TPL["url_alloc_project"]."projectID=".$projectID."&sbs_link=attachments");
+    move_attachment("project", $projectID);
+    alloc_redirect($TPL["url_alloc_project"]."projectID=".$projectID."&sbs_link=attachments");
 }
 
 
@@ -531,49 +541,50 @@ $client->set_tpl_values("client_");
 
 // If a client has been chosen
 if ($clientID) {
-
-  $query = prepare("SELECT * 
+    $query = prepare(
+        "SELECT * 
                       FROM clientContact
-                     WHERE clientContact.clientID = %d AND clientContact.primaryContact = true"
-                   ,$clientID);
-  $db->query($query);
-  $cc = new clientContact();
-  $cc->read_db_record($db);
-  
-  $one = $client->format_address("postal");
-  $two = $client->format_address("street");
-  $thr = $cc->format_contact();
-  $fou = $project->format_client_old();  
-
-  $temp = str_replace("<br>","",$fou);
-  $temp and $thr = $fou;
-
-  $url = $TPL["url_alloc_client"]."clientID=".$clientID;
-
-  if ($project->get_value("clientContactID")) {
+                     WHERE clientContact.clientID = %d AND clientContact.primaryContact = true",
+        $clientID
+    );
+    $db->query($query);
     $cc = new clientContact();
-    $cc->set_id($project->get_value("clientContactID"));
-    $cc->select();
-    $fiv = $cc->format_contact();
-    $temp = str_replace("<br>","",$fiv);
-    $temp and $thr = $fiv;
-  }
+    $cc->read_db_record($db);
+  
+    $one = $client->format_address("postal");
+    $two = $client->format_address("street");
+    $thr = $cc->format_contact();
+    $fou = $project->format_client_old();
 
-  $TPL["clientDetails"] = "<table width=\"100%\">";
-  $TPL["clientDetails"].= "<tr>";
-  $TPL["clientDetails"].= "<td colspan=\"3\"><h2 style=\"margin-bottom:0px; display:inline;\"><a href=".$url.">".$TPL["client_clientName"]."</a></h2></td>    ";
-  $TPL["clientDetails"].= "</tr>";
-  $TPL["clientDetails"].= "<tr>";
-  $one and $TPL["clientDetails"].= "<td class=\"nobr\"><u>Postal Address</u></td>";
-  $two and $TPL["clientDetails"].= "<td class=\"nobr\"><u>Street Address</u></td>";
-  $thr and $TPL["clientDetails"].= "<td><u>Contact</u></td>";
-  $TPL["clientDetails"].= "</tr>";
-  $TPL["clientDetails"].= "<tr>";
-  $one and $TPL["clientDetails"].= "<td valign=\"top\">".$one."</td>";
-  $two and $TPL["clientDetails"].= "<td valign=\"top\">".$two."</td>";
-  $thr and $TPL["clientDetails"].= "<td valign=\"top\">".$thr."</td>";
-  $TPL["clientDetails"].= "</tr>";
-  $TPL["clientDetails"].= "</table>";
+    $temp = str_replace("<br>", "", $fou);
+    $temp and $thr = $fou;
+
+    $url = $TPL["url_alloc_client"]."clientID=".$clientID;
+
+    if ($project->get_value("clientContactID")) {
+        $cc = new clientContact();
+        $cc->set_id($project->get_value("clientContactID"));
+        $cc->select();
+        $fiv = $cc->format_contact();
+        $temp = str_replace("<br>", "", $fiv);
+        $temp and $thr = $fiv;
+    }
+
+    $TPL["clientDetails"] = "<table width=\"100%\">";
+    $TPL["clientDetails"].= "<tr>";
+    $TPL["clientDetails"].= "<td colspan=\"3\"><h2 style=\"margin-bottom:0px; display:inline;\"><a href=".$url.">".$TPL["client_clientName"]."</a></h2></td>    ";
+    $TPL["clientDetails"].= "</tr>";
+    $TPL["clientDetails"].= "<tr>";
+    $one and $TPL["clientDetails"].= "<td class=\"nobr\"><u>Postal Address</u></td>";
+    $two and $TPL["clientDetails"].= "<td class=\"nobr\"><u>Street Address</u></td>";
+    $thr and $TPL["clientDetails"].= "<td><u>Contact</u></td>";
+    $TPL["clientDetails"].= "</tr>";
+    $TPL["clientDetails"].= "<tr>";
+    $one and $TPL["clientDetails"].= "<td valign=\"top\">".$one."</td>";
+    $two and $TPL["clientDetails"].= "<td valign=\"top\">".$two."</td>";
+    $thr and $TPL["clientDetails"].= "<td valign=\"top\">".$thr."</td>";
+    $TPL["clientDetails"].= "</tr>";
+    $TPL["clientDetails"].= "</table>";
 }
 
 
@@ -583,11 +594,11 @@ $db->query(prepare("SELECT fullName, emailAddress, clientContactPhone, clientCon
                      WHERE entity='project' 
                        AND entityID = %d
                        AND interestedPartyActive = 1
-                  ORDER BY fullName",$project->get_id()));
+                  ORDER BY fullName", $project->get_id()));
 while ($db->next_record()) {
-  $value = interestedParty::get_encoded_interested_party_identifier($db->f("fullName"), $db->f("emailAddress"));
-  $phone = array("p"=>$db->f('clientContactPhone'),"m"=>$db->f('clientContactMobile'));
-  $TPL["interestedParties"][] = array('key'=>$value, 'name'=>$db->f("fullName"), 'email'=>$db->f("emailAddress"), 'phone'=>$phone);
+    $value = interestedParty::get_encoded_interested_party_identifier($db->f("fullName"), $db->f("emailAddress"));
+    $phone = array("p"=>$db->f('clientContactPhone'),"m"=>$db->f('clientContactMobile'));
+    $TPL["interestedParties"][] = array('key'=>$value, 'name'=>$db->f("fullName"), 'email'=>$db->f("emailAddress"), 'phone'=>$phone);
 }
 
 $TPL["interestedPartyOptions"] = $project->get_cc_list_select();
@@ -599,45 +610,46 @@ $TPL["clientHidden"] = "<input type=\"hidden\" id=\"clientID\" name=\"clientID\"
 $TPL["clientHidden"].= "<input type=\"hidden\" id=\"clientContactID\" name=\"clientContactID\" value=\"".$project->get_value("clientContactID")."\">";
 
 // Gets $ per hour, even if user uses metric like $200 Daily
-function get_projectPerson_hourly_rate($personID,$projectID) {
-  $db = new db_alloc();
-  $q = prepare("SELECT rate,rateUnitID FROM projectPerson WHERE personID = %d AND projectID = %d",$personID,$projectID);
-  $db->query($q);
-  $db->next_record();
-  $rate = $db->f("rate");
-  $unitID = $db->f("rateUnitID");
-  $t = new timeUnit();
-  $timeUnits = $t->get_assoc_array("timeUnitID","timeUnitSeconds",$unitID);
-  ($rate && $timeUnits[$unitID]) and $hourly_rate = $rate / ($timeUnits[$unitID]/60/60);
-  return $hourly_rate;
+function get_projectPerson_hourly_rate($personID, $projectID)
+{
+    $db = new db_alloc();
+    $q = prepare("SELECT rate,rateUnitID FROM projectPerson WHERE personID = %d AND projectID = %d", $personID, $projectID);
+    $db->query($q);
+    $db->next_record();
+    $rate = $db->f("rate");
+    $unitID = $db->f("rateUnitID");
+    $t = new timeUnit();
+    $timeUnits = $t->get_assoc_array("timeUnitID", "timeUnitSeconds", $unitID);
+    ($rate && $timeUnits[$unitID]) and $hourly_rate = $rate / ($timeUnits[$unitID]/60/60);
+    return $hourly_rate;
 }
 
 if (is_object($project) && $project->get_id()) {
-  if (is_array($TPL["taskListRows"])) { // $tasks is a global defined in show_tasks() for performance reasons
-    foreach ($TPL["taskListRows"] as $tid => $t) {
-      $hourly_rate = get_projectPerson_hourly_rate($t["personID"],$t["projectID"]);
-      $time_remaining = $t["timeLimit"] - (task::get_time_billed($t["taskID"])/60/60);
+    if (is_array($TPL["taskListRows"])) { // $tasks is a global defined in show_tasks() for performance reasons
+        foreach ($TPL["taskListRows"] as $tid => $t) {
+            $hourly_rate = get_projectPerson_hourly_rate($t["personID"], $t["projectID"]);
+            $time_remaining = $t["timeLimit"] - (task::get_time_billed($t["taskID"])/60/60);
 
-      $cost_remaining = $hourly_rate * $time_remaining;
+            $cost_remaining = $hourly_rate * $time_remaining;
 
-      if ($cost_remaining > 0) {
-        #echo "<br>Tally: ".$TPL["cost_remaining"] += $cost_remaining; 
-        $TPL["cost_remaining"] += $cost_remaining; 
-        $TPL["time_remaining"] += $time_remaining;
-      } 
-      $t["timeLimit"] and $count_quoted_tasks++;
+            if ($cost_remaining > 0) {
+                #echo "<br>Tally: ".$TPL["cost_remaining"] += $cost_remaining;
+                $TPL["cost_remaining"] += $cost_remaining;
+                $TPL["time_remaining"] += $time_remaining;
+            }
+            $t["timeLimit"] and $count_quoted_tasks++;
+        }
+
+
+        $TPL["time_remaining"] and $TPL["time_remaining"] = sprintf("%0.1f", $TPL["time_remaining"])." Hours.";
+
+        $TPL["count_incomplete_tasks"] = count($TPL["taskListRows"]);
+        $not_quoted = count($TPL["taskListRows"]) - $count_quoted_tasks;
+        $not_quoted and $TPL["count_not_quoted_tasks"] = "(".sprintf("%d", $not_quoted)." tasks not included in estimate)";
     }
 
 
-    $TPL["time_remaining"] and $TPL["time_remaining"] = sprintf("%0.1f",$TPL["time_remaining"])." Hours.";
-
-    $TPL["count_incomplete_tasks"] = count($TPL["taskListRows"]);
-    $not_quoted = count($TPL["taskListRows"]) - $count_quoted_tasks;
-    $not_quoted and $TPL["count_not_quoted_tasks"] = "(".sprintf("%d",$not_quoted)." tasks not included in estimate)";
-  }
-
-
-  $TPL["invoice_links"].= "<a href=\"".$TPL["url_alloc_invoice"]."clientID=".$clientID."&projectID=".$project->get_id()."\">New Invoice</a>";
+    $TPL["invoice_links"].= "<a href=\"".$TPL["url_alloc_invoice"]."clientID=".$clientID."&projectID=".$project->get_id()."\">New Invoice</a>";
 }
 
 $TPL["navigation_links"] = $project->get_navigation_links();
@@ -651,14 +663,14 @@ $TPL["cost_centre_tfID_options"] = page::select_options($query, $TPL["project_co
 
 $db->query($query);
 while ($db->row()) {
-  $tf_array[$db->f("value")] = $db->f("label");
+    $tf_array[$db->f("value")] = $db->f("label");
 }
 
 if ($TPL["project_cost_centre_tfID"]) {
-  $tf = new tf();
-  $tf->set_id($TPL["project_cost_centre_tfID"]);
-  $tf->select();
-  $TPL["cost_centre_tfID_label"] = $tf->get_link();
+    $tf = new tf();
+    $tf->set_id($TPL["project_cost_centre_tfID"]);
+    $tf->select();
+    $TPL["cost_centre_tfID_label"] = $tf->get_link();
 }
 
 
@@ -667,7 +679,7 @@ $query = prepare("SELECT roleName,roleID FROM role WHERE roleLevel = 'project' O
 $db->query($query);
 #$project_person_role_array[] = "";
 while ($db->next_record()) {
-  $project_person_role_array[$db->f("roleID")] = $db->f("roleName");
+    $project_person_role_array[$db->f("roleID")] = $db->f("roleName");
 }
 
 
@@ -675,23 +687,23 @@ while ($db->next_record()) {
 $email_type_array = array("None"=>"None", "Assigned Tasks"=>"Assigned Tasks", "All Tasks"=>"All Tasks");
 
 $t = new meta("currencyType");
-$currency_array = $t->get_assoc_array("currencyTypeID","currencyTypeID");
+$currency_array = $t->get_assoc_array("currencyTypeID", "currencyTypeID");
 $projectType_array = project::get_project_type_array();
 
 $m = new meta("projectStatus");
-$projectStatus_array = $m->get_assoc_array("projectStatusID","projectStatusID");
+$projectStatus_array = $m->get_assoc_array("projectStatusID", "projectStatusID");
 $timeUnit = new timeUnit();
-$rate_type_array = $timeUnit->get_assoc_array("timeUnitID","timeUnitLabelB");
+$rate_type_array = $timeUnit->get_assoc_array("timeUnitID", "timeUnitLabelB");
 $TPL["project_projectType"] = $projectType_array[$TPL["project_projectType"]];
 $TPL["projectType_options"] = page::select_options($projectType_array, $TPL["project_projectType"]);
 $TPL["projectStatus_options"] = page::select_options($projectStatus_array, $TPL["project_projectStatus"]);
 $TPL["project_projectPriority"] or $TPL["project_projectPriority"] = 3;
 $projectPriorities = config::get_config_item("projectPriorities") or $projectPriorities = array();
 $tp = array();
-foreach($projectPriorities as $key => $arr) {
-  $tp[$key] = $arr["label"];
+foreach ($projectPriorities as $key => $arr) {
+    $tp[$key] = $arr["label"];
 }
-$TPL["projectPriority_options"] = page::select_options($tp,$TPL["project_projectPriority"]);
+$TPL["projectPriority_options"] = page::select_options($tp, $TPL["project_projectPriority"]);
 $TPL["project_projectPriority"] and $TPL["priorityLabel"] = " <div style=\"display:inline; color:".$projectPriorities[$TPL["project_projectPriority"]]["colour"]."\">[".$tp[$TPL["project_projectPriority"]]."]</div>";
 
 
@@ -702,17 +714,17 @@ $TPL["defaultTimeSheetRateUnits"] = $rate_type_array[$project->get_value("defaul
 $TPL["currencyType_options"] = page::select_options($currency_array, $TPL["project_currencyTypeID"]);
 
 if ($_GET["projectID"] || $_POST["projectID"] || $TPL["project_projectID"]) {
-  define("PROJECT_EXISTS",1);
+    define("PROJECT_EXISTS", 1);
 }
 
 if ($new_project && !(is_object($project) && $project->get_id())) {
-  $TPL["main_alloc_title"] = "New Project - ".APPLICATION_NAME;
-  $TPL["projectSelfLink"] = "New Project";
-  $p = new project();
-  $TPL["message_help_no_esc"][] = "Create a new Project by inputting the Project Name and any other details, and clicking the Save button.";
-  $TPL["message_help_no_esc"][] = "";
-  $TPL["message_help_no_esc"][] = "<a href=\"#x\" class=\"magic\" id=\"copy_project_link\">Or copy an existing project</a>";
-  $str =<<<DONE
+    $TPL["main_alloc_title"] = "New Project - ".APPLICATION_NAME;
+    $TPL["projectSelfLink"] = "New Project";
+    $p = new project();
+    $TPL["message_help_no_esc"][] = "Create a new Project by inputting the Project Name and any other details, and clicking the Save button.";
+    $TPL["message_help_no_esc"][] = "";
+    $TPL["message_help_no_esc"][] = "<a href=\"#x\" class=\"magic\" id=\"copy_project_link\">Or copy an existing project</a>";
+    $str =<<<DONE
     <div id="copy_project" style="display:none; margin-top:10px;">
       <form action="{$TPL["url_alloc_project"]}" method="post">
         <table>
@@ -742,13 +754,12 @@ if ($new_project && !(is_object($project) && $project->get_id())) {
       </form>
     </div>
 DONE;
-  $TPL["message_help_no_esc"][] = $str;
-
+    $TPL["message_help_no_esc"][] = $str;
 } else {
-  $TPL["main_alloc_title"] = "Project " . $project->get_id() . ": " . $project->get_name() . " - ".APPLICATION_NAME;
-  $TPL["projectSelfLink"] = "<a href=\"". $project->get_url() . "\">";
-  $TPL["projectSelfLink"] .=  sprintf("%d %s", $project->get_id(), $project->get_name(array("return"=>"html")));
-  $TPL["projectSelfLink"] .= "</a>";
+    $TPL["main_alloc_title"] = "Project " . $project->get_id() . ": " . $project->get_name() . " - ".APPLICATION_NAME;
+    $TPL["projectSelfLink"] = "<a href=\"". $project->get_url() . "\">";
+    $TPL["projectSelfLink"] .=  sprintf("%d %s", $project->get_id(), $project->get_name(array("return"=>"html")));
+    $TPL["projectSelfLink"] .= "</a>";
 }
 
 $TPL["taxName"] = config::get_config_item("taxName");
@@ -767,11 +778,11 @@ $q = prepare("SELECT SUM((amount * pow(10,-currencyType.numberToBasic)))
                WHERE timeSheet.projectID = %d
                  AND transaction.status = 'pending'
             GROUP BY transaction.currencyTypeID
-              ",$project->get_id());
+              ", $project->get_id());
 $db->query($q);
 unset($rows);
 while ($row = $db->row()) {
-  $rows[] = $row;
+    $rows[] = $row;
 }
 $TPL["total_timeSheet_transactions_pending"] = page::money_print($rows);
 
@@ -782,11 +793,11 @@ $q = prepare("SELECT SUM(customerBilledDollars * timeSheetItemDuration * multipl
            LEFT JOIN currencyType on currencyType.currencyTypeID = timeSheet.currencyTypeID
                WHERE timeSheet.projectID = %d
             GROUP BY timeSheetItemID
-                ",$project->get_id());
+                ", $project->get_id());
 $db->query($q);
 unset($rows);
 while ($row = $db->row()) {
-  $rows[] = $row;
+    $rows[] = $row;
 }
 $TPL["total_timeSheet_customerBilledDollars"] = page::money_print($rows);
 
@@ -798,11 +809,11 @@ $q = prepare("SELECT SUM((amount * pow(10,-currencyType.numberToBasic)))
                WHERE timeSheet.projectID = %d
                  AND transaction.status = 'approved'
             GROUP BY transaction.currencyTypeID
-              ",$project->get_id());
+              ", $project->get_id());
 $db->query($q);
 unset($rows);
 while ($row = $db->row()) {
-  $rows[] = $row;
+    $rows[] = $row;
 }
 $TPL["total_timeSheet_transactions_approved"] = page::money_print($rows);
 
@@ -815,11 +826,11 @@ $q = prepare("SELECT SUM((amount * pow(10,-currencyType.numberToBasic)))
                WHERE invoice.projectID = %d
                  AND transaction.status = 'pending'
             GROUP BY transaction.currencyTypeID
-              ",$project->get_id());
+              ", $project->get_id());
 $db->query($q);
 unset($rows);
 while ($row = $db->row()) {
-  $rows[] = $row;
+    $rows[] = $row;
 }
 $TPL["total_invoice_transactions_pending"] = page::money_print($rows);
 
@@ -832,11 +843,11 @@ $q = prepare("SELECT SUM((amount * pow(10,-currencyType.numberToBasic)))
                WHERE invoice.projectID = %d
                  AND transaction.status = 'approved'
             GROUP BY transaction.currencyTypeID
-              ",$project->get_id());
+              ", $project->get_id());
 $db->query($q);
 unset($rows);
 while ($row = $db->row()) {
-  $rows[] = $row;
+    $rows[] = $row;
 }
 $TPL["total_invoice_transactions_approved"] = page::money_print($rows);
 
@@ -848,33 +859,30 @@ $q = prepare("SELECT SUM((amount * pow(10,-currencyType.numberToBasic)))
                WHERE transaction.projectID = %d
                  AND transaction.status = 'approved'
             GROUP BY transaction.currencyTypeID
-              ",$project->get_id());
+              ", $project->get_id());
 $db->query($q);
 unset($rows);
 while ($row = $db->row()) {
-  $rows[] = $row;
+    $rows[] = $row;
 }
 $TPL["total_expenses_transactions_approved"] = page::money_print($rows);
 
 
 if ($project->get_id()) {
-  $defaults["projectID"] = $project->get_id();
-  $defaults["showFinances"] = true;
-  if (!$project->have_perm(PERM_READ_WRITE)) {
-    $defaults["personID"] = $current_user->get_id();
-  }
-  $rtn = timeSheet::get_list($defaults);
-  $TPL["timeSheetListRows"] = $rtn["rows"];
-  $TPL["timeSheetListExtra"] = $rtn["extra"];
+    $defaults["projectID"] = $project->get_id();
+    $defaults["showFinances"] = true;
+    if (!$project->have_perm(PERM_READ_WRITE)) {
+        $defaults["personID"] = $current_user->get_id();
+    }
+    $rtn = timeSheet::get_list($defaults);
+    $TPL["timeSheetListRows"] = $rtn["rows"];
+    $TPL["timeSheetListExtra"] = $rtn["extra"];
 }
 
 
 
 if ($project->have_perm(PERM_READ_WRITE)) {
-  include_template("templates/projectFormM.tpl");
+    include_template("templates/projectFormM.tpl");
 } else {
-  include_template("templates/projectViewM.tpl");
+    include_template("templates/projectViewM.tpl");
 }
-
-
-?>

--- a/project/projectGraph.php
+++ b/project/projectGraph.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -29,39 +29,40 @@ $defaults = array("showHeader"=>true
                  ,"form_name"=>"projectSummary_filter"
                  );
 
-function show_filter() {
-  global $TPL;
-  global $defaults;
+function show_filter()
+{
+    global $TPL;
+    global $defaults;
 
-  $_FORM = task::load_form_data($defaults);
-  $arr = task::load_task_filter($_FORM);
-  is_array($arr) and $TPL = array_merge($TPL,$arr);
-  include_template("../task/templates/taskFilterS.tpl");
+    $_FORM = task::load_form_data($defaults);
+    $arr = task::load_task_filter($_FORM);
+    is_array($arr) and $TPL = array_merge($TPL, $arr);
+    include_template("../task/templates/taskFilterS.tpl");
 }
 
-function show_projects($template_name) {
-  global $TPL;
-  global $default;
-  $_FORM = task::load_form_data($defaults);
-  $arr = task::load_task_filter($_FORM);
-  is_array($arr) and $TPL = array_merge($TPL,$arr);
+function show_projects($template_name)
+{
+    global $TPL;
+    global $default;
+    $_FORM = task::load_form_data($defaults);
+    $arr = task::load_task_filter($_FORM);
+    is_array($arr) and $TPL = array_merge($TPL, $arr);
  
-  if (is_array($_FORM["projectID"])) {
-    $projectIDs = $_FORM["projectID"];
-    foreach($projectIDs as $projectID) {
-      $project = new project();
-      $project->set_id($projectID);
-      $project->select();
-      $_FORM["projectID"] = array($projectID);
-      $TPL["graphTitle"] = urlencode($project->get_value("projectName"));
-      $arr = task::load_task_filter($_FORM);
-      is_array($arr) and $TPL = array_merge($TPL,$arr);
-      include_template($template_name);
+    if (is_array($_FORM["projectID"])) {
+        $projectIDs = $_FORM["projectID"];
+        foreach ($projectIDs as $projectID) {
+            $project = new project();
+            $project->set_id($projectID);
+            $project->select();
+            $_FORM["projectID"] = array($projectID);
+            $TPL["graphTitle"] = urlencode($project->get_value("projectName"));
+            $arr = task::load_task_filter($_FORM);
+            is_array($arr) and $TPL = array_merge($TPL, $arr);
+            include_template($template_name);
+        }
     }
-  }
 }
 
 $TPL["main_alloc_title"] = "Project Graph - ".APPLICATION_NAME;
 
 include_template("templates/projectGraphM.tpl");
-?>

--- a/project/projectGraphImage.php
+++ b/project/projectGraphImage.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -37,7 +37,7 @@ $options["debug"] = 0;
 $tasks = task::get_list($options) or $tasks = array();
 
 foreach ($tasks as $task) {
-  $objects[$task["taskID"]] = $task["object"];
+    $objects[$task["taskID"]] = $task["object"];
 }
 
 $task_graph = new task_graph();
@@ -47,13 +47,10 @@ $task_graph->init($objects);
 $task_graph->draw_grid();
 
 foreach ($tasks as $task) {
-  $task_graph->draw_task($task);
+    $task_graph->draw_task($task);
 }
 
 $task_graph->draw_milestones();
 $task_graph->draw_today();
 $task_graph->draw_legend();
 $task_graph->output();
-
-
-?>

--- a/project/projectList.php
+++ b/project/projectList.php
@@ -30,14 +30,15 @@ $defaults = array("showProjectType"=>true
                  ,"form_name"=>"projectList_filter"
                  );
 
-function show_filter() {
-  global $TPL;
-  global $defaults;
+function show_filter()
+{
+    global $TPL;
+    global $defaults;
 
-  $_FORM = project::load_form_data($defaults);
-  $arr = project::load_project_filter($_FORM);
-  is_array($arr) and $TPL = array_merge($TPL,$arr);
-  include_template("templates/projectListFilterS.tpl");
+    $_FORM = project::load_form_data($defaults);
+    $arr = project::load_project_filter($_FORM);
+    is_array($arr) and $TPL = array_merge($TPL, $arr);
+    include_template("templates/projectListFilterS.tpl");
 }
 
 
@@ -47,7 +48,7 @@ $TPL["_FORM"] = $_FORM;
 
 
 if (!$current_user->prefs["projectList_filter"]) {
-  $TPL["message_help"][] = "
+    $TPL["message_help"][] = "
 
 allocPSA helps you manage Projects. This page allows you to see a list of
 Projects.
@@ -58,7 +59,6 @@ Simply adjust the filter settings and click the <b>Filter</b> button to
 display a list of previously created Projects. 
 If you would prefer to create a new Project, click the <b>New Project</b> link
 in the top-right hand corner of the box below.";
-
 }
 
 
@@ -67,5 +67,3 @@ in the top-right hand corner of the box below.";
 
 $TPL["main_alloc_title"] = "Project List - ".APPLICATION_NAME;
 include_template("templates/projectListM.tpl");
-
-?>

--- a/project/updateProjectClientContactList.php
+++ b/project/updateProjectClientContactList.php
@@ -3,32 +3,28 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 if ($_GET["clientID"]) {
-  usleep(400000);
-  echo client::get_client_contact_select($_GET["clientID"], $_GET["clientContactID"]);
+    usleep(400000);
+    echo client::get_client_contact_select($_GET["clientID"], $_GET["clientContactID"]);
 }
-
-
-?>
-

--- a/project/updateProjectClientList.php
+++ b/project/updateProjectClientList.php
@@ -3,32 +3,28 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 if ($_GET["clientStatus"]) {
-  usleep(400000);
-  echo client::get_client_select($_GET["clientStatus"],$_GET["clientID"]);
+    usleep(400000);
+    echo client::get_client_select($_GET["clientStatus"], $_GET["clientID"]);
 }
-
-
-?>
-

--- a/project/updateProjectList.php
+++ b/project/updateProjectList.php
@@ -3,33 +3,29 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 if ($_GET["projectStatus"]) {
-  usleep(400000);
-  $options = project::get_list_dropdown_options($_GET["projectStatus"]);
-  echo "<select name=\"copy_projectID\">".$options."</select>";
+    usleep(400000);
+    $options = project::get_list_dropdown_options($_GET["projectStatus"]);
+    echo "<select name=\"copy_projectID\">".$options."</select>";
 }
-
-
-?>
-

--- a/project/updateProjectPersonRate.php
+++ b/project/updateProjectPersonRate.php
@@ -3,34 +3,32 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 if ($_GET["project"] && $_GET["person"]) {
-  $rate = projectPerson::get_rate($_GET["project"], $_GET["person"]);
+    $rate = projectPerson::get_rate($_GET["project"], $_GET["person"]);
 
-  $project = new project($_GET["project"]);
-  $currency = $project->get_value("currencyTypeID") or $currency = config::get_config_item("currency");
-  $rate['rate'] = page::money($currency, $rate['rate'], '%mo');
-  echo alloc_json_encode($rate);
+    $project = new project($_GET["project"]);
+    $currency = $project->get_value("currencyTypeID") or $currency = config::get_config_item("currency");
+    $rate['rate'] = page::money($currency, $rate['rate'], '%mo');
+    echo alloc_json_encode($rate);
 }
-
-?>

--- a/reminder/lib/init.php
+++ b/reminder/lib/init.php
@@ -3,26 +3,26 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class reminder_module extends module {
-  var $module = "reminder";
-  var $db_entities = array("reminder", "reminderRecipient");
+class reminder_module extends module
+{
+    var $module = "reminder";
+    var $db_entities = array("reminder", "reminderRecipient");
 }
-?>

--- a/reminder/lib/reminder.inc.php
+++ b/reminder/lib/reminder.inc.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -24,11 +24,12 @@
 define("REMINDER_METAPERSON_TASK_ASSIGNEE", 2);
 define("REMINDER_METAPERSON_TASK_MANAGER", 3);
 
-class reminder extends db_entity {
-  public $data_table = "reminder";
-  public $display_field_name = "reminderSubject";
-  public $key_field = "reminderID";
-  public $data_fields = array("reminderType"
+class reminder extends db_entity
+{
+    public $data_table = "reminder";
+    public $display_field_name = "reminderSubject";
+    public $key_field = "reminderID";
+    public $data_fields = array("reminderType"
                              ,"reminderLinkID"
                              ,"reminderTime"
                              ,"reminderHash"
@@ -47,403 +48,440 @@ class reminder extends db_entity {
                              );
 
   // set the modified time to now
-  function set_modified_time() {
-    $this->set_value("reminderModifiedTime", date("Y-m-d H:i:s"));
-  }
+    function set_modified_time()
+    {
+        $this->set_value("reminderModifiedTime", date("Y-m-d H:i:s"));
+    }
 
-  function delete() {
-    $q = prepare("DELETE FROM reminderRecipient WHERE reminderID = %d",$this->get_id());
-    $db = new db_alloc();
-    $db->query($q);
-    return parent::delete();
-  }
+    function delete()
+    {
+        $q = prepare("DELETE FROM reminderRecipient WHERE reminderID = %d", $this->get_id());
+        $db = new db_alloc();
+        $db->query($q);
+        return parent::delete();
+    }
 
-  function get_recipients() {
-    $db = new db_alloc();
-    $type = $this->get_value('reminderType');
-    if ($type == "project") {
-      $query = prepare("SELECT * 
+    function get_recipients()
+    {
+        $db = new db_alloc();
+        $type = $this->get_value('reminderType');
+        if ($type == "project") {
+            $query = prepare("SELECT * 
                           FROM projectPerson 
                      LEFT JOIN person ON projectPerson.personID=person.personID 
                          WHERE projectPerson.projectID = %d 
-                      ORDER BY person.username",$this->get_value('reminderLinkID'));
-
-    } else if ($type == "task") {
-      // Modified query option: to send to all people on the project that this task is from.
-      $recipients = array("-3" => "Task Manager"
+                      ORDER BY person.username", $this->get_value('reminderLinkID'));
+        } else if ($type == "task") {
+          // Modified query option: to send to all people on the project that this task is from.
+            $recipients = array("-3" => "Task Manager"
                          ,"-2" => "Task Assignee");
 
-      $db->query("SELECT projectID FROM task WHERE taskID = %d",$this->get_value('reminderLinkID'));
-      $db->next_record();
+            $db->query("SELECT projectID FROM task WHERE taskID = %d", $this->get_value('reminderLinkID'));
+            $db->next_record();
 
-      if ($db->f('projectID')) {
-        $query = prepare("SELECT * 
+            if ($db->f('projectID')) {
+                $query = prepare("SELECT * 
                             FROM projectPerson 
                        LEFT JOIN person ON projectPerson.personID=person.personID 
                            WHERE projectPerson.projectID = %d 
-                        ORDER BY person.username",$db->f('projectID'));
+                        ORDER BY person.username", $db->f('projectID'));
+            } else {
+                $query = "SELECT * FROM person WHERE personActive = 1 ORDER BY username";
+            }
+        } else {
+            $query = "SELECT * FROM person WHERE personActive = 1 ORDER BY username";
+        }
+        $db->query($query);
+        while ($db->next_record()) {
+            $person = new person();
+            $person->read_db_record($db);
+            $recipients[$person->get_id()] = $person->get_name();
+        }
 
-      } else {
-        $query = "SELECT * FROM person WHERE personActive = 1 ORDER BY username";
-      }
-
-    } else {
-      $query = "SELECT * FROM person WHERE personActive = 1 ORDER BY username";
-    }
-    $db->query($query);
-    while ($db->next_record()) {
-      $person = new person();
-      $person->read_db_record($db);
-      $recipients[$person->get_id()] = $person->get_name();
-    }
-
-    return $recipients;
-  }
-
-  function get_recipient_options() {
-    $current_user = &singleton("current_user");
-
-    $recipients = $this->get_recipients();
-    $type = $this->get_value('reminderType');
-
-    $selected = array();
-    $db = new db_alloc();
-    $query = "SELECT * from reminderRecipient WHERE reminderID = %d";
-    $db->query($query, $this->get_id());
-    while ($db->next_record()) {
-      if ($db->f('metaPersonID'))
-        $selected[] = $db->f('metaPersonID');
-      else
-        $selected[] = $db->f('personID');
+        return $recipients;
     }
 
-    if(!$selected && $_GET["personID"]) {
-      $selected[] = $_GET["personID"];
-    }
-    if (!$this->get_id()) {
-      $selected[] = $current_user->get_id();
-    }
-    return array($recipients, $selected);
-  }
+    function get_recipient_options()
+    {
+        $current_user = &singleton("current_user");
 
-  function get_hour_options() {
-    $hours = array("1"=>"1", "2"=>"2", "3"=>"3", "4"=>"4", "5"=>"5", "6"=>"6", "7"=>"7", "8"=>"8", "9"=>"9", "10"=>"10", "11"=>"11", "12"=>"12");
-    if ($this->get_value('reminderTime') != "") {
-      $date = strtotime($this->get_value('reminderTime'));
-      $hour = date("h", $date);
-    } else {
-      $hour = date("h", mktime(date("H"), date("i") + 5 - (date("i") % 5), 0, date("m"), date("d"), date("Y")));
-    }
-    return page::select_options($hours, $hour);
-  }
+        $recipients = $this->get_recipients();
+        $type = $this->get_value('reminderType');
 
-  function get_minute_options() {
-    $minutes = array("0"=>"00", "10"=>"10", "20"=>"20", "30"=>"30", "40"=>"40", "50"=>"50");
-    if ($this->get_value('reminderTime') != "") {
-      $date = strtotime($this->get_value('reminderTime'));
-      $minute = date("i", $date);
-    } else {
-      $minute = date("i", mktime(date("H"), date("i") + 5 - (date("i") % 5), 0, date("m"), date("d"), date("Y")));
-    }
-    return page::select_options($minutes, $minute);
-  }
+        $selected = array();
+        $db = new db_alloc();
+        $query = "SELECT * from reminderRecipient WHERE reminderID = %d";
+        $db->query($query, $this->get_id());
+        while ($db->next_record()) {
+            if ($db->f('metaPersonID')) {
+                $selected[] = $db->f('metaPersonID');
+            } else {
+                $selected[] = $db->f('personID');
+            }
+        }
 
-  function get_meridian_options() {
-    $meridians = array("am"=>"AM", "pm"=>"PM");
-    if ($this->get_value('reminderTime') != "") {
-      $date = strtotime($this->get_value('reminderTime'));
-      $meridian = date("a", $date);
-    } else {
-      $meridian = date("a", mktime(date("H"), date("i") + 5 - (date("i") % 5), 0, date("m"), date("d"), date("Y")));
+        if (!$selected && $_GET["personID"]) {
+            $selected[] = $_GET["personID"];
+        }
+        if (!$this->get_id()) {
+            $selected[] = $current_user->get_id();
+        }
+        return array($recipients, $selected);
     }
-    return page::select_options($meridians, $meridian);
-  }
 
-  function get_recuring_interval_options() {
-    $recuring_interval_options = array("Hour"=>"Hour(s)", "Day"=>"Day(s)", "Week"=>"Week(s)", "Month"=>"Month(s)", "Year"=>"Year(s)");
-    $recuring_interval = $this->get_value('reminderRecuringInterval');
-    if ($recuring_interval == "") {
-      $recuring_interval = "Week";
+    function get_hour_options()
+    {
+        $hours = array("1"=>"1", "2"=>"2", "3"=>"3", "4"=>"4", "5"=>"5", "6"=>"6", "7"=>"7", "8"=>"8", "9"=>"9", "10"=>"10", "11"=>"11", "12"=>"12");
+        if ($this->get_value('reminderTime') != "") {
+            $date = strtotime($this->get_value('reminderTime'));
+            $hour = date("h", $date);
+        } else {
+            $hour = date("h", mktime(date("H"), date("i") + 5 - (date("i") % 5), 0, date("m"), date("d"), date("Y")));
+        }
+        return page::select_options($hours, $hour);
     }
-    return page::select_options($recuring_interval_options, $recuring_interval);
-  }
 
-  function get_advnotice_interval_options() {
-    $advnotice_interval_options = array("Minute"=>"Minute(s)", "Hour"=>"Hour(s)", "Day"=>"Day(s)", "Week"=>"Week(s)", "Month"=>"Month(s)", "Year"=>"Year(s)");
-    $advnotice_interval = $this->get_value('reminderAdvNoticeInterval');
-    if ($advnotice_interval == "") {
-      $advnotice_interval = "Hour";
+    function get_minute_options()
+    {
+        $minutes = array("0"=>"00", "10"=>"10", "20"=>"20", "30"=>"30", "40"=>"40", "50"=>"50");
+        if ($this->get_value('reminderTime') != "") {
+            $date = strtotime($this->get_value('reminderTime'));
+            $minute = date("i", $date);
+        } else {
+            $minute = date("i", mktime(date("H"), date("i") + 5 - (date("i") % 5), 0, date("m"), date("d"), date("Y")));
+        }
+        return page::select_options($minutes, $minute);
     }
-    return page::select_options($advnotice_interval_options, $advnotice_interval);
-  }
 
-  function is_alive() {
-    $type = $this->get_value('reminderType');
-    if ($type == "project") {
-      $project = new project();
-      $project->set_id($this->get_value('reminderLinkID'));
-      if ($project->select() == false || $project->get_value('projectStatus') == "Archived") {
-        return false;
-      }
-    } else if ($type == "task") {
-      $task = new task();
-      $task->set_id($this->get_value('reminderLinkID'));
-      if ($task->select() == false || substr($task->get_value("taskStatus"),0,6) == 'closed') {
-        return false;
-      }
-    } else if ($type == "client") {
-      $client = new client();
-      $client->set_id($this->get_value('reminderLinkID'));
-      if ($client->select() == false || $client->get_value('clientStatus') == "Archived") {
-        return false;
-      }
+    function get_meridian_options()
+    {
+        $meridians = array("am"=>"AM", "pm"=>"PM");
+        if ($this->get_value('reminderTime') != "") {
+            $date = strtotime($this->get_value('reminderTime'));
+            $meridian = date("a", $date);
+        } else {
+            $meridian = date("a", mktime(date("H"), date("i") + 5 - (date("i") % 5), 0, date("m"), date("d"), date("Y")));
+        }
+        return page::select_options($meridians, $meridian);
     }
-    return true;
-  }
 
-  function deactivate() {
-    $this->set_value("reminderActive",0);
-    return $this->save();
-  }
+    function get_recuring_interval_options()
+    {
+        $recuring_interval_options = array("Hour"=>"Hour(s)", "Day"=>"Day(s)", "Week"=>"Week(s)", "Month"=>"Month(s)", "Year"=>"Year(s)");
+        $recuring_interval = $this->get_value('reminderRecuringInterval');
+        if ($recuring_interval == "") {
+            $recuring_interval = "Week";
+        }
+        return page::select_options($recuring_interval_options, $recuring_interval);
+    }
+
+    function get_advnotice_interval_options()
+    {
+        $advnotice_interval_options = array("Minute"=>"Minute(s)", "Hour"=>"Hour(s)", "Day"=>"Day(s)", "Week"=>"Week(s)", "Month"=>"Month(s)", "Year"=>"Year(s)");
+        $advnotice_interval = $this->get_value('reminderAdvNoticeInterval');
+        if ($advnotice_interval == "") {
+            $advnotice_interval = "Hour";
+        }
+        return page::select_options($advnotice_interval_options, $advnotice_interval);
+    }
+
+    function is_alive()
+    {
+        $type = $this->get_value('reminderType');
+        if ($type == "project") {
+            $project = new project();
+            $project->set_id($this->get_value('reminderLinkID'));
+            if ($project->select() == false || $project->get_value('projectStatus') == "Archived") {
+                return false;
+            }
+        } else if ($type == "task") {
+            $task = new task();
+            $task->set_id($this->get_value('reminderLinkID'));
+            if ($task->select() == false || substr($task->get_value("taskStatus"), 0, 6) == 'closed') {
+                return false;
+            }
+        } else if ($type == "client") {
+            $client = new client();
+            $client->set_id($this->get_value('reminderLinkID'));
+            if ($client->select() == false || $client->get_value('clientStatus') == "Archived") {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function deactivate()
+    {
+        $this->set_value("reminderActive", 0);
+        return $this->save();
+    }
 
   // mail out reminder and update to next date if repeating or remove if onceoff
-  // checks to make sure that it is the right time to send reminder should be 
+  // checks to make sure that it is the right time to send reminder should be
   // dome before calling this function
-  function mail_reminder() {
+    function mail_reminder()
+    {
 
-    // check for a reminder.reminderHash that links off to a token.tokenHash
-    // this lets us trigger reminders on complex actions, for example create
-    // a reminder that sends when a task status changes from pending to open
+      // check for a reminder.reminderHash that links off to a token.tokenHash
+      // this lets us trigger reminders on complex actions, for example create
+      // a reminder that sends when a task status changes from pending to open
 
-    // Note this->reminderTime is going to always be null for the token that
-    // link to task->moved_from_pending_to_open().
-    // Whereas the task->reopen_pending_task() will have a reminderTime set.
+      // Note this->reminderTime is going to always be null for the token that
+      // link to task->moved_from_pending_to_open().
+      // Whereas the task->reopen_pending_task() will have a reminderTime set.
 
-    $ok = true;
-    if ($this->get_value("reminderHash")) {
-      $token = new token();
-      if ($token->set_hash($this->get_value("reminderHash"))) {
-        list($entity,$method) = $token->execute();
-        if (is_object($entity) && $entity->get_id()) {
-          if (!$entity->$method()) {
-            $token->decrement_tokenUsed(); // next time, gadget
-            $ok = false;
-          }
+        $ok = true;
+        if ($this->get_value("reminderHash")) {
+            $token = new token();
+            if ($token->set_hash($this->get_value("reminderHash"))) {
+                list($entity,$method) = $token->execute();
+                if (is_object($entity) && $entity->get_id()) {
+                    if (!$entity->$method()) {
+                        $token->decrement_tokenUsed(); // next time, gadget
+                        $ok = false;
+                    }
+                }
+            }
         }
-      }
+
+        if ($ok) {
+            $recipients = $this->get_all_recipients();
+          # Reminders can be clients, tasks, projects or "general" - comment threads don't exist for general
+            if ($this->get_value('reminderType') != 'general') {
+                # Nowhere to put the subject?
+                $commentID = comment::add_comment(
+                    $this->get_value('reminderType'),
+                    $this->get_value('reminderLinkID'),
+                    $this->get_value('reminderContent'),
+                    $this->get_value('reminderType'),
+                    $this->get_value('reminderLinkID')
+                );
+                # Repackage the recipients to become IPs of the new comment
+                $ips = array();
+                foreach ((array)$recipients as $id => $person) {
+                      $ip = array();
+                      $ip['name'] = $person['name'];
+                      $ip['addIP'] = true;
+                      $ip['addContact'] = false;
+                      $ip['internal'] = true;
+
+                      $ips[$person['emailAddress']] = $ip;
+                }
+
+                comment::add_interested_parties($commentID, false, $ips);
+                # email_receive false or true? false for now... maybe true is better?
+                comment::send_comment($commentID, array("interested"));
+            } else {
+                foreach ((array)$recipients as $person) {
+                    if ($person['emailAddress']) {
+                        $email = sprintf("%s %s <%s>", $person['firstName'], $person['surname'], $person['emailAddress']);
+                        $subject = $this->get_value('reminderSubject');
+                        $content = $this->get_value('reminderContent');
+                        $e = new email_send($email, $subject, $content, "reminder");
+                        $e->send();
+                    }
+                }
+            }
+
+          // Update reminder (reminderTime can be blank for task->moved_from_pending_to_open)
+            if ($this->get_value('reminderRecuringInterval') == "No") {
+                $this->deactivate();
+            } else if ($this->get_value('reminderRecuringValue') != 0) {
+                $interval = $this->get_value('reminderRecuringValue');
+                $intervalUnit = $this->get_value('reminderRecuringInterval');
+                $newtime = $this->get_next_reminder_time(strtotime($this->get_value('reminderTime')), $interval, $intervalUnit);
+                $this->set_value('reminderTime', date("Y-m-d H:i:s", $newtime));
+                $this->set_value('reminderAdvNoticeSent', 0);
+                $this->save();
+            }
+        }
     }
 
-    if ($ok) {
+    function get_next_reminder_time($reminderTime, $interval, $intervalUnit)
+    {
 
-      $recipients = $this->get_all_recipients();
-      # Reminders can be clients, tasks, projects or "general" - comment threads don't exist for general
-      if ($this->get_value('reminderType') != 'general') {
-        # Nowhere to put the subject?
-        $commentID = comment::add_comment($this->get_value('reminderType'), $this->get_value('reminderLinkID'),
-          $this->get_value('reminderContent'), $this->get_value('reminderType'), $this->get_value('reminderLinkID'));
-        # Repackage the recipients to become IPs of the new comment
-        $ips = array();
-        foreach ((array)$recipients as $id => $person) {
-          $ip = array();
-          $ip['name'] = $person['name'];
-          $ip['addIP'] = true;
-          $ip['addContact'] = false;
-          $ip['internal'] = true;
+        $date_H = date("H", $reminderTime);
+        $date_i = date("i", $reminderTime);
+        $date_s = date("s", $reminderTime);
+        $date_m = date("m", $reminderTime);
+        $date_d = date("d", $reminderTime);
+        $date_Y = date("Y", $reminderTime);
 
-          $ips[$person['emailAddress']] = $ip;
+        switch ($intervalUnit) {
+            case "Minute":
+                $date_i = date("i", $reminderTime) + $interval;
+                break;
+            case "Hour":
+                $date_H = date("H", $reminderTime) + $interval;
+                break;
+            case "Day":
+                $date_d = date("d", $reminderTime) + $interval;
+                break;
+            case "Week":
+                $date_d = date("d", $reminderTime) + (7 * $interval);
+                break;
+            case "Month":
+                $date_m = date("m", $reminderTime) + $interval;
+                break;
+            case "Year":
+                $date_Y = date("Y", $reminderTime) + $interval;
+                break;
         }
 
-        comment::add_interested_parties($commentID, false, $ips);
-        # email_receive false or true? false for now... maybe true is better?
-        comment::send_comment($commentID, array("interested"));
-      } else {
-        foreach ((array)$recipients as $person) {
-          if ($person['emailAddress']) {
-            $email = sprintf("%s %s <%s>", $person['firstName'], $person['surname'], $person['emailAddress']);
-            $subject = $this->get_value('reminderSubject');
-            $content = $this->get_value('reminderContent');
-            $e = new email_send($email, $subject, $content, "reminder");
-            $e->send();
-          }
-        }
-      }
-
-      // Update reminder (reminderTime can be blank for task->moved_from_pending_to_open)
-      if ($this->get_value('reminderRecuringInterval') == "No") {
-        $this->deactivate();
-
-      } else if ($this->get_value('reminderRecuringValue') != 0) {
-        $interval = $this->get_value('reminderRecuringValue');
-        $intervalUnit = $this->get_value('reminderRecuringInterval');
-        $newtime = $this->get_next_reminder_time(strtotime($this->get_value('reminderTime')),$interval,$intervalUnit);
-        $this->set_value('reminderTime', date("Y-m-d H:i:s", $newtime));
-        $this->set_value('reminderAdvNoticeSent', 0);
-        $this->save();
-      }
+        return mktime($date_H, $date_i, $date_s, $date_m, $date_d, $date_Y);
     }
-  }
-
-  function get_next_reminder_time($reminderTime,$interval,$intervalUnit) {
-
-    $date_H = date("H",$reminderTime);
-    $date_i = date("i",$reminderTime);
-    $date_s = date("s",$reminderTime);
-    $date_m = date("m",$reminderTime);
-    $date_d = date("d",$reminderTime);
-    $date_Y = date("Y",$reminderTime);
-
-     switch ($intervalUnit) {
-       case "Minute": $date_i = date("i", $reminderTime) + $interval;       break;
-       case "Hour":   $date_H = date("H", $reminderTime) + $interval;       break;
-       case "Day":    $date_d = date("d", $reminderTime) + $interval;       break;
-       case "Week":   $date_d = date("d", $reminderTime) + (7 * $interval); break;
-       case "Month":  $date_m = date("m", $reminderTime) + $interval;       break;
-       case "Year":   $date_Y = date("Y", $reminderTime) + $interval;       break;
-     }
-
-     return mktime($date_H,$date_i,$date_s,$date_m,$date_d,$date_Y);
-  }
 
 
   // checks advanced notice time if any and mails advanced notice if it is time
-  function mail_advnotice() {
-    $date = strtotime($this->get_value('reminderTime'));
-    // if no advanced notice needs to be sent then dont bother
-    if ($this->get_value('reminderAdvNoticeInterval') != "No" 
-    &&  $this->get_value('reminderAdvNoticeSent') == 0 && !$this->get_value("reminderHash")) {
+    function mail_advnotice()
+    {
+        $date = strtotime($this->get_value('reminderTime'));
+      // if no advanced notice needs to be sent then dont bother
+        if ($this->get_value('reminderAdvNoticeInterval') != "No"
+        &&  $this->get_value('reminderAdvNoticeSent') == 0 && !$this->get_value("reminderHash")) {
+            $date = strtotime($this->get_value('reminderTime'));
+            $interval = -$this->get_value('reminderAdvNoticeValue');
+            $intervalUnit = $this->get_value('reminderAdvNoticeInterval');
+            $advnotice_time = $this->get_next_reminder_time($date, $interval, $intervalUnit);
 
-      $date = strtotime($this->get_value('reminderTime'));
-      $interval = -$this->get_value('reminderAdvNoticeValue');
-      $intervalUnit = $this->get_value('reminderAdvNoticeInterval');
-      $advnotice_time = $this->get_next_reminder_time($date,$interval,$intervalUnit);
+          // only sent advanced notice if it is time to send it
+            if (date("YmdHis", $advnotice_time) <= date("YmdHis")) {
+                $recipients = $this->get_all_recipients();
 
-      // only sent advanced notice if it is time to send it
-      if (date("YmdHis", $advnotice_time) <= date("YmdHis")) {
-        $recipients = $this->get_all_recipients();
+                $subject = sprintf(
+                    "Adv Notice: %s",
+                    $this->get_value('reminderSubject')
+                );
+                  $content = $this->get_value('reminderContent');
 
-        $subject = sprintf("Adv Notice: %s"
-                          ,$this->get_value('reminderSubject'));
-        $content = $this->get_value('reminderContent');
-
-	foreach ($recipients as $person) {
-          if ($person['emailAddress']) {
-            $email = sprintf("%s %s <%s>"
-                          ,$person['firstName']
-                          ,$person['surname']
-                          ,$person['emailAddress']);
-            $e = new email_send($email, $subject, $content, "reminder_advnotice");
-            $e->send();
-          }
+                foreach ($recipients as $person) {
+                    if ($person['emailAddress']) {
+                        $email = sprintf(
+                            "%s %s <%s>",
+                            $person['firstName'],
+                            $person['surname'],
+                            $person['emailAddress']
+                        );
+                          $e = new email_send($email, $subject, $content, "reminder_advnotice");
+                          $e->send();
+                    }
+                }
+                $this->set_value('reminderAdvNoticeSent', 1);
+                $this->save();
+            }
         }
-        $this->set_value('reminderAdvNoticeSent', 1);
-        $this->save();
-      }
     }
-  }
 
   // get the personID of the person who'll actually recieve this reminder
   // (i.e., convert "Task Assignee" into "Bob")
-  function get_effective_person_id($recipient) {
-    if($recipient->get_value('personID') == null) { //nulls don't come through correctly?
-      // OK, slightly more complicated, we need to get the relevant link entity
-      $metaperson = -$recipient->get_value('metaPersonID');
-      $type = $this->get_value("reminderType");
-      if($type == "task") {
-        $task = new task();
-        $task->set_id($this->get_value('reminderLinkID'));
-        $task->select();
+    function get_effective_person_id($recipient)
+    {
+        if ($recipient->get_value('personID') == null) { //nulls don't come through correctly?
+          // OK, slightly more complicated, we need to get the relevant link entity
+            $metaperson = -$recipient->get_value('metaPersonID');
+            $type = $this->get_value("reminderType");
+            if ($type == "task") {
+                $task = new task();
+                $task->set_id($this->get_value('reminderLinkID'));
+                $task->select();
 
-        switch($metaperson) {
-          case REMINDER_METAPERSON_TASK_ASSIGNEE:
-            return $task->get_value('personID');
-          break;
-          case REMINDER_METAPERSON_TASK_MANAGER:
-            return $task->get_value('managerID');
-          break;
+                switch ($metaperson) {
+                    case REMINDER_METAPERSON_TASK_ASSIGNEE:
+                        return $task->get_value('personID');
+                    break;
+                    case REMINDER_METAPERSON_TASK_MANAGER:
+                        return $task->get_value('managerID');
+                    break;
+                }
+            } else {
+                // we should never actually get here...
+                alloc_error("Unknown metaperson.");
+            }
+        } else {
+            return $recipient->get_value('personID');
         }
-      } else {
-        // we should never actually get here...
-        alloc_error("Unknown metaperson.");
-      }
-    } else {
-      return $recipient->get_value('personID');
     }
-  }
 
   // gets a human-friendly description of the recipient, either the recipient name or in the form Task Manager (Bob)
-  function get_recipient_description() {
-      $people =& get_cached_table("person");
-      $name = $people[$this->get_effective_person_id()]["name"];
-      if($this->get_value("metaPerson") === null) {
-        return $name;
-      } else {
-        return sprintf("%s (%s)", reminder::get_metaperson_name($this->get_value("metaPerson")), $name);
-      }
-  }
+    function get_recipient_description()
+    {
+        $people =& get_cached_table("person");
+        $name = $people[$this->get_effective_person_id()]["name"];
+        if ($this->get_value("metaPerson") === null) {
+            return $name;
+        } else {
+            return sprintf("%s (%s)", reminder::get_metaperson_name($this->get_value("metaPerson")), $name);
+        }
+    }
 
   // gets the human-friendly name of the meta person (e.g. R_MP_TASK_ASSIGNEE to "Task assignee")
-  function get_metaperson_name($metaperson) {
-    switch($metaperson) {
-      case REMINDER_METAPERSON_TASK_ASSIGNEE:
-        return "Task Assignee";
-      break;
-      case REMINDER_METAPERSON_TASK_MANAGER:
-        return "Task Manager";
-      break;
+    function get_metaperson_name($metaperson)
+    {
+        switch ($metaperson) {
+            case REMINDER_METAPERSON_TASK_ASSIGNEE:
+                return "Task Assignee";
+            break;
+            case REMINDER_METAPERSON_TASK_MANAGER:
+                return "Task Manager";
+            break;
+        }
     }
-  }
 
-  function get_all_recipients() {
-    $db = new db_alloc();
-    $query = "SELECT * FROM reminderRecipient WHERE reminderID = %d";
-    $db->query($query, $this->get_id());
-    $people =& get_cached_table("person");
-    $recipients = array();
-    $person = new reminderRecipient();
-    while ($db->next_record()) {
-      $person->read_db_record($db);
-      $id = $this->get_effective_person_id($person);
-      // hash on person ID prevents multiple emails to the same person
-      $recipients[$id] = $people[$id];
+    function get_all_recipients()
+    {
+        $db = new db_alloc();
+        $query = "SELECT * FROM reminderRecipient WHERE reminderID = %d";
+        $db->query($query, $this->get_id());
+        $people =& get_cached_table("person");
+        $recipients = array();
+        $person = new reminderRecipient();
+        while ($db->next_record()) {
+            $person->read_db_record($db);
+            $id = $this->get_effective_person_id($person);
+          // hash on person ID prevents multiple emails to the same person
+            $recipients[$id] = $people[$id];
+        }
+        return $recipients;
     }
-    return $recipients;
-  }
 
-  function update_recipients($recipients) {
-    $db = new db_alloc();
-    $query = "DELETE FROM reminderRecipient WHERE reminderID = %d";
-    $db->query($query, $this->get_id());
-    foreach ((array)$recipients as $r) {
-      $recipient = new reminderRecipient();
-      $recipient->set_value('reminderID', $this->get_id());
-      if ($r < 0) {
-        $recipient->set_value('metaPersonID', $r);
-        $recipient->set_value('personID', null);
-      } else {
-        $recipient->set_value('personID', $r);
-      }
-      $recipient->save();
+    function update_recipients($recipients)
+    {
+        $db = new db_alloc();
+        $query = "DELETE FROM reminderRecipient WHERE reminderID = %d";
+        $db->query($query, $this->get_id());
+        foreach ((array)$recipients as $r) {
+            $recipient = new reminderRecipient();
+            $recipient->set_value('reminderID', $this->get_id());
+            if ($r < 0) {
+                $recipient->set_value('metaPersonID', $r);
+                $recipient->set_value('personID', null);
+            } else {
+                $recipient->set_value('personID', $r);
+            }
+            $recipient->save();
+        }
+        return;
     }
-    return;
-  }
 
-  function get_list_filter($filter=array()) {
-    $filter["type"] and $sql[] = prepare("reminderType='%s'",$filter["type"]);
-    $filter["id"]   and $sql[] = prepare("reminderLinkID=%d",$filter["id"]);
-    $filter["reminderID"] and $sql[] = prepare("reminder.reminderID=%d",$filter["reminderID"]);
-    $filter["filter_recipient"] and $sql[] = prepare("personID = %d", $filter["filter_recipient"]);
-    imp($filter["filter_reminderActive"]) and $sql[] = prepare("reminderActive = %d",$filter["filter_reminderActive"]);
+    function get_list_filter($filter = array())
+    {
+        $filter["type"] and $sql[] = prepare("reminderType='%s'", $filter["type"]);
+        $filter["id"]   and $sql[] = prepare("reminderLinkID=%d", $filter["id"]);
+        $filter["reminderID"] and $sql[] = prepare("reminder.reminderID=%d", $filter["reminderID"]);
+        $filter["filter_recipient"] and $sql[] = prepare("personID = %d", $filter["filter_recipient"]);
+        imp($filter["filter_reminderActive"]) and $sql[] = prepare("reminderActive = %d", $filter["filter_reminderActive"]);
 
-    return $sql;
-  }
-
-  public static function get_list($_FORM) {
-    $filter = reminder::get_list_filter($_FORM);
-    if (is_array($filter) && count($filter)) {
-      $f = " WHERE ".implode(" AND ",$filter);
+        return $sql;
     }
-    $db = new db_alloc();
-    $q = "SELECT reminder.*,reminderRecipient.*,token.*,tokenAction.*, reminder.reminderID as rID
+
+    public static function get_list($_FORM)
+    {
+        $filter = reminder::get_list_filter($_FORM);
+        if (is_array($filter) && count($filter)) {
+            $f = " WHERE ".implode(" AND ", $filter);
+        }
+        $db = new db_alloc();
+        $q = "SELECT reminder.*,reminderRecipient.*,token.*,tokenAction.*, reminder.reminderID as rID
             FROM reminder
        LEFT JOIN reminderRecipient ON reminder.reminderID = reminderRecipient.reminderID
        LEFT JOIN token ON reminder.reminderHash = token.tokenHash
@@ -451,27 +489,23 @@ class reminder extends db_entity {
            ".$f."
         GROUP BY reminder.reminderID
         ORDER BY reminderTime,reminderType";
-    $db->query($q);
-    while ($row = $db->row()) {
-      $reminder = new reminder();
-      $reminder->read_db_record($db);
-      $rows[$row['reminderID']] = $row;
+        $db->query($q);
+        while ($row = $db->row()) {
+            $reminder = new reminder();
+            $reminder->read_db_record($db);
+            $rows[$row['reminderID']] = $row;
+        }
+        return $rows;
     }
-    return $rows;
-  }
 
-  function get_list_html($type=null,$id=null) {
-    global $TPL;
-    $_REQUEST["type"] = $type;
-    $_REQUEST["id"] = $id;
-    $TPL["reminderRows"] = reminder::get_list($_REQUEST);
-    $type and $TPL["returnToParent"] = $type;
-    $type or  $TPL["returnToParent"] = "list";
-    include_template(dirname(__FILE__)."/../templates/reminderListS.tpl");
-  }
-
+    function get_list_html($type = null, $id = null)
+    {
+        global $TPL;
+        $_REQUEST["type"] = $type;
+        $_REQUEST["id"] = $id;
+        $TPL["reminderRows"] = reminder::get_list($_REQUEST);
+        $type and $TPL["returnToParent"] = $type;
+        $type or  $TPL["returnToParent"] = "list";
+        include_template(dirname(__FILE__)."/../templates/reminderListS.tpl");
+    }
 }
-
-
-
-?>

--- a/reminder/lib/reminderRecipient.inc.php
+++ b/reminder/lib/reminderRecipient.inc.php
@@ -3,28 +3,27 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class reminderRecipient extends db_entity {
-  public $data_table = "reminderRecipient";
-  public $display_field_name = "reminderRecipientID";
-  public $key_field = "reminderRecipientID";
-  public $data_fields = array("reminderID","personID","metaPersonID");
+class reminderRecipient extends db_entity
+{
+    public $data_table = "reminderRecipient";
+    public $display_field_name = "reminderRecipientID";
+    public $key_field = "reminderRecipientID";
+    public $data_fields = array("reminderID","personID","metaPersonID");
 }
-
-?>

--- a/reminder/reminder.php
+++ b/reminder/reminder.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -30,7 +30,7 @@ $parentType = $_POST["parentType"] or $parentType = $_GET["parentType"];
 $parentID = $_POST["parentID"] or $parentID = $_GET["parentID"];
 $returnToParent = $_POST["returnToParent"] or $returnToParent = $_GET["returnToParent"];
 $TPL["returnToParent"] = $returnToParent;
-$parentID = sprintf("%d",$parentID);
+$parentID = sprintf("%d", $parentID);
 
 // Hacks to get reminders to work from the task calendar
 $_GET["reminderTime"] and $TPL["reminderTime"] = $_GET["reminderTime"];
@@ -39,242 +39,235 @@ $_GET["personID"] and $TPL["personID"] = $_GET["personID"];
 $step or $step = 1;
 
 if ($parentType == "general" && $step == 2) {
-  $step++;
-  $parentID = "0";
+    $step++;
+    $parentID = "0";
 }
 
 switch ($step) {
-case 1:
-  // Reminder type (project,task,client,general)
-  $parent_types = array("client"=>"Client", "project"=>"Project", "task"=>"Task", "general"=>"General");
-  $TPL["parentTypeOptions"] = page::select_options($parent_types);
-  include_template("templates/reminderSelectParentTypeM.tpl");
-  break;
+    case 1:
+      // Reminder type (project,task,client,general)
+        $parent_types = array("client"=>"Client", "project"=>"Project", "task"=>"Task", "general"=>"General");
+        $TPL["parentTypeOptions"] = page::select_options($parent_types);
+        include_template("templates/reminderSelectParentTypeM.tpl");
+        break;
 
-case 2:
-  // Which project,task,client. (skip for general)
+    case 2:
+      // Which project,task,client. (skip for general)
 
-  // get personID
-  $personID = $current_user->get_id();
-  $parent_names = array();
+      // get personID
+        $personID = $current_user->get_id();
+        $parent_names = array();
 
-  $db = new db_alloc();
-  if ($parentType == "client") {
-    $query = "SELECT * FROM client WHERE clientStatus!='Archived' ORDER BY clientName";
-    $db->query($query);
-    while ($db->next_record()) {
-      $client = new client();
-      $client->read_db_record($db);
-      $parent_names[$client->get_id()] = $client->get_value('clientName');
-    }
-  } else if ($parentType == "project") {
-    if ($current_user->have_role("admin")) {
-      $query = "SELECT * FROM project WHERE projectStatus != 'Archived' ORDER BY projectName";
-    } else {
-      $query = prepare("SELECT * 
+        $db = new db_alloc();
+        if ($parentType == "client") {
+            $query = "SELECT * FROM client WHERE clientStatus!='Archived' ORDER BY clientName";
+            $db->query($query);
+            while ($db->next_record()) {
+                $client = new client();
+                $client->read_db_record($db);
+                $parent_names[$client->get_id()] = $client->get_value('clientName');
+            }
+        } else if ($parentType == "project") {
+            if ($current_user->have_role("admin")) {
+                $query = "SELECT * FROM project WHERE projectStatus != 'Archived' ORDER BY projectName";
+            } else {
+                $query = prepare("SELECT * 
                           FROM project 
                      LEFT JOIN projectPerson ON project.projectID=projectPerson.projectID 
                          WHERE personID='%d' 
                            AND projectStatus != 'Archived'
                       ORDER BY projectName", $personID);
-    }
-    $db->query($query);
-    while ($db->next_record()) {
-      $project = new project();
-      $project->read_db_record($db);
-      $parent_names[$project->get_id()] = $project->get_value('projectName');
-    }
+            }
+            $db->query($query);
+            while ($db->next_record()) {
+                $project = new project();
+                $project->read_db_record($db);
+                $parent_names[$project->get_id()] = $project->get_value('projectName');
+            }
+        } else if ($parentType == "task") {
+            if ($current_user->have_role("admin")) {
+                    $query = "SELECT * FROM task";
+            } else {
+                    $query = prepare("SELECT * FROM task WHERE personID=%d ORDER BY taskName", $personID);
+            }
+            $db->query($query);
+            while ($db->next_record()) {
+                    $task = new task();
+                    $task->read_db_record($db);
+                if (substr($task->get_value("taskStatus"), 0, 6) != "closed") {
+                    $parent_names[$task->get_id()] = $task->get_value('taskName');
+                }
+            }
+        }
+        $TPL["parentType"] = $parentType;
+        $TPL["parentNameOptions"] = page::select_options($parent_names);
+        include_template("templates/reminderSelectParentM.tpl");
+        break;
 
-  } else if ($parentType == "task") {
-    if ($current_user->have_role("admin")) {
-      $query = "SELECT * FROM task";
-    } else {
-      $query = prepare("SELECT * FROM task WHERE personID=%d ORDER BY taskName", $personID);
-    }
-    $db->query($query);
-    while ($db->next_record()) {
-      $task = new task();
-      $task->read_db_record($db);
-      if (substr($task->get_value("taskStatus"),0,6) != "closed") {
-        $parent_names[$task->get_id()] = $task->get_value('taskName');
-      }
-    }
-  }
-  $TPL["parentType"] = $parentType;
-  $TPL["parentNameOptions"] = page::select_options($parent_names);
-  include_template("templates/reminderSelectParentM.tpl");
-  break;
-
-case 3:
-  // reminder entry form
-  $reminder = new reminder();
-  if (isset($reminderID)) {
-    $reminder->set_id($reminderID);
-    $reminder->select();
-    $parentType = $reminder->get_value('reminderType');
-    $parentID = $reminder->get_value('reminderLinkID');
-    $TPL["reminder_title"] = "Edit Reminder";
-    $TPL["reminder_buttons"] = <<<EOD
+    case 3:
+      // reminder entry form
+        $reminder = new reminder();
+        if (isset($reminderID)) {
+            $reminder->set_id($reminderID);
+            $reminder->select();
+            $parentType = $reminder->get_value('reminderType');
+            $parentID = $reminder->get_value('reminderLinkID');
+            $TPL["reminder_title"] = "Edit Reminder";
+            $TPL["reminder_buttons"] = <<<EOD
 <input type="hidden" name="reminder_id" value="{$reminderID}">
 <button type="submit" name="reminder_delete" value="1" class="delete_button">Delete<i class="icon-trash"></i></button>
 <button type="submit" name="reminder_update" value="1" class="save_button default">Save<i class="icon-ok-sign"></i></button>
 EOD;
-
-  } else {
-    $reminder->set_value('reminderType', $parentType);
-    $reminder->set_value('reminderLinkID', $parentID);
-    $TPL["reminder_title"] = "New Reminder";
-    $TPL["reminder_buttons"] = <<<EOD2
+        } else {
+            $reminder->set_value('reminderType', $parentType);
+            $reminder->set_value('reminderLinkID', $parentID);
+            $TPL["reminder_title"] = "New Reminder";
+            $TPL["reminder_buttons"] = <<<EOD2
 <button type="submit" name="reminder_save" value="1" class="save_button">Save<i class="icon-ok-sign"></i></button>
 EOD2;
-  }
+        }
 
   // link to parent
-  if ($parentType == "client") {
-    $TPL["return_address"] = $TPL["url_alloc_client"]."clientID=".$parentID;
-    $TPL["reminder_goto_parent"] = "<a href=\"".$TPL["return_address"]."\">Goto Client</a>";
-  } else if ($parentType == "project") {
-    $TPL["return_address"] = $TPL["url_alloc_project"]."projectID=".$parentID;
-    $TPL["reminder_goto_parent"] = "<a href=\"".$TPL["return_address"]."\">Goto Project</a>";
-  } else if ($parentType == "task") {
-    $TPL["return_address"] = $TPL["url_alloc_task"]."taskID=".$parentID;
-    $TPL["reminder_goto_parent"] = "<a href=\"".$TPL["return_address"]."\">Goto Task</a>";
-  }
+        if ($parentType == "client") {
+            $TPL["return_address"] = $TPL["url_alloc_client"]."clientID=".$parentID;
+            $TPL["reminder_goto_parent"] = "<a href=\"".$TPL["return_address"]."\">Goto Client</a>";
+        } else if ($parentType == "project") {
+            $TPL["return_address"] = $TPL["url_alloc_project"]."projectID=".$parentID;
+            $TPL["reminder_goto_parent"] = "<a href=\"".$TPL["return_address"]."\">Goto Project</a>";
+        } else if ($parentType == "task") {
+            $TPL["return_address"] = $TPL["url_alloc_task"]."taskID=".$parentID;
+            $TPL["reminder_goto_parent"] = "<a href=\"".$TPL["return_address"]."\">Goto Task</a>";
+        }
   // recipients
-  list($TPL["reminder_recipients"],$TPL["selected_recipients"]) = $reminder->get_recipient_options();
-  $recipients_display = array();
-  foreach ($TPL["selected_recipients"] as $recipient) {
-    $recipients_display []= $TPL["reminder_recipients"][$recipient];
-  }
-  $TPL['recipients_display'] = implode($recipients_display, ", ");
+        list($TPL["reminder_recipients"],$TPL["selected_recipients"]) = $reminder->get_recipient_options();
+        $recipients_display = array();
+        foreach ($TPL["selected_recipients"] as $recipient) {
+            $recipients_display []= $TPL["reminder_recipients"][$recipient];
+        }
+        $TPL['recipients_display'] = implode($recipients_display, ", ");
   // date/time
-  $_GET["reminderTime"] && $reminder->set_value("reminderTime",$_GET["reminderTime"]);
-  $TPL["reminderTime"] = $reminder->get_value("reminderTime");
-  $TPL["reminderHash"] = $reminder->get_value("reminderHash");
-  $TPL["reminderAdvNoticeInterval"] = $reminder->get_value("reminderAdvNoticeInterval");
-  $TPL["reminderRecuringInterval"] = $reminder->get_value("reminderRecuringInterval");
-  $TPL["reminderID"] = $reminder->get_id();
+        $_GET["reminderTime"] && $reminder->set_value("reminderTime", $_GET["reminderTime"]);
+        $TPL["reminderTime"] = $reminder->get_value("reminderTime");
+        $TPL["reminderHash"] = $reminder->get_value("reminderHash");
+        $TPL["reminderAdvNoticeInterval"] = $reminder->get_value("reminderAdvNoticeInterval");
+        $TPL["reminderRecuringInterval"] = $reminder->get_value("reminderRecuringInterval");
+        $TPL["reminderID"] = $reminder->get_id();
 
-  list($d,$t) = explode(" ",$reminder->get_value("reminderTime"));
-  $TPL["reminder_date"] = $d or $TPL["reminder_date"] = date("Y-m-d");
+        list($d,$t) = explode(" ", $reminder->get_value("reminderTime"));
+        $TPL["reminder_date"] = $d or $TPL["reminder_date"] = date("Y-m-d");
 
-  $TPL["reminder_hours"] = $reminder->get_hour_options();
-  $TPL["reminder_minutes"] = $reminder->get_minute_options();
-  $TPL["reminder_meridians"] = $reminder->get_meridian_options();
-  $TPL["reminder_recuring_value"] = $reminder->get_value('reminderRecuringValue');
-  $TPL["reminder_recuring_intervals"] = $reminder->get_recuring_interval_options();
+        $TPL["reminder_hours"] = $reminder->get_hour_options();
+        $TPL["reminder_minutes"] = $reminder->get_minute_options();
+        $TPL["reminder_meridians"] = $reminder->get_meridian_options();
+        $TPL["reminder_recuring_value"] = $reminder->get_value('reminderRecuringValue');
+        $TPL["reminder_recuring_intervals"] = $reminder->get_recuring_interval_options();
   // advanced notice?
-  $TPL["reminder_advnotice_value"] = $reminder->get_value('reminderAdvNoticeValue');
-  $TPL["reminder_advnotice_intervals"] = $reminder->get_advnotice_interval_options();
+        $TPL["reminder_advnotice_value"] = $reminder->get_value('reminderAdvNoticeValue');
+        $TPL["reminder_advnotice_intervals"] = $reminder->get_advnotice_interval_options();
   // subject
-  if ($reminder->get_value('reminderSubject') != "") {
-    $TPL["reminder_default_subject"] = $reminder->get_value('reminderSubject');
-  } else {
-    if ($parentType == "client") {
-      $TPL["reminder_default_subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_reminderClient"), "client", $parentID);
-      $TPL["reminder_default_content"] = config::get_config_item("allocURL")."client/client.php?clientID=".$parentID;
+        if ($reminder->get_value('reminderSubject') != "") {
+            $TPL["reminder_default_subject"] = $reminder->get_value('reminderSubject');
+        } else {
+            if ($parentType == "client") {
+                $TPL["reminder_default_subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_reminderClient"), "client", $parentID);
+                $TPL["reminder_default_content"] = config::get_config_item("allocURL")."client/client.php?clientID=".$parentID;
+            } else if ($parentType == "project") {
+                $TPL["reminder_default_subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_reminderProject"), "project", $parentID);
+                $TPL["reminder_default_content"] = config::get_config_item("allocURL")."project/project.php?projectID=".$parentID;
+            } else if ($parentType == "task") {
+                $TPL["reminder_default_subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_reminderTask"), "task", $parentID);
+                $TPL["reminder_default_content"] = config::get_config_item("allocURL")."task/task.php?taskID=".$parentID;
+            } else if ($parentType == "general") {
+                $TPL["reminder_default_subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_reminderOther"), "");
+            }
+        }
+        $TPL["reminder_default_content"].= "\n".$reminder->get_value('reminderContent');
+        $TPL["parentType"] = $parentType;
+        $TPL["parentID"] = $parentID;
+        $TPL["reminderActive"] = $reminder->get_value("reminderActive");
+        if (!is_object($reminder) || !$reminder->get_id()) {
+            $TPL["reminderActive"] = true;
+        }
 
-    } else if ($parentType == "project") {
-      $TPL["reminder_default_subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_reminderProject"), "project", $parentID);
-      $TPL["reminder_default_content"] = config::get_config_item("allocURL")."project/project.php?projectID=".$parentID;
-
-    } else if ($parentType == "task") {
-      $TPL["reminder_default_subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_reminderTask"), "task", $parentID);
-      $TPL["reminder_default_content"] = config::get_config_item("allocURL")."task/task.php?taskID=".$parentID;
-
-    } else if ($parentType == "general") {
-      $TPL["reminder_default_subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_reminderOther"), "");
-    }
-  }
-  $TPL["reminder_default_content"].= "\n".$reminder->get_value('reminderContent');
-  $TPL["parentType"] = $parentType;
-  $TPL["parentID"] = $parentID;
-  $TPL["reminderActive"] = $reminder->get_value("reminderActive");
-  if (!is_object($reminder) || !$reminder->get_id()) {
-    $TPL["reminderActive"] = true;
-  }
-
-  if ($reminder->get_value("reminderHash")) {
-    $db = new db_alloc();
-    $r = $db->qr("SELECT tokenAction
+        if ($reminder->get_value("reminderHash")) {
+            $db = new db_alloc();
+            $r = $db->qr("SELECT tokenAction
                     FROM token 
                LEFT JOIN tokenAction ON token.tokenActionID = tokenAction.tokenActionID
-                   WHERE token.tokenHash = '%s'",$reminder->get_value("reminderHash"));
-    $TPL["tokenName"] = $r["tokenAction"];
-  }
-  include_template("templates/reminderM.tpl");
-  break;
-
-case 4:
-  // save and return to list
-  if ($_POST["reminder_save"] || $_POST["reminder_update"]) {
-
-    $recipient_keys = $_POST["reminder_recipient"];
-    // make 24 hour with 12am = 0 -> 11am = 11 -> 12pm = 12 -> 11pm = 23
-    if ($_POST["reminder_hour"] == 12) {
-      $_POST["reminder_hour"] = 0;
-    }
-    if ($_POST["reminder_meridian"] == "pm") {
-      $_POST["reminder_hour"] += 12;
-    }
-    $reminder = new reminder();
-
-    if (isset($_POST["reminder_update"])) {
-      $reminder->set_id($_POST["reminder_id"]);
-      $reminder->select();
-      if ($reminder->get_value("reminderHash")) {
-        $token = new token();
-        $token->set_hash($reminder->get_value("reminderHash"),false);
-        if ($token->get_value("tokenActionID") == 3) {
-          $reminder->set_value("reminderTime","");
-          $no = true;
+                   WHERE token.tokenHash = '%s'", $reminder->get_value("reminderHash"));
+            $TPL["tokenName"] = $r["tokenAction"];
         }
-      }
-    }
+        include_template("templates/reminderM.tpl");
+        break;
 
-    $reminder->set_value('reminderType', $parentType);
-    $reminder->set_value('reminderLinkID', $parentID);
-    $reminder->set_value('reminderModifiedUser', $current_user->get_id());
-    $reminder->set_modified_time();
-    $no or $reminder->set_value('reminderTime',$_POST["reminder_date"]." ".$_POST["reminder_hour"].":".$_POST["reminder_minute"].":00");
-    $reminder->set_value('reminderHash',$_POST["reminderHash"]);
+    case 4:
+      // save and return to list
+        if ($_POST["reminder_save"] || $_POST["reminder_update"]) {
+            $recipient_keys = $_POST["reminder_recipient"];
+        // make 24 hour with 12am = 0 -> 11am = 11 -> 12pm = 12 -> 11pm = 23
+            if ($_POST["reminder_hour"] == 12) {
+                $_POST["reminder_hour"] = 0;
+            }
+            if ($_POST["reminder_meridian"] == "pm") {
+                $_POST["reminder_hour"] += 12;
+            }
+            $reminder = new reminder();
+
+            if (isset($_POST["reminder_update"])) {
+                $reminder->set_id($_POST["reminder_id"]);
+                $reminder->select();
+                if ($reminder->get_value("reminderHash")) {
+                    $token = new token();
+                    $token->set_hash($reminder->get_value("reminderHash"), false);
+                    if ($token->get_value("tokenActionID") == 3) {
+                          $reminder->set_value("reminderTime", "");
+                          $no = true;
+                    }
+                }
+            }
+
+            $reminder->set_value('reminderType', $parentType);
+            $reminder->set_value('reminderLinkID', $parentID);
+            $reminder->set_value('reminderModifiedUser', $current_user->get_id());
+            $reminder->set_modified_time();
+            $no or $reminder->set_value('reminderTime', $_POST["reminder_date"]." ".$_POST["reminder_hour"].":".$_POST["reminder_minute"].":00");
+            $reminder->set_value('reminderHash', $_POST["reminderHash"]);
       
 
 
-    if (!$_POST["reminder_recuring_value"]) {
-      $reminder->set_value('reminderRecuringInterval', 'No');
-      $reminder->set_value('reminderRecuringValue', '0');
-    } else {
-      if ($_POST["reminder_recuring_value"] == 0 && $_POST["reminder_recuring_interval"] && $_POST["reminder_recuring_interval"] != 'No') {
-        $_POST["reminder_recuring_value"] = 1;
-      }
-      $reminder->set_value('reminderRecuringInterval', $_POST["reminder_recuring_interval"]);
-      $reminder->set_value('reminderRecuringValue', $_POST["reminder_recuring_value"]);
-    }
-    $reminder->set_value('reminderAdvNoticeSent', '0');
-    if (!$_POST["reminder_advnotice_value"]) {
-      $reminder->set_value('reminderAdvNoticeInterval', 'No');
-      $reminder->set_value('reminderAdvNoticeValue', '0');
-    } else {
-      $reminder->set_value('reminderAdvNoticeInterval', $_POST["reminder_advnotice_interval"]);
-      $reminder->set_value('reminderAdvNoticeValue', $_POST["reminder_advnotice_value"]);
-    }
-    $reminder->set_value('reminderSubject', $_POST["reminder_subject"]);
-    $reminder->set_value('reminderContent', rtrim($_POST["reminder_content"]));
-    $reminder->set_value('reminderActive', sprintf("%d",$_POST["reminderActive"]));
-    $reminder->save();
-    $reminder->update_recipients($recipient_keys);
-    $returnToParent = "reminder";
-    $reminderID = $reminder->get_id();
-    $TPL["message_good"][] = "Reminder saved.";
+            if (!$_POST["reminder_recuring_value"]) {
+                $reminder->set_value('reminderRecuringInterval', 'No');
+                $reminder->set_value('reminderRecuringValue', '0');
+            } else {
+                if ($_POST["reminder_recuring_value"] == 0 && $_POST["reminder_recuring_interval"] && $_POST["reminder_recuring_interval"] != 'No') {
+                    $_POST["reminder_recuring_value"] = 1;
+                }
+                $reminder->set_value('reminderRecuringInterval', $_POST["reminder_recuring_interval"]);
+                $reminder->set_value('reminderRecuringValue', $_POST["reminder_recuring_value"]);
+            }
+            $reminder->set_value('reminderAdvNoticeSent', '0');
+            if (!$_POST["reminder_advnotice_value"]) {
+                $reminder->set_value('reminderAdvNoticeInterval', 'No');
+                $reminder->set_value('reminderAdvNoticeValue', '0');
+            } else {
+                $reminder->set_value('reminderAdvNoticeInterval', $_POST["reminder_advnotice_interval"]);
+                $reminder->set_value('reminderAdvNoticeValue', $_POST["reminder_advnotice_value"]);
+            }
+            $reminder->set_value('reminderSubject', $_POST["reminder_subject"]);
+            $reminder->set_value('reminderContent', rtrim($_POST["reminder_content"]));
+            $reminder->set_value('reminderActive', sprintf("%d", $_POST["reminderActive"]));
+            $reminder->save();
+            $reminder->update_recipients($recipient_keys);
+            $returnToParent = "reminder";
+            $reminderID = $reminder->get_id();
+            $TPL["message_good"][] = "Reminder saved.";
+        } else if ($_POST["reminder_delete"] && $_POST["reminder_id"]) {
+            $reminder = new reminder();
+            $reminder->set_id($_POST["reminder_id"]);
+            $reminder->delete();
+        }
 
-  } else if ($_POST["reminder_delete"] && $_POST["reminder_id"]) {
-    $reminder = new reminder();
-    $reminder->set_id($_POST["reminder_id"]);
-    $reminder->delete();
-  }
-
-  $headers = array("client"   => $TPL["url_alloc_client"]."clientID=".$parentID."&sbs_link=reminders"
+        $headers = array("client"   => $TPL["url_alloc_client"]."clientID=".$parentID."&sbs_link=reminders"
                   ,"project"  => $TPL["url_alloc_project"]."projectID=".$parentID."&sbs_link=reminders"
                   ,"task"     => $TPL["url_alloc_task"]."taskID=".$parentID."&sbs_link=reminders"
                   ,"home"     => $TPL["url_alloc_home"]
@@ -284,13 +277,10 @@ case 4:
                   ,""         => $TPL["url_alloc_reminderList"]
                   );
 
-  alloc_redirect($headers[$returnToParent]);
+        alloc_redirect($headers[$returnToParent]);
 
-  break;
+        break;
 
-default:
-  alloc_error("Unrecognized state");
+    default:
+        alloc_error("Unrecognized state");
 }
-
-
-?>

--- a/reminder/reminderList.php
+++ b/reminder/reminderList.php
@@ -3,44 +3,41 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function show_reminder_filter($template) {
-  $current_user = &singleton("current_user");
-  global $TPL;
-  if ($current_user->have_role("admin") || $current_user->have_role("manage")) {
+function show_reminder_filter($template)
+{
+    $current_user = &singleton("current_user");
+    global $TPL;
+    if ($current_user->have_role("admin") || $current_user->have_role("manage")) {
+        $TPL["reminderActiveOptions"] = page::select_options(array("1"=>"Active","0"=>"Inactive"), $_REQUEST["filter_reminderActive"]);
 
-    $TPL["reminderActiveOptions"] = page::select_options(array("1"=>"Active","0"=>"Inactive"),$_REQUEST["filter_reminderActive"]);
-
-    $db = new db_alloc();
-    $db->query("SELECT username,personID FROM person WHERE personActive = 1 ORDER BY username");
-    while ($db->next_record()) {
-      $recipientOptions[$db->f("personID")] = $db->f("username");
+        $db = new db_alloc();
+        $db->query("SELECT username,personID FROM person WHERE personActive = 1 ORDER BY username");
+        while ($db->next_record()) {
+            $recipientOptions[$db->f("personID")] = $db->f("username");
+        }
+        $TPL["recipientOptions"] = page::select_options($recipientOptions, $_REQUEST["filter_recipient"]);
+        include_template($template);
     }
-    $TPL["recipientOptions"] = page::select_options($recipientOptions, $_REQUEST["filter_recipient"]);
-    include_template($template);
-  }
 }
 
 
 include_template("templates/reminderListM.tpl");
-
-
-?>

--- a/reminder/sendReminders.php
+++ b/reminder/sendReminders.php
@@ -3,24 +3,24 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_AUTH",true);
+define("NO_AUTH", true);
 require_once("../alloc.php");
 
 $db = new db_alloc();
@@ -42,17 +42,17 @@ $query = prepare("SELECT *
 
 $db->query($query);
 while ($db->next_record()) {
-  $reminder = new reminder();
-  $reminder->read_db_record($db);
+    $reminder = new reminder();
+    $reminder->read_db_record($db);
   //echo "<br>Adv: ".$reminder->get_id();
-  $current_user = new person();
-  $current_user->load_current_user($db->f('reminderCreatedUser'));
-  singleton("current_user",$current_user);
-  if (!$reminder->is_alive()) {
-    $reminder->deactivate();
-  } else {
-    $reminder->mail_advnotice();
-  }
+    $current_user = new person();
+    $current_user->load_current_user($db->f('reminderCreatedUser'));
+    singleton("current_user", $current_user);
+    if (!$reminder->is_alive()) {
+        $reminder->deactivate();
+    } else {
+        $reminder->mail_advnotice();
+    }
 }
 
 
@@ -65,18 +65,15 @@ $query = prepare("SELECT *
 
 $db->query($query);
 while ($db->next_record()) {
-  $reminder = new reminder();
-  $reminder->read_db_record($db);
+    $reminder = new reminder();
+    $reminder->read_db_record($db);
   //echo "<br>Rem: ".$reminder->get_id();
-  $current_user = new person();
-  $current_user->load_current_user($db->f('reminderCreatedUser'));
-  singleton("current_user",$current_user);
-  if (!$reminder->is_alive()) {
-    $reminder->deactivate();
-  } else {
-    $reminder->mail_reminder();
-  }
+    $current_user = new person();
+    $current_user->load_current_user($db->f('reminderCreatedUser'));
+    singleton("current_user", $current_user);
+    if (!$reminder->is_alive()) {
+        $reminder->deactivate();
+    } else {
+        $reminder->mail_reminder();
+    }
 }
-
-
-?>

--- a/report/lib/init.php
+++ b/report/lib/init.php
@@ -3,32 +3,33 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class report_module extends module {
-  var $module = "report";
+class report_module extends module
+{
+    var $module = "report";
 }
 
-function has_report_perm() {
-  $current_user = &singleton("current_user");
-  if (is_object($current_user)) {
-    return $current_user->have_role("admin") || $current_user->have_role("manage");
-  }
-  return false;
+function has_report_perm()
+{
+    $current_user = &singleton("current_user");
+    if (is_object($current_user)) {
+        return $current_user->have_role("admin") || $current_user->have_role("manage");
+    }
+    return false;
 }
-?>

--- a/report/report.php
+++ b/report/report.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,7 +23,7 @@
 require_once("../alloc.php");
 
 if (!has_report_perm()) {
-  alloc_error("you don't have permission to generate reports.",true);
+    alloc_error("you don't have permission to generate reports.", true);
 }
 
 $current_user = &singleton("current_user");
@@ -43,161 +43,160 @@ $modules["item"] = "Items";
 $modules["person"] = "Users";
 $modules["announcement"] = "Announcements";
 
-$TPL["module_options"] = page::select_options($modules,$_POST["mod"]);
+$TPL["module_options"] = page::select_options($modules, $_POST["mod"]);
 
 
 if ($_POST["do_step_2"]) {
-
-  if (!is_array($fields)) {
-    $fields = array();
-  }
-  $ignored_fields = array();
-  $table_fields = array();
-  $db_tables = array();
-
-
-  if ($_POST["mod"] == "client") {
-    $db_tables[] = "client";
-    $db_tables[] = "clientContact";
-    $db_tables[] = "comment";
-    $query["join"] = " LEFT JOIN clientContact ON client.clientID = clientContact.clientID";
-    $query["join"].= " LEFT JOIN comment ON (client.clientID = comment.commentLinkID AND commentType = 'client')";
-  }
-
-  if ($_POST["mod"] == "project") {
-    $db_tables[] = "project";
-    $db_tables[] = "projectCommissionPerson";
-    $db_tables[] = "projectPerson";
-    $query["join"] = " LEFT JOIN projectCommissionPerson ON project.projectID = projectCommissionPerson.projectID";
-    $query["join"].= " LEFT JOIN projectPerson ON project.projectID = projectPerson.projectID";
-  }
-
-  if ($_POST["mod"] == "task") {
-    $db_tables[] = "task";
-  }
-
-  if ($_POST["mod"] == "time") {
-    $db_tables[] = "timeSheet";
-    $db_tables[] = "timeSheetItem";
-    $query["join"] = " LEFT JOIN timeSheetItem ON timeSheet.timeSheetID = timeSheetItem.timeSheetID";
-  }
-
-  if ($_POST["mod"] == "transaction" && $current_user->have_role("admin")) {
-    $db_tables[] = "tf";
-    $db_tables[] = "transaction";
-    $db_tables[] = "transactionRepeat";
-    $db_tables[] = "expenseForm";
-    $query["join"].= " LEFT JOIN transaction ON transaction.tfID = tf.tfID";
-    $query["join"].= " LEFT JOIN transactionRepeat ON transaction.tfID = transactionRepeat.tfID";
-    $query["join"].= " LEFT JOIN expenseForm ON expenseForm.expenseformID = transaction.expenseformID";
-  }
-
-  if ($_POST["mod"] == "invoice") {
-    $db_tables[] = "invoice";
-    $db_tables[] = "invoiceItem";
-    $query["join"].= " LEFT JOIN invoiceItem on invoice.invoiceID = invoiceItem.invoiceID";
-  }
-
-  if ($_POST["mod"] == "item") {
-    $db_tables[] = "item";
-  }
-
-  if ($_POST["mod"] == "person") {
-    $db_tables[] = "person";
-  }
-
-  if ($_POST["mod"] == "announcement") {
-    $db_tables[] = "announcement";
-  }
+    if (!is_array($fields)) {
+        $fields = array();
+    }
+    $ignored_fields = array();
+    $table_fields = array();
+    $db_tables = array();
 
 
-  /* 
+    if ($_POST["mod"] == "client") {
+        $db_tables[] = "client";
+        $db_tables[] = "clientContact";
+        $db_tables[] = "comment";
+        $query["join"] = " LEFT JOIN clientContact ON client.clientID = clientContact.clientID";
+        $query["join"].= " LEFT JOIN comment ON (client.clientID = comment.commentLinkID AND commentType = 'client')";
+    }
+
+    if ($_POST["mod"] == "project") {
+        $db_tables[] = "project";
+        $db_tables[] = "projectCommissionPerson";
+        $db_tables[] = "projectPerson";
+        $query["join"] = " LEFT JOIN projectCommissionPerson ON project.projectID = projectCommissionPerson.projectID";
+        $query["join"].= " LEFT JOIN projectPerson ON project.projectID = projectPerson.projectID";
+    }
+
+    if ($_POST["mod"] == "task") {
+        $db_tables[] = "task";
+    }
+
+    if ($_POST["mod"] == "time") {
+        $db_tables[] = "timeSheet";
+        $db_tables[] = "timeSheetItem";
+        $query["join"] = " LEFT JOIN timeSheetItem ON timeSheet.timeSheetID = timeSheetItem.timeSheetID";
+    }
+
+    if ($_POST["mod"] == "transaction" && $current_user->have_role("admin")) {
+        $db_tables[] = "tf";
+        $db_tables[] = "transaction";
+        $db_tables[] = "transactionRepeat";
+        $db_tables[] = "expenseForm";
+        $query["join"].= " LEFT JOIN transaction ON transaction.tfID = tf.tfID";
+        $query["join"].= " LEFT JOIN transactionRepeat ON transaction.tfID = transactionRepeat.tfID";
+        $query["join"].= " LEFT JOIN expenseForm ON expenseForm.expenseformID = transaction.expenseformID";
+    }
+
+    if ($_POST["mod"] == "invoice") {
+        $db_tables[] = "invoice";
+        $db_tables[] = "invoiceItem";
+        $query["join"].= " LEFT JOIN invoiceItem on invoice.invoiceID = invoiceItem.invoiceID";
+    }
+
+    if ($_POST["mod"] == "item") {
+        $db_tables[] = "item";
+    }
+
+    if ($_POST["mod"] == "person") {
+        $db_tables[] = "person";
+    }
+
+    if ($_POST["mod"] == "announcement") {
+        $db_tables[] = "announcement";
+    }
+
+
+  /*
      this is how to not include particular fields $ignored_fields[] = "timeSheetItem.timeSheetItemID"; */
 
-  $query["start"] = " SELECT ";
-  $query["where"] = " WHERE 1=1 ";
-  $query["from"] = prepare(" FROM %s ",$db_tables[0]);
+    $query["start"] = " SELECT ";
+    $query["where"] = " WHERE 1=1 ";
+    $query["from"] = prepare(" FROM %s ", $db_tables[0]);
 
 
 
-  foreach($db_tables as $table) {
-    if (class_exists($table)) {
-      $class = new $table;
-      $TPL["table_fields"].= "<tr><td colspan=\"6\">&nbsp;</td></tr>";
-      $TPL["table_fields"].= "<tr><td colspan=\"6\"><b>".strtoupper($table)."</b></td></tr>";
-      if (is_object($class) && $class->key_field->label == ($table."ID")) {
-        if (count($db_tables) > 1) {
-          $groupby_str = $table.".".$table."ID";
-          $groupby = "<input type=\"radio\" name=\"table_groupby\" value=\"";
-          $groupby.= $groupby_str."\"";
-          $groupby.= ($_POST["table_groupby"] == $groupby_str ? " checked" : "").">";
-          $groupby = "<b>Group by this table</b> ".$groupby;
-        } else {
-          $groupby = "&nbsp;";
-        }
-      }
-      $TPL["table_fields"].= "<tr><td colspan=\"6\">".$groupby."</td></tr><tr>";
-      $TPL["table_fields"].= "<td>&nbsp;</td>";
-      $TPL["table_fields"].= "<td><b>Like (john smit%)</b></td><td><b>Numerical (>=5)</b></td>";
-      $TPL["table_fields"].= "<td>&nbsp;</td>";
-      $TPL["table_fields"].= "<td><b>Like (john smit%)</b></td><td><b>Numerical (>=5)</b></td>";
-      $TPL["table_fields"].= "</tr>";
-      unset($i);
-      $class->data_fields[$class->key_field->get_name()] = true;
-      foreach($class->data_fields as $name=>$v) {
-        $str = $table.".".$name;
-        if (!in_array($str, $ignored_fields)) {
-          $table_fields[] = $str;
-          $TPL["table_fields"].= "<td valign=\"middle\">";
-          $TPL["table_fields"].= "\n<input type=\"checkbox\" name=\"table_name[".$str."]\" value=\"";
-          $TPL["table_fields"].= $str."\"".($_POST["table_name"][$str] == $str ? " checked" : "").">";
-          $TPL["table_fields"].= $name;
-          $TPL["table_fields"].= "</td><td valign=\"middle\">";
-          $TPL["table_fields"].= "\n<input type=\"text\" name=\"table_like[".$str."]\"";
-          $TPL["table_fields"].= "value=\"".$_POST["table_like"][$str]."\"size=\"15\">\n";
-          $TPL["table_fields"].= "</td><td valign=\"middle\">";
-          $TPL["table_fields"].= "<input type=\"text\" name=\"table_num_op_1[".$str."]\" value=\"";
-          $TPL["table_fields"].= $_POST["table_num_op_1"][$str]."\" size=\"8\"> and ";
-          $TPL["table_fields"].= "<input type=\"text\" name=\"table_num_op_2[".$str."]\" value=\"";
-          $TPL["table_fields"].= $_POST["table_num_op_2"][$str]."\" size=\"8\">";
-          $TPL["table_fields"].= "</td>";
-          if (isset($i)) {
-            $TPL["table_fields"].= "</tr><tr>";
+    foreach ($db_tables as $table) {
+        if (class_exists($table)) {
+            $class = new $table;
+            $TPL["table_fields"].= "<tr><td colspan=\"6\">&nbsp;</td></tr>";
+            $TPL["table_fields"].= "<tr><td colspan=\"6\"><b>".strtoupper($table)."</b></td></tr>";
+            if (is_object($class) && $class->key_field->label == ($table."ID")) {
+                if (count($db_tables) > 1) {
+                    $groupby_str = $table.".".$table."ID";
+                    $groupby = "<input type=\"radio\" name=\"table_groupby\" value=\"";
+                    $groupby.= $groupby_str."\"";
+                    $groupby.= ($_POST["table_groupby"] == $groupby_str ? " checked" : "").">";
+                    $groupby = "<b>Group by this table</b> ".$groupby;
+                } else {
+                    $groupby = "&nbsp;";
+                }
+            }
+            $TPL["table_fields"].= "<tr><td colspan=\"6\">".$groupby."</td></tr><tr>";
+            $TPL["table_fields"].= "<td>&nbsp;</td>";
+            $TPL["table_fields"].= "<td><b>Like (john smit%)</b></td><td><b>Numerical (>=5)</b></td>";
+            $TPL["table_fields"].= "<td>&nbsp;</td>";
+            $TPL["table_fields"].= "<td><b>Like (john smit%)</b></td><td><b>Numerical (>=5)</b></td>";
+            $TPL["table_fields"].= "</tr>";
             unset($i);
-          } else {
-            $i = "set";
-          }
+            $class->data_fields[$class->key_field->get_name()] = true;
+            foreach ($class->data_fields as $name => $v) {
+                $str = $table.".".$name;
+                if (!in_array($str, $ignored_fields)) {
+                    $table_fields[] = $str;
+                    $TPL["table_fields"].= "<td valign=\"middle\">";
+                    $TPL["table_fields"].= "\n<input type=\"checkbox\" name=\"table_name[".$str."]\" value=\"";
+                    $TPL["table_fields"].= $str."\"".($_POST["table_name"][$str] == $str ? " checked" : "").">";
+                    $TPL["table_fields"].= $name;
+                    $TPL["table_fields"].= "</td><td valign=\"middle\">";
+                    $TPL["table_fields"].= "\n<input type=\"text\" name=\"table_like[".$str."]\"";
+                    $TPL["table_fields"].= "value=\"".$_POST["table_like"][$str]."\"size=\"15\">\n";
+                    $TPL["table_fields"].= "</td><td valign=\"middle\">";
+                    $TPL["table_fields"].= "<input type=\"text\" name=\"table_num_op_1[".$str."]\" value=\"";
+                    $TPL["table_fields"].= $_POST["table_num_op_1"][$str]."\" size=\"8\"> and ";
+                    $TPL["table_fields"].= "<input type=\"text\" name=\"table_num_op_2[".$str."]\" value=\"";
+                    $TPL["table_fields"].= $_POST["table_num_op_2"][$str]."\" size=\"8\">";
+                    $TPL["table_fields"].= "</td>";
+                    if (isset($i)) {
+                        $TPL["table_fields"].= "</tr><tr>";
+                        unset($i);
+                    } else {
+                        $i = "set";
+                    }
+                }
+            }
+        } else {
+            alloc_error("class ".$table." does not exist.. ");
         }
-      }
-    } else {
-      alloc_error("class ".$table." does not exist.. ");
     }
-  }
-  $TPL["table_fields"].= "</tr>";
+    $TPL["table_fields"].= "</tr>";
 
-  if ($_POST["field_quotes"] == "single") {
-    $s_q_sel = " selected";
-  } else if ($_POST["field_quotes"] == "double") {
-    $d_q_sel = " selected";
-  }
+    if ($_POST["field_quotes"] == "single") {
+        $s_q_sel = " selected";
+    } else if ($_POST["field_quotes"] == "double") {
+        $d_q_sel = " selected";
+    }
 
-  if ($_POST["generate_file"]) {
-    $g_f_sel = " checked";
-  }
-  $_POST["field_separator"] or $_POST["field_separator"] = ",";
+    if ($_POST["generate_file"]) {
+        $g_f_sel = " checked";
+    }
+    $_POST["field_separator"] or $_POST["field_separator"] = ",";
 
-  $TPL["dump_options"].= "Generate File: ";
-  $TPL["dump_options"].= "<input type=\"checkbox\" name=\"generate_file\"".$g_f_sel."> ";
-  $TPL["dump_options"].= " with field separator ";
-  $TPL["dump_options"].= "<input type=\"text\" name=\"field_separator\" size=\"5\" value=\"";
-  $TPL["dump_options"].= $_POST["field_separator"]."\"> (type 'tab' for tab).";
-  $TPL["dump_options"].= "<br>Quotes around fields: ";
-  $TPL["dump_options"].= "<select name=\"field_quotes\">";
-  $TPL["dump_options"].= "<option value=\"\">None";
-  $TPL["dump_options"].= "<option value=\"single\"".$s_q_sel.">Single";
-  $TPL["dump_options"].= "<option value=\"double\"".$d_q_sel.">Double";
-  $TPL["dump_options"].= "</select><br>";
-  $TPL["dump_options"].= '<br><br>
+    $TPL["dump_options"].= "Generate File: ";
+    $TPL["dump_options"].= "<input type=\"checkbox\" name=\"generate_file\"".$g_f_sel."> ";
+    $TPL["dump_options"].= " with field separator ";
+    $TPL["dump_options"].= "<input type=\"text\" name=\"field_separator\" size=\"5\" value=\"";
+    $TPL["dump_options"].= $_POST["field_separator"]."\"> (type 'tab' for tab).";
+    $TPL["dump_options"].= "<br>Quotes around fields: ";
+    $TPL["dump_options"].= "<select name=\"field_quotes\">";
+    $TPL["dump_options"].= "<option value=\"\">None";
+    $TPL["dump_options"].= "<option value=\"single\"".$s_q_sel.">Single";
+    $TPL["dump_options"].= "<option value=\"double\"".$d_q_sel.">Double";
+    $TPL["dump_options"].= "</select><br>";
+    $TPL["dump_options"].= '<br><br>
   <button type="submit" name="do_step_3" value="1" class="filter_button">Generate Database Report<i class="icon-cogs"></i></button>
   ';
 }
@@ -206,130 +205,126 @@ if ($_POST["do_step_2"]) {
 // END STEP TWO
 
 if ($_POST["do_step_3"]) {
+    if (!is_array($table_fields)) {
+        alloc_error("Did not get table_fields array.");
+        $table_fields = array();
+    }
 
-  if (!is_array($table_fields)) {
-    alloc_error("Did not get table_fields array.");
-    $table_fields = array();
-  }
 
+    foreach ($table_fields as $v) {
+        if ($_POST["table_name"][$v] != "") {
+            $query["select"].= $commar.db_esc($_POST["table_name"][$v]);
+            $commar = ",";          // no commar the first time
 
-  foreach($table_fields as $v) {
+            if ($_POST["table_like"][$v] != "") {
+                $query["where"].= " AND ".db_esc($_POST["table_name"][$v])." LIKE '".db_esc($_POST["table_like"][$v])."'";
+            }
 
-    if ($_POST["table_name"][$v] != "") {
-      $query["select"].= $commar.db_esc($_POST["table_name"][$v]);
-      $commar = ",";          // no commar the first time
+            if ($_POST["table_num_op_1"][$v] != "") {
+                if (preg_match("/([^\d]{1,2})(\d\d\d\d-\d\d?-\d\d?)/", $_POST["table_num_op_1"][$v], $m)) {
+                    $query["where"].= " AND ".db_esc($_POST["table_name"][$v])." ".db_esc($m[1])."'".db_esc($m[2])."'";
+                } else {
+                    $query["where"].= " AND ".db_esc($_POST["table_name"][$v])." ".db_esc($_POST["table_num_op_1"][$v]);
+                }
+            }
 
-      if ($_POST["table_like"][$v] != "") {
-        $query["where"].= " AND ".db_esc($_POST["table_name"][$v])." LIKE '".db_esc($_POST["table_like"][$v])."'";
-      }
-
-      if ($_POST["table_num_op_1"][$v] != "") {
-        if (preg_match("/([^\d]{1,2})(\d\d\d\d-\d\d?-\d\d?)/",$_POST["table_num_op_1"][$v],$m)) {
-          $query["where"].= " AND ".db_esc($_POST["table_name"][$v])." ".db_esc($m[1])."'".db_esc($m[2])."'";
-        } else {
-          $query["where"].= " AND ".db_esc($_POST["table_name"][$v])." ".db_esc($_POST["table_num_op_1"][$v]);
+            if ($_POST["table_num_op_2"][$v] != "") {
+                if (preg_match("/([^\d]{1,2})(\d\d\d\d-\d\d?-\d\d?)/", $_POST["table_num_op_2"][$v], $m)) {
+                    $query["where"].= " AND ".db_esc($_POST["table_name"][$v])." ".db_esc($m[1])."'".db_esc($m[2])."'";
+                } else {
+                    $query["where"].= " AND ".db_esc($_POST["table_name"][$v])." ".db_esc($_POST["table_num_op_2"][$v]);
+                }
+            }
         }
-      }
+    }
 
-      if ($_POST["table_num_op_2"][$v] != "") {
-        if (preg_match("/([^\d]{1,2})(\d\d\d\d-\d\d?-\d\d?)/",$_POST["table_num_op_2"][$v],$m)) {
-          $query["where"].= " AND ".db_esc($_POST["table_name"][$v])." ".db_esc($m[1])."'".db_esc($m[2])."'";
+    if ($_POST["table_groupby"] != "") {
+        if (!isset($query["group"])) {
+            $query["group"] = " GROUP BY ".db_esc($_POST["table_groupby"]);
         } else {
-          $query["where"].= " AND ".db_esc($_POST["table_name"][$v])." ".db_esc($_POST["table_num_op_2"][$v]);
+            $query["group"].= ",".db_esc($_POST["table_groupby"]);
         }
-      }
-    }
-  }
-
-  if ($_POST["table_groupby"] != "") {
-    if (!isset($query["group"])) {
-      $query["group"] = " GROUP BY ".db_esc($_POST["table_groupby"]);
-    } else {
-      $query["group"].= ",".db_esc($_POST["table_groupby"]);
-    }
-  }
-
-
-
-  $final_query = $query["start"].$query["select"].$query["from"].$query["join"].$query["where"].$query["group"];
-
-  if ($query["select"]) {
-    $db = new db_alloc();
-    $db->query($final_query);
-
-    $fields = explode(",", $query["select"]);
-    $TPL["result_row"] = "<tr>";
-    foreach($fields as $field) {
-      $TPL["result_row"].= "<th>".$field."</th>";
-    }
-    $TPL["result_row"].= "</tr>";
-
-    if (!$_POST["generate_file"]) {
-      $start_row_separator = "<tr class='%s'>";
-      $end_row_separator = "</tr>\n";
-      $start_field_separator = "<td>&nbsp;";
-      $end_field_separator = "</td>";
-    } else {
-      unset($TPL["result_row"]);
-      $start_row_separator = "";
-      $end_row_separator = "\n";
-      $start_field_separator = "";
-      if ($_POST["field_separator"] == 'tab') {
-        $end_field_separator = chr(9);
-      } else {
-        $end_field_separator = $_POST["field_separator"];
-      }
-    }
-
-    if ($_POST["field_quotes"] == "single") {
-      $quotes = "'";
-    }
-    if ($_POST["field_quotes"] == "double") {
-      $quotes = "\"";
     }
 
 
-    while ($db->next_record()) {
-      $odd_even = $odd_even == "even" ? "odd" : "even";
-      $TPL["result_row"].= sprintf($start_row_separator,$odd_even);
-      foreach($fields as $k=>$field) {
-        $field = end(explode(".", $field));
-        if (stripos("ModifiedUser", $field) !== FALSE || stripos("personID", $field) !== FALSE) {
-          $person = new person();
-          $person->set_id($db->f($field));
-          $person->select();
+
+    $final_query = $query["start"].$query["select"].$query["from"].$query["join"].$query["where"].$query["group"];
+
+    if ($query["select"]) {
+        $db = new db_alloc();
+        $db->query($final_query);
+
+        $fields = explode(",", $query["select"]);
+        $TPL["result_row"] = "<tr>";
+        foreach ($fields as $field) {
+            $TPL["result_row"].= "<th>".$field."</th>";
+        }
+        $TPL["result_row"].= "</tr>";
+
+        if (!$_POST["generate_file"]) {
+            $start_row_separator = "<tr class='%s'>";
+            $end_row_separator = "</tr>\n";
+            $start_field_separator = "<td>&nbsp;";
+            $end_field_separator = "</td>";
+        } else {
+            unset($TPL["result_row"]);
+            $start_row_separator = "";
+            $end_row_separator = "\n";
+            $start_field_separator = "";
+            if ($_POST["field_separator"] == 'tab') {
+                $end_field_separator = chr(9);
+            } else {
+                $end_field_separator = $_POST["field_separator"];
+            }
+        }
+
+        if ($_POST["field_quotes"] == "single") {
+            $quotes = "'";
+        }
+        if ($_POST["field_quotes"] == "double") {
+            $quotes = "\"";
+        }
+
+
+        while ($db->next_record()) {
+            $odd_even = $odd_even == "even" ? "odd" : "even";
+            $TPL["result_row"].= sprintf($start_row_separator, $odd_even);
+            foreach ($fields as $k => $field) {
+                $field = end(explode(".", $field));
+                if (stripos("ModifiedUser", $field) !== false || stripos("personID", $field) !== false) {
+                    $person = new person();
+                    $person->set_id($db->f($field));
+                    $person->select();
           
-          $result = $person->get_name(array("format"=>"nick"));
-        } else if (stripos("tfID", $field) !== FALSE) {
-          $result = tf::get_name($db->f($field));
-        } else {
-          $result = $db->f($field);
+                    $result = $person->get_name(array("format"=>"nick"));
+                } else if (stripos("tfID", $field) !== false) {
+                    $result = tf::get_name($db->f($field));
+                } else {
+                    $result = $db->f($field);
+                }
+                $TPL["result_row"].= $start_field_separator;
+                $TPL["result_row"].= $quotes.$result.$quotes;
+                if (isset($fields[$k + 1]) || !$_POST["generate_file"]) {
+                    $TPL["result_row"].= $end_field_separator;
+                }
+            }
+            $TPL["result_row"].= $end_row_separator;
+            $counter++;
         }
-        $TPL["result_row"].= $start_field_separator;
-        $TPL["result_row"].= $quotes.$result.$quotes;
-        if (isset($fields[$k + 1]) || !$_POST["generate_file"]) {
-          $TPL["result_row"].= $end_field_separator;
+        $TPL["counter"] = "Number of rows(s): ".$counter;
+
+        if ($_POST["generate_file"]) {
+          // write to file
+            header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
+            header('Content-Type: application/octet-stream');
+            header('Content-Size: '.strlen($TPL["result_row"]));
+            header('Content-Disposition: attachment; filename="csv_'.mktime().'.csv"');
+            echo $TPL["result_row"];
+            exit;
         }
-      }
-      $TPL["result_row"].= $end_row_separator;
-      $counter++;
+    } else {
+        alloc_error("Please select some Fields using the checkboxes.");
     }
-    $TPL["counter"] = "Number of rows(s): ".$counter;
-
-    if ($_POST["generate_file"]) {
-      // write to file
-      header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
-      header('Content-Type: application/octet-stream');
-      header('Content-Size: '.strlen($TPL["result_row"]));
-      header('Content-Disposition: attachment; filename="csv_'.mktime().'.csv"');
-      echo $TPL["result_row"];
-      exit;
-    }
-
-  } else {
-    alloc_error("Please select some Fields using the checkboxes.");
-  }
-
 }
 
 
@@ -337,5 +332,3 @@ if ($_POST["do_step_3"]) {
 $TPL["main_alloc_title"] = "Reports - ".APPLICATION_NAME;
 
 include_template("templates/reportM.tpl");
-
-?>

--- a/sale/lib/init.php
+++ b/sale/lib/init.php
@@ -3,18 +3,18 @@
 /*
  *
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions Pty. Ltd.
- * 
+ *
  * This file is part of allocPSA <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software; you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software
  * Foundation; either version 2 of the License, or (at your option) any later
  * version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with
  * allocPSA; if not, write to the Free Software Foundation, Inc., 51 Franklin
  * St, Fifth Floor, Boston, MA 02110-1301 USA
@@ -22,13 +22,13 @@
  */
 
 
-class sale_module extends module {
-  var $module = "sale";
-  var $db_entities = array("product"
+class sale_module extends module
+{
+    var $module = "sale";
+    var $db_entities = array("product"
                           ,"productCost"
                           ,"productSale"
                           ,"productSaleItem"
                           );
-  var $home_items = array("saleListHomeItemAdmin","saleListHomeItem");
+    var $home_items = array("saleListHomeItemAdmin","saleListHomeItem");
 }
-?>

--- a/sale/lib/product.inc.php
+++ b/sale/lib/product.inc.php
@@ -3,30 +3,31 @@
 /*
  *
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions Pty. Ltd.
- * 
+ *
  * This file is part of allocPSA <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software; you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software
  * Foundation; either version 2 of the License, or (at your option) any later
  * version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with
  * allocPSA; if not, write to the Free Software Foundation, Inc., 51 Franklin
  * St, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 
-class product extends db_entity {
-  public $classname = "product";
-  public $data_table = "product";
-  public $display_field_name = "productName";
-  public $key_field = "productID";
-  public $data_fields = array("productName"
+class product extends db_entity
+{
+    public $classname = "product";
+    public $data_table = "product";
+    public $display_field_name = "productName";
+    public $key_field = "productID";
+    public $data_fields = array("productName"
                              ,"sellPrice" => array("type"=>"money","currency"=>"sellPriceCurrencyTypeID")
                              ,"sellPriceCurrencyTypeID"
                              ,"sellPriceIncTax" => array("empty_to_null"=>false)
@@ -35,88 +36,92 @@ class product extends db_entity {
                              ,"productActive"
                              );
 
-  function delete() {
-    $this->set_value("productActive",0);
-    $this->save();
-  }
-
-  function get_list_filter($filter) {
-    // stub function for one day when you can filter products
-    return $sql;
-  }
-
-  public static function get_list($_FORM=array()) {
-
-    $filter = product::get_list_filter($_FORM);
-
-    $debug = $_FORM["debug"];
-    $debug and print "\n<pre>_FORM: ".print_r($_FORM,1)."</pre>";
-    $debug and print "\n<pre>filter: ".print_r($filter,1)."</pre>";
-
-    if (is_array($filter) && count($filter)) {
-      $f = " WHERE ".implode(" AND ",$filter);
+    function delete()
+    {
+        $this->set_value("productActive", 0);
+        $this->save();
     }
 
-    // Put the inactive ones down the bottom.
-    $f .= " ORDER BY productActive DESC, productName"; 
-
-    $taxName = config::get_config_item("taxName");
-
-    $query = prepare("SELECT * FROM product ".$f);
-    $db = new db_alloc();
-    $db->query($query);
-    while ($row = $db->next_record()) {
-      $product = new product();
-      $product->read_db_record($db);
-      $row["taxName"] = $taxName;
-      $rows[] = $row;
+    function get_list_filter($filter)
+    {
+      // stub function for one day when you can filter products
+        return $sql;
     }
 
-    return $rows;
-  }
+    public static function get_list($_FORM = array())
+    {
 
-  function get_link($row=array()) {
-    global $TPL;
-    if (is_object($this)) {
-      return "<a href=\"".$TPL["url_alloc_product"]."productID=".$this->get_id()."\">".$this->get_value("productName",DST_HTML_DISPLAY)."</a>";
-    } else {
-      return "<a href=\"".$TPL["url_alloc_product"]."productID=".$row["productID"]."\">".page::htmlentities($row["productName"])."</a>";
-    } 
-  }
+        $filter = product::get_list_filter($_FORM);
 
-  function get_list_vars() {
-    // stub function for one day when you can specify list parameters
-    return array();
-  }
+        $debug = $_FORM["debug"];
+        $debug and print "\n<pre>_FORM: ".print_r($_FORM, 1)."</pre>";
+        $debug and print "\n<pre>filter: ".print_r($filter, 1)."</pre>";
 
-  function get_buy_cost($id=false) {
-    $id or $id = $this->get_id();
-    $db = new db_alloc();
-    $q = prepare("SELECT amount, currencyTypeID, tax
+        if (is_array($filter) && count($filter)) {
+            $f = " WHERE ".implode(" AND ", $filter);
+        }
+
+      // Put the inactive ones down the bottom.
+        $f .= " ORDER BY productActive DESC, productName";
+
+        $taxName = config::get_config_item("taxName");
+
+        $query = prepare("SELECT * FROM product ".$f);
+        $db = new db_alloc();
+        $db->query($query);
+        while ($row = $db->next_record()) {
+            $product = new product();
+            $product->read_db_record($db);
+            $row["taxName"] = $taxName;
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    function get_link($row = array())
+    {
+        global $TPL;
+        if (is_object($this)) {
+            return "<a href=\"".$TPL["url_alloc_product"]."productID=".$this->get_id()."\">".$this->get_value("productName", DST_HTML_DISPLAY)."</a>";
+        } else {
+            return "<a href=\"".$TPL["url_alloc_product"]."productID=".$row["productID"]."\">".page::htmlentities($row["productName"])."</a>";
+        }
+    }
+
+    function get_list_vars()
+    {
+      // stub function for one day when you can specify list parameters
+        return array();
+    }
+
+    function get_buy_cost($id = false)
+    {
+        $id or $id = $this->get_id();
+        $db = new db_alloc();
+        $q = prepare("SELECT amount, currencyTypeID, tax
                     FROM productCost
                    WHERE isPercentage != 1
                      AND productID = %d
                      AND productCostActive = true
-                 ",$id);
-    $db->query($q);
-    while ($row = $db->row()) {
-      if ($row["tax"]) {
-        list($amount_minus_tax,$amount_of_tax) = tax($row["amount"]);
-        $row["amount"] = $amount_minus_tax;
-      }
-      $amount += exchangeRate::convert($row["currencyTypeID"],$row["amount"]);
+                 ", $id);
+        $db->query($q);
+        while ($row = $db->row()) {
+            if ($row["tax"]) {
+                list($amount_minus_tax,$amount_of_tax) = tax($row["amount"]);
+                $row["amount"] = $amount_minus_tax;
+            }
+            $amount += exchangeRate::convert($row["currencyTypeID"], $row["amount"]);
+        }
+        return $amount;
     }
-    return $amount;
-  }
 
-  function get_list_html($rows=array(),$_FORM=array()) {
-    global $TPL;
-    $TPL["productListRows"] = $rows;
-    $_FORM["taxName"] = config::get_config_item("taxName");
-    $TPL["_FORM"] = $_FORM;
-    include_template(dirname(__FILE__)."/../templates/productListS.tpl");
-  }
-
+    function get_list_html($rows = array(), $_FORM = array())
+    {
+        global $TPL;
+        $TPL["productListRows"] = $rows;
+        $_FORM["taxName"] = config::get_config_item("taxName");
+        $TPL["_FORM"] = $_FORM;
+        include_template(dirname(__FILE__)."/../templates/productListS.tpl");
+    }
 }
-
-?>

--- a/sale/lib/productCost.inc.php
+++ b/sale/lib/productCost.inc.php
@@ -3,29 +3,30 @@
 /*
  *
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions Pty. Ltd.
- * 
+ *
  * This file is part of allocPSA <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software; you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software
  * Foundation; either version 2 of the License, or (at your option) any later
  * version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with
  * allocPSA; if not, write to the Free Software Foundation, Inc., 51 Franklin
  * St, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 
-class productCost extends db_entity {
-  public $classname = "productCost";
-  public $data_table = "productCost";
-  public $key_field = "productCostID";
-  public $data_fields = array("tfID"
+class productCost extends db_entity
+{
+    public $classname = "productCost";
+    public $data_table = "productCost";
+    public $key_field = "productCostID";
+    public $data_fields = array("tfID"
                              ,"productID"
                              ,"amount" => array("type"=>"money")
                              ,"isPercentage"=> array("empty_to_null"=>false)
@@ -35,24 +36,19 @@ class productCost extends db_entity {
                              ,"productCostActive"
                              );
 
-  function validate() {
-    $this->get_value("productID")    or $err[] = "Missing a Product.";
-    $this->get_value("tfID")         or $err[] = "Missing a Destination TF.";
-    $this->get_value("amount")       or $err[] = "Missing an amount.";
-    return parent::validate($err);
-  }
-
-  function delete() {
-    if ($this->get_id()) {
-      $this->set_value("productCostActive",0);
-      return $this->save();
+    function validate()
+    {
+        $this->get_value("productID")    or $err[] = "Missing a Product.";
+        $this->get_value("tfID")         or $err[] = "Missing a Destination TF.";
+        $this->get_value("amount")       or $err[] = "Missing an amount.";
+        return parent::validate($err);
     }
-  }
 
-
-
-
-
+    function delete()
+    {
+        if ($this->get_id()) {
+            $this->set_value("productCostActive", 0);
+            return $this->save();
+        }
+    }
 }
-
-?>

--- a/sale/lib/productSale.inc.php
+++ b/sale/lib/productSale.inc.php
@@ -3,30 +3,31 @@
   /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
 define("PERM_APPROVE_PRODUCT_TRANSACTIONS", 256);
-class productSale extends db_entity {
-  public $classname = "productSale";
-  public $data_table = "productSale";
-  public $key_field = "productSaleID";
-  public $data_fields = array("clientID"
+class productSale extends db_entity
+{
+    public $classname = "productSale";
+    public $data_table = "productSale";
+    public $key_field = "productSaleID";
+    public $data_fields = array("clientID"
                              ,"projectID"
                              ,"personID"
                              ,"tfID"
@@ -39,354 +40,384 @@ class productSale extends db_entity {
                              ,"extRef"
                              ,"extRefDate"
                              );
-  public $permissions = array(PERM_APPROVE_PRODUCT_TRANSACTIONS => "approve product transactions");
+    public $permissions = array(PERM_APPROVE_PRODUCT_TRANSACTIONS => "approve product transactions");
 
-  function validate() {
-    if ($this->get_value("status") == "admin" || $this->get_value("status") == "finished") {
-      $orig = new $this->classname;
-      $orig->set_id($this->get_id());
-      $orig->select();
-      $orig_status = $orig->get_value("status");
-      if ($orig_status == "allocate" && $this->get_value("status") == "admin") {
+    function validate()
+    {
+        if ($this->get_value("status") == "admin" || $this->get_value("status") == "finished") {
+            $orig = new $this->classname;
+            $orig->set_id($this->get_id());
+            $orig->select();
+            $orig_status = $orig->get_value("status");
+            if ($orig_status == "allocate" && $this->get_value("status") == "admin") {
+            } else if (!$this->have_perm(PERM_APPROVE_PRODUCT_TRANSACTIONS)) {
+                $rtn[] = "Unable to save Product Sale, user does not have correct permissions.";
+            }
+        }
 
-      } else if (!$this->have_perm(PERM_APPROVE_PRODUCT_TRANSACTIONS)) {
-        $rtn[] = "Unable to save Product Sale, user does not have correct permissions.";
-      }
+        if ($this->get_value("extRef")) {
+            $q = prepare(
+                "SELECT productSaleID FROM productSale WHERE productSaleID != %d AND extRef = '%s'",
+                $this->get_id(),
+                $this->get_value("extRef")
+            );
+            $db = new db_alloc();
+            if ($r = $db->qr($q)) {
+                  $rtn[] = "Unable to save Product Sale, this external reference number is used in Sale ".$r["productSaleID"];
+            }
+        }
+
+        return parent::validate($rtn);
     }
-
-    if ($this->get_value("extRef")) {
-      $q = prepare("SELECT productSaleID FROM productSale WHERE productSaleID != %d AND extRef = '%s'"
-                   ,$this->get_id(),$this->get_value("extRef"));
-      $db = new db_alloc();
-      if ($r = $db->qr($q)) {
-        $rtn[] = "Unable to save Product Sale, this external reference number is used in Sale ".$r["productSaleID"];
-      }
-    }
-
-    return parent::validate($rtn);
-  }
  
-  function is_owner() {
-    $current_user = &singleton("current_user");
-    return !$this->get_id()
+    function is_owner()
+    {
+        $current_user = &singleton("current_user");
+        return !$this->get_id()
            || $this->get_value("productSaleCreatedUser") == $current_user->get_id()
            || $this->get_value("personID") == $current_user->get_id();
-  } 
+    }
 
-  function delete() {
-    $db = new db_alloc();
-    $query = prepare("SELECT * 
+    function delete()
+    {
+        $db = new db_alloc();
+        $query = prepare(
+            "SELECT * 
                         FROM productSaleItem 
-                       WHERE productSaleID = %d"
-                    , $this->get_id());
-    $db->query($query);
-    while ($db->next_record()) {
-      $productSaleItem = new productSaleItem();
-      $productSaleItem->read_db_record($db);
-      $productSaleItem->delete();
-    }
-    $this->delete_transactions();
-    return parent::delete();
-  }
-
-  function translate_meta_tfID($tfID="") {
-    // The special -1 and -2 tfID's represent META TF, i.e. calculated at runtime
-    // -1 == META: Project TF
-    if ($tfID == -1) { 
-      if ($this->get_value("projectID")) {
-        $project = new project();
-        $project->set_id($this->get_value("projectID"));
-        $project->select();
-        $tfID = $project->get_value("cost_centre_tfID");
-      }
-      if (!$tfID) {
-        alloc_error("Unable to use META: Project TF. Please ensure the project has a TF set, or adjust the transactions.");
-      }
-
-    // -2 == META: Salesperson TF
-    } else if ($tfID == -2) {
-      if ($this->get_value("personID")) {
-        $person = new person();
-        $person->set_id($this->get_value("personID")); 
-        $person->select();
-        $tfID = $person->get_value("preferred_tfID");
-        if (!$tfID) {
-          alloc_error("Unable to use META: Salesperson TF. Please ensure the Saleperson has a Preferred Payment TF.");
+                       WHERE productSaleID = %d",
+            $this->get_id()
+        );
+        $db->query($query);
+        while ($db->next_record()) {
+            $productSaleItem = new productSaleItem();
+            $productSaleItem->read_db_record($db);
+            $productSaleItem->delete();
         }
-      } else {
-        alloc_error("Unable to use META: Salesperson TF. No product salesperson set.");
-      }
-    } else if ($tfID == -3) {
-      $tfID = $this->get_value("tfID");
-      $tfID or alloc_error("Unable to use META: Sale TF not set.");
+        $this->delete_transactions();
+        return parent::delete();
     }
-    return $tfID;
-  }
+
+    function translate_meta_tfID($tfID = "")
+    {
+      // The special -1 and -2 tfID's represent META TF, i.e. calculated at runtime
+      // -1 == META: Project TF
+        if ($tfID == -1) {
+            if ($this->get_value("projectID")) {
+                $project = new project();
+                $project->set_id($this->get_value("projectID"));
+                $project->select();
+                $tfID = $project->get_value("cost_centre_tfID");
+            }
+            if (!$tfID) {
+                alloc_error("Unable to use META: Project TF. Please ensure the project has a TF set, or adjust the transactions.");
+            }
+
+        // -2 == META: Salesperson TF
+        } else if ($tfID == -2) {
+            if ($this->get_value("personID")) {
+                $person = new person();
+                $person->set_id($this->get_value("personID"));
+                $person->select();
+                $tfID = $person->get_value("preferred_tfID");
+                if (!$tfID) {
+                    alloc_error("Unable to use META: Salesperson TF. Please ensure the Saleperson has a Preferred Payment TF.");
+                }
+            } else {
+                alloc_error("Unable to use META: Salesperson TF. No product salesperson set.");
+            }
+        } else if ($tfID == -3) {
+            $tfID = $this->get_value("tfID");
+            $tfID or alloc_error("Unable to use META: Sale TF not set.");
+        }
+        return $tfID;
+    }
   
-  function get_productSaleItems() {
-    $q = prepare("SELECT * FROM productSaleItem WHERE productSaleID = %d",$this->get_id());
-    $db = new db_alloc();
-    $db->query($q);
-    $rows = array();
-    while($row = $db->row()) {
-      $rows[$row["productSaleItemID"]] = $row;
+    function get_productSaleItems()
+    {
+        $q = prepare("SELECT * FROM productSaleItem WHERE productSaleID = %d", $this->get_id());
+        $db = new db_alloc();
+        $db->query($q);
+        $rows = array();
+        while ($row = $db->row()) {
+            $rows[$row["productSaleItemID"]] = $row;
+        }
+        return $rows;
     }
-    return $rows;
-  }
 
-  function get_amounts() {
+    function get_amounts()
+    {
 
-    $rows = $this->get_productSaleItems();
-    $rows or $rows = array();
-    $rtn = array();
+        $rows = $this->get_productSaleItems();
+        $rows or $rows = array();
+        $rtn = array();
   
-    foreach ($rows as $row) {
-      $productSaleItem = new productSaleItem();
-      $productSaleItem->read_row_record($row);
-      //$rtn["total_spent"] += $productSaleItem->get_amount_spent();
-      //$rtn["total_earnt"] += $productSaleItem->get_amount_earnt();
-      //$rtn["total_other"] += $productSaleItem->get_amount_other();
-      list($sp,$spcur) = array($productSaleItem->get_value("sellPrice"),$productSaleItem->get_value("sellPriceCurrencyTypeID"));
+        foreach ($rows as $row) {
+            $productSaleItem = new productSaleItem();
+            $productSaleItem->read_row_record($row);
+          //$rtn["total_spent"] += $productSaleItem->get_amount_spent();
+          //$rtn["total_earnt"] += $productSaleItem->get_amount_earnt();
+          //$rtn["total_other"] += $productSaleItem->get_amount_other();
+            list($sp,$spcur) = array($productSaleItem->get_value("sellPrice"),$productSaleItem->get_value("sellPriceCurrencyTypeID"));
 
-      $sellPriceCurr[$spcur] += page::money($spcur,$sp,"%m");
-      $total_sellPrice += exchangeRate::convert($spcur,$sp);
-      $total_margin += $productSaleItem->get_amount_margin();
-      $total_unallocated += $productSaleItem->get_amount_unallocated();
-    }    
+            $sellPriceCurr[$spcur] += page::money($spcur, $sp, "%m");
+            $total_sellPrice += exchangeRate::convert($spcur, $sp);
+            $total_margin += $productSaleItem->get_amount_margin();
+            $total_unallocated += $productSaleItem->get_amount_unallocated();
+        }
 
-    unset($sep,$label,$show);
+        unset($sep, $label, $show);
 
-    foreach ((array)$sellPriceCurr as $code => $amount) {
-      $label.= $sep.page::money($code,$amount,"%s%mo %c");
-      $sep = " + ";
-      $code != config::get_config_item("currency") and $show = true;
+        foreach ((array)$sellPriceCurr as $code => $amount) {
+            $label.= $sep.page::money($code, $amount, "%s%mo %c");
+            $sep = " + ";
+            $code != config::get_config_item("currency") and $show = true;
+        }
+        $show && $label and $sellPrice_label = " (".$label.")";
+
+        $total_sellPrice_plus_gst = add_tax($total_sellPrice);
+
+        $rtn["total_sellPrice"] = page::money(config::get_config_item("currency"), $total_sellPrice, "%s%mo %c").$sellPrice_label;
+        $rtn["total_sellPrice_plus_gst"] = page::money(config::get_config_item("currency"), $total_sellPrice_plus_gst, "%s%mo %c").$sellPrice_label;
+        $rtn["total_margin"] = page::money(config::get_config_item("currency"), $total_margin, "%s%mo %c");
+        $rtn["total_unallocated"] = page::money(config::get_config_item("currency"), $total_unallocated, "%s%mo %c");
+        $rtn["total_unallocated_number"] = page::money(config::get_config_item("currency"), $total_unallocated, "%mo");
+
+        $rtn["total_sellPrice_value"] = page::money(config::get_config_item("currency"), $total_sellPrice, "%mo");
+        return $rtn;
     }
-    $show && $label and $sellPrice_label = " (".$label.")";
 
-    $total_sellPrice_plus_gst = add_tax($total_sellPrice);
-
-    $rtn["total_sellPrice"] = page::money(config::get_config_item("currency"),$total_sellPrice,"%s%mo %c").$sellPrice_label;
-    $rtn["total_sellPrice_plus_gst"] = page::money(config::get_config_item("currency"),$total_sellPrice_plus_gst,"%s%mo %c").$sellPrice_label;
-    $rtn["total_margin"] = page::money(config::get_config_item("currency"),$total_margin,"%s%mo %c");
-    $rtn["total_unallocated"] = page::money(config::get_config_item("currency"),$total_unallocated,"%s%mo %c");
-    $rtn["total_unallocated_number"] = page::money(config::get_config_item("currency"),$total_unallocated,"%mo");
-
-    $rtn["total_sellPrice_value"] = page::money(config::get_config_item("currency"),$total_sellPrice,"%mo");
-    return $rtn;
-  }
-
-  function create_transactions() {
-    $rows = $this->get_productSaleItems();
-    $rows or $rows = array();
+    function create_transactions()
+    {
+        $rows = $this->get_productSaleItems();
+        $rows or $rows = array();
   
-    foreach ($rows as $row) {
-      $productSaleItem = new productSaleItem();
-      $productSaleItem->read_row_record($row);
-      $productSaleItem->create_transactions();
+        foreach ($rows as $row) {
+            $productSaleItem = new productSaleItem();
+            $productSaleItem->read_row_record($row);
+            $productSaleItem->create_transactions();
+        }
     }
-  }
 
-  function delete_transactions() {
-    $rows = $this->get_productSaleItems();
-    $rows or $rows = array();
+    function delete_transactions()
+    {
+        $rows = $this->get_productSaleItems();
+        $rows or $rows = array();
   
-    foreach ($rows as $row) {
-      $productSaleItem = new productSaleItem();
-      $productSaleItem->read_row_record($row);
-      $productSaleItem->delete_transactions();
+        foreach ($rows as $row) {
+            $productSaleItem = new productSaleItem();
+            $productSaleItem->read_row_record($row);
+            $productSaleItem->delete_transactions();
+        }
     }
-  }
  
-  function move_forwards() {
-    $current_user = &singleton("current_user");
-    global $TPL;
-    $status = $this->get_value("status");
-    $db = new db_alloc();
+    function move_forwards()
+    {
+        $current_user = &singleton("current_user");
+        global $TPL;
+        $status = $this->get_value("status");
+        $db = new db_alloc();
 
 
-    if ($this->get_value("clientID")) {
-      $c = $this->get_foreign_object("client");
-      $extra = " for ".$c->get_value("clientName");
-      $taskDesc[] = "";
-    }
+        if ($this->get_value("clientID")) {
+            $c = $this->get_foreign_object("client");
+            $extra = " for ".$c->get_value("clientName");
+            $taskDesc[] = "";
+        }
 
-    $taskname1 = "Sale ".$this->get_id().": raise an invoice".$extra;
-    $taskname2 = "Sale ".$this->get_id().": place an order to the supplier";
-    $taskname3 = "Sale ".$this->get_id().": pay the supplier";
-    $taskname4 = "Sale ".$this->get_id().": deliver the goods / action the work";
-    $cyberadmin = 59;
+        $taskname1 = "Sale ".$this->get_id().": raise an invoice".$extra;
+        $taskname2 = "Sale ".$this->get_id().": place an order to the supplier";
+        $taskname3 = "Sale ".$this->get_id().": pay the supplier";
+        $taskname4 = "Sale ".$this->get_id().": deliver the goods / action the work";
+        $cyberadmin = 59;
 
 
-    $taskDesc[] = "Sale items:";
-    $taskDesc[] = "";
-    foreach((array)$this->get_productSaleItems() as $psiID => $psi_row) {
-      $p = new product();
-      $p->set_id($psi_row["productID"]);
-      $taskDesc[] = "  ".page::money($psi_row["sellPriceCurrencyTypeID"],$psi_row["sellPrice"],"%S%mo")
+        $taskDesc[] = "Sale items:";
+        $taskDesc[] = "";
+        foreach ((array)$this->get_productSaleItems() as $psiID => $psi_row) {
+            $p = new product();
+            $p->set_id($psi_row["productID"]);
+            $taskDesc[] = "  ".page::money($psi_row["sellPriceCurrencyTypeID"], $psi_row["sellPrice"], "%S%mo")
                     ." for ".$psi_row["quantity"]
                     ." x ".$p->get_name();
-      $hasItems = true;
-    }
+            $hasItems = true;
+        }
 
-    if (!$hasItems) {
-      return alloc_error("No sale items have been added.");
-    }
+        if (!$hasItems) {
+            return alloc_error("No sale items have been added.");
+        }
 
-    $amounts = $this->get_amounts();
-    $taskDesc[] = "";
-    $taskDesc[] = "Total: ".$amounts["total_sellPrice"];
-    $taskDesc[] = "Total inc ".config::get_config_item("taxName").": ".$amounts["total_sellPrice_plus_gst"];
-    $taskDesc[] = "";
-    $taskDesc[] = "Refer to the sale in alloc for up-to-date information:";
-    $taskDesc[] = config::get_config_item("allocURL")."sale/productSale.php?productSaleID=".$this->get_id();
+        $amounts = $this->get_amounts();
+        $taskDesc[] = "";
+        $taskDesc[] = "Total: ".$amounts["total_sellPrice"];
+        $taskDesc[] = "Total inc ".config::get_config_item("taxName").": ".$amounts["total_sellPrice_plus_gst"];
+        $taskDesc[] = "";
+        $taskDesc[] = "Refer to the sale in alloc for up-to-date information:";
+        $taskDesc[] = config::get_config_item("allocURL")."sale/productSale.php?productSaleID=".$this->get_id();
 
-    $taskDesc = implode("\n",$taskDesc);
+        $taskDesc = implode("\n", $taskDesc);
 
-    if ($status == "edit") {
-      $this->set_value("status", "allocate");
+        if ($status == "edit") {
+            $this->set_value("status", "allocate");
       
-      $items = $this->get_productSaleItems();
-      foreach ($items as $r) {
-        $psi = new productSaleItem();
-        $psi->set_id($r["productSaleItemID"]);
-        $psi->select();
-        if (!$db->qr("SELECT transactionID FROM transaction WHERE productSaleItemID = %d",$psi->get_id())) {
-          $psi->create_transactions();
+            $items = $this->get_productSaleItems();
+            foreach ($items as $r) {
+                $psi = new productSaleItem();
+                $psi->set_id($r["productSaleItemID"]);
+                $psi->select();
+                if (!$db->qr("SELECT transactionID FROM transaction WHERE productSaleItemID = %d", $psi->get_id())) {
+                    $psi->create_transactions();
+                }
+            }
+        } else if ($status == "allocate") {
+            $this->set_value("status", "admin");
+
+          // 1. from salesperson to admin
+            $q = prepare("SELECT * FROM task WHERE projectID = %d AND taskName = '%s'", $cyberadmin, $taskname1);
+            if (config::for_cyber() && !$db->qr($q)) {
+                $task = new task();
+                $task->set_value("projectID", $cyberadmin); // Cyber Admin Project
+                $task->set_value("taskName", $taskname1);
+                $task->set_value("managerID", $this->get_value("personID")); // salesperson
+                $task->set_value("personID", 67); // Cyber Support people (jane)
+                $task->set_value("priority", 3);
+                $task->set_value("taskTypeID", "Task");
+                $task->set_value("taskDescription", $taskDesc);
+                $task->set_value("dateTargetStart", date("Y-m-d"));
+                $task->set_value("dateTargetCompletion", date("Y-m-d", date("U")+(60*60*24*7)));
+                $task->save();
+                $TPL["message_good"][] = "Task created: ".$task->get_id()." ".$task->get_value("taskName");
+
+                $p1 = new person();
+                $p1->set_id($this->get_value("personID"));
+                $p1->select();
+                $p2 = new person();
+                $p2->set_id(67);
+                $p2->select();
+                $recipients[$p1->get_value("emailAddress")] = array("name"=>$p1->get_name(),"addIP"=>true,"internal"=>true);
+                $recipients[$p2->get_value("emailAddress")] = array("name"=>$p2->get_name(),"addIP"=>true,"internal"=>true);
+
+                $comment = $p2->get_name().",\n\n".$taskname1."\n\n".$taskDesc;
+                $commentID = comment::add_comment("task", $task->get_id(), $comment, "task", $task->get_id());
+                $emailRecipients = comment::add_interested_parties($commentID, null, $recipients);
+
+                // Re-email the comment out, including any attachments
+                if (!comment::send_comment($commentID, $emailRecipients)) {
+                    alloc_error("Email failed to send.");
+                } else {
+                    $TPL["message_good"][] = "Emailed task comment to ".$p1->get_value("emailAddress").", ".$p2->get_value("emailAddress").".";
+                }
+            }
+        } else if ($status == "admin" && $this->have_perm(PERM_APPROVE_PRODUCT_TRANSACTIONS)) {
+            $this->set_value("status", "finished");
+            if ($_REQUEST["changeTransactionStatus"]) {
+                $rows = $this->get_productSaleItems();
+                foreach ($rows as $row) {
+                    $ids[] = $row["productSaleItemID"];
+                }
+                if ($ids) {
+                    $q = prepare("UPDATE transaction SET status = '%s' WHERE productSaleItemID in (%s)", $_REQUEST["changeTransactionStatus"], $ids);
+                    $db = new db_alloc();
+                    $db->query($q);
+                }
+            }
+
+          // 2. from admin to salesperson
+            $q = prepare("SELECT * FROM task WHERE projectID = %d AND taskName = '%s'", $cyberadmin, $taskname2);
+            if (config::for_cyber() && !$db->qr($q)) {
+                $task = new task();
+                $task->set_value("projectID", $cyberadmin); // Cyber Admin Project
+                $task->set_value("taskName", $taskname2);
+                $task->set_value("managerID", 67); // Cyber Support people (jane)
+                $task->set_value("personID", $this->get_value("personID")); // salesperson
+                $task->set_value("priority", 3);
+                $task->set_value("taskTypeID", "Task");
+                $task->set_value("taskDescription", $taskDesc);
+                $task->set_value("dateTargetStart", date("Y-m-d"));
+                $task->set_value("dateTargetCompletion", date("Y-m-d", date("U")+(60*60*24*7)));
+                $task->save();
+
+                $q = prepare(
+                    "SELECT * FROM task WHERE projectID = %d AND taskName = '%s'",
+                    $cyberadmin,
+                    $taskname1
+                );
+                $rai_row = $db->qr($q);
+                if ($rai_row) {
+                      $task->add_pending_tasks($rai_row["taskID"]);
+                }
+
+                $order_the_hardware_taskID = $task->get_id();
+                $TPL["message_good"][] = "Task created: ".$task->get_id()." ".$task->get_value("taskName");
+
+                $task->add_notification(
+                    3,
+                    1,
+                    "Task ".$task->get_id()." ".$taskname2,
+                    "Task status moved from pending to open.",
+                    array(array("field"=>"metaPersonID","who"=>-2))
+                );
+            }
+
+          // 3. from salesperson to admin
+            $q = prepare("SELECT * FROM task WHERE projectID = %d AND taskName = '%s'", $cyberadmin, $taskname3);
+            if (config::for_cyber() && !$db->qr($q)) {
+                $task = new task();
+                $task->set_value("projectID", $cyberadmin); // Cyber Admin Project
+                $task->set_value("taskName", $taskname3);
+                $task->set_value("managerID", $this->get_value("personID")); // salesperson
+                $task->set_value("personID", 67); // Cyber Support people (jane)
+                $task->set_value("priority", 3);
+                $task->set_value("taskTypeID", "Task");
+                $task->set_value("taskDescription", $taskDesc);
+                $task->set_value("dateTargetStart", date("Y-m-d"));
+                $task->set_value("dateTargetCompletion", date("Y-m-d", date("U")+(60*60*24*7)));
+                $task->save();
+                $task->add_pending_tasks($order_the_hardware_taskID);
+                $pay_the_supplier_taskID = $task->get_id();
+                $TPL["message_good"][] = "Task created: ".$task->get_id()." ".$task->get_value("taskName");
+
+                $task->add_notification(
+                    3,
+                    1,
+                    "Task ".$task->get_id()." ".$taskname3,
+                    "Task status moved from pending to open.",
+                    array(array("field"=>"metaPersonID","who"=>-2))
+                );
+            }
+
+          // 4. from admin to salesperson
+            $q = prepare("SELECT * FROM task WHERE projectID = %d AND taskName = '%s'", $cyberadmin, $taskname4);
+            if (config::for_cyber() && !$db->qr($q)) {
+                $task = new task();
+                $task->set_value("projectID", $cyberadmin); // Cyber Admin Project
+                $task->set_value("taskName", $taskname4);
+                $task->set_value("managerID", 67); // Cyber Support people
+                $task->set_value("personID", $this->get_value("personID")); // salesperson
+                $task->set_value("priority", 3);
+                $task->set_value("taskTypeID", "Task");
+                $task->set_value("taskDescription", $taskDesc);
+                $task->set_value("dateTargetStart", date("Y-m-d"));
+                $task->set_value("dateTargetCompletion", date("Y-m-d", date("U")+(60*60*24*7)));
+                $task->save();
+                $task->add_pending_tasks($pay_the_supplier_taskID);
+                $TPL["message_good"][] = "Task created: ".$task->get_id()." ".$task->get_value("taskName");
+
+                $task->add_notification(
+                    3,
+                    1,
+                    "Task ".$task->get_id()." ".$taskname4,
+                    "Task status moved from pending to open.",
+                    array(array("field"=>"metaPersonID","who"=>-2))
+                );
+            }
         }
-      }
-
-    } else if ($status == "allocate") {
-      $this->set_value("status", "admin");
-
-      // 1. from salesperson to admin
-      $q = prepare("SELECT * FROM task WHERE projectID = %d AND taskName = '%s'",$cyberadmin,$taskname1);
-      if (config::for_cyber() && !$db->qr($q)) {
-        $task = new task();
-        $task->set_value("projectID",$cyberadmin); // Cyber Admin Project
-        $task->set_value("taskName",$taskname1);
-        $task->set_value("managerID",$this->get_value("personID")); // salesperson
-        $task->set_value("personID",67); // Cyber Support people (jane)
-        $task->set_value("priority",3);
-        $task->set_value("taskTypeID","Task");
-        $task->set_value("taskDescription",$taskDesc);
-        $task->set_value("dateTargetStart",date("Y-m-d"));
-        $task->set_value("dateTargetCompletion",date("Y-m-d",date("U")+(60*60*24*7)));
-        $task->save();
-        $TPL["message_good"][] = "Task created: ".$task->get_id()." ".$task->get_value("taskName");
-
-        $p1 = new person();
-        $p1->set_id($this->get_value("personID"));
-        $p1->select();
-        $p2 = new person();
-        $p2->set_id(67);
-        $p2->select();
-        $recipients[$p1->get_value("emailAddress")] = array("name"=>$p1->get_name(),"addIP"=>true,"internal"=>true);
-        $recipients[$p2->get_value("emailAddress")] = array("name"=>$p2->get_name(),"addIP"=>true,"internal"=>true);
-
-        $comment = $p2->get_name().",\n\n".$taskname1."\n\n".$taskDesc;
-        $commentID = comment::add_comment("task", $task->get_id(), $comment, "task", $task->get_id());
-        $emailRecipients = comment::add_interested_parties($commentID, null, $recipients);
-
-        // Re-email the comment out, including any attachments
-        if (!comment::send_comment($commentID,$emailRecipients)) {
-          alloc_error("Email failed to send.");
-        } else {
-          $TPL["message_good"][] = "Emailed task comment to ".$p1->get_value("emailAddress").", ".$p2->get_value("emailAddress").".";
-        }
-
-      }
-
-    } else if ($status == "admin" && $this->have_perm(PERM_APPROVE_PRODUCT_TRANSACTIONS)) {
-      $this->set_value("status", "finished");
-      if ($_REQUEST["changeTransactionStatus"]) {
-        $rows = $this->get_productSaleItems();
-        foreach ($rows as $row) {
-          $ids[] = $row["productSaleItemID"];
-        }
-        if ($ids) {
-          $q = prepare("UPDATE transaction SET status = '%s' WHERE productSaleItemID in (%s)",$_REQUEST["changeTransactionStatus"],$ids);
-          $db = new db_alloc();
-          $db->query($q);
-        }
-      }
-
-      // 2. from admin to salesperson
-      $q = prepare("SELECT * FROM task WHERE projectID = %d AND taskName = '%s'",$cyberadmin,$taskname2);
-      if (config::for_cyber() && !$db->qr($q)) {
-        $task = new task();
-        $task->set_value("projectID",$cyberadmin); // Cyber Admin Project
-        $task->set_value("taskName",$taskname2);
-        $task->set_value("managerID",67); // Cyber Support people (jane)
-        $task->set_value("personID",$this->get_value("personID")); // salesperson
-        $task->set_value("priority",3);
-        $task->set_value("taskTypeID","Task");
-        $task->set_value("taskDescription",$taskDesc);
-        $task->set_value("dateTargetStart",date("Y-m-d"));
-        $task->set_value("dateTargetCompletion",date("Y-m-d",date("U")+(60*60*24*7)));
-        $task->save();
-
-        $q = prepare("SELECT * FROM task WHERE projectID = %d AND taskName = '%s'"
-                    ,$cyberadmin,$taskname1);
-        $rai_row = $db->qr($q);
-        if ($rai_row) {
-          $task->add_pending_tasks($rai_row["taskID"]);
-        }
-
-        $order_the_hardware_taskID = $task->get_id();
-        $TPL["message_good"][] = "Task created: ".$task->get_id()." ".$task->get_value("taskName");
-
-        $task->add_notification(3,1,"Task ".$task->get_id()." ".$taskname2,"Task status moved from pending to open."
-                               ,array(array("field"=>"metaPersonID","who"=>-2)));
-      }
-
-      // 3. from salesperson to admin
-      $q = prepare("SELECT * FROM task WHERE projectID = %d AND taskName = '%s'",$cyberadmin,$taskname3);
-      if (config::for_cyber() && !$db->qr($q)) {
-        $task = new task();
-        $task->set_value("projectID",$cyberadmin); // Cyber Admin Project
-        $task->set_value("taskName",$taskname3);
-        $task->set_value("managerID",$this->get_value("personID")); // salesperson
-        $task->set_value("personID",67); // Cyber Support people (jane)
-        $task->set_value("priority",3);
-        $task->set_value("taskTypeID","Task");
-        $task->set_value("taskDescription",$taskDesc);
-        $task->set_value("dateTargetStart",date("Y-m-d"));
-        $task->set_value("dateTargetCompletion",date("Y-m-d",date("U")+(60*60*24*7)));
-        $task->save();
-        $task->add_pending_tasks($order_the_hardware_taskID);
-        $pay_the_supplier_taskID = $task->get_id();
-        $TPL["message_good"][] = "Task created: ".$task->get_id()." ".$task->get_value("taskName");
-
-        $task->add_notification(3,1,"Task ".$task->get_id()." ".$taskname3,"Task status moved from pending to open."
-                               ,array(array("field"=>"metaPersonID","who"=>-2)));
-      }
-
-      // 4. from admin to salesperson
-      $q = prepare("SELECT * FROM task WHERE projectID = %d AND taskName = '%s'",$cyberadmin,$taskname4);
-      if (config::for_cyber() && !$db->qr($q)) {
-        $task = new task();
-        $task->set_value("projectID",$cyberadmin); // Cyber Admin Project
-        $task->set_value("taskName",$taskname4);
-        $task->set_value("managerID",67); // Cyber Support people
-        $task->set_value("personID",$this->get_value("personID")); // salesperson
-        $task->set_value("priority",3);
-        $task->set_value("taskTypeID","Task");
-        $task->set_value("taskDescription",$taskDesc);
-        $task->set_value("dateTargetStart",date("Y-m-d"));
-        $task->set_value("dateTargetCompletion",date("Y-m-d",date("U")+(60*60*24*7)));
-        $task->save();
-        $task->add_pending_tasks($pay_the_supplier_taskID);
-        $TPL["message_good"][] = "Task created: ".$task->get_id()." ".$task->get_value("taskName");
-
-        $task->add_notification(3,1,"Task ".$task->get_id()." ".$taskname4,"Task status moved from pending to open."
-                               ,array(array("field"=>"metaPersonID","who"=>-2)));
-      }
     }
-  }
 
-  function get_transactions($productSaleItemID=false) {
-    $rows = array();
-    $query = prepare("SELECT transaction.*
+    function get_transactions($productSaleItemID = false)
+    {
+        $rows = array();
+        $query = prepare(
+            "SELECT transaction.*
                             ,productCost.productCostID  as pc_productCostID
                             ,productCost.amount         as pc_amount
                             ,productCost.isPercentage   as pc_isPercentage
@@ -395,159 +426,165 @@ class productSale extends db_entity {
                    LEFT JOIN productCost on transaction.productCostID = productCost.productCostID
                        WHERE productSaleID = %d
                          AND productSaleItemID = %d
-                    ORDER BY transactionID"
-                    ,$this->get_id()
-                    ,$productSaleItemID);
-    $db = new db_alloc();
-    $db->query($query);
-    while ($row = $db->row()) {
-      if ($row["transactionType"] == "tax") {
-        $row["saleTransactionType"] = "tax";
-      } else if ($row["pc_productCostID"]) {
-        $row["saleTransactionType"] = $row["pc_isPercentage"] ? "aPerc" : "aCost";
-      } else if (!$done && $row["transactionType"] == "sale" && !$row["productCostID"]) {
-        $done = true;
-        $row["saleTransactionType"] = "sellPrice";
-      }
-      $rows[] = $row;
-    }
-    return $rows;
-  }
-
-  function move_backwards() {
-    $current_user = &singleton("current_user");
-
-    if ($this->get_value("status") == "finished" && $current_user->have_role("admin")) {
-      $this->set_value("status", "admin");
-
-    } else if ($this->get_value("status") == "admin" && $current_user->have_role("admin")) {
-      $this->set_value("status", "allocate");
-
-    } else if ($this->get_value("status") == "allocate") {
-      $this->set_value("status", "edit");
-    }
-  }
-
-  public static function get_list_filter($filter=array()) {
-    $current_user = &singleton("current_user");
-
-    // If they want starred, load up the productSaleID filter element
-    if ($filter["starred"]) {
-      foreach ((array)$current_user->prefs["stars"]["productSale"] as $k=>$v) {
-        $filter["productSaleID"][] = $k;
-      }
-      is_array($filter["productSaleID"]) or $filter["productSaleID"][] = -1;
+                    ORDER BY transactionID",
+            $this->get_id(),
+            $productSaleItemID
+        );
+        $db = new db_alloc();
+        $db->query($query);
+        while ($row = $db->row()) {
+            if ($row["transactionType"] == "tax") {
+                $row["saleTransactionType"] = "tax";
+            } else if ($row["pc_productCostID"]) {
+                $row["saleTransactionType"] = $row["pc_isPercentage"] ? "aPerc" : "aCost";
+            } else if (!$done && $row["transactionType"] == "sale" && !$row["productCostID"]) {
+                $done = true;
+                $row["saleTransactionType"] = "sellPrice";
+            }
+            $rows[] = $row;
+        }
+        return $rows;
     }
 
-    // Filter productSaleID
-    $filter["productSaleID"] and $sql[] = sprintf_implode("productSale.productSaleID = %d", $filter["productSaleID"]);
+    function move_backwards()
+    {
+        $current_user = &singleton("current_user");
 
-    // No point continuing if primary key specified, so return
-    if ($filter["productSaleID"] || $filter["starred"]) {
-      return $sql;
+        if ($this->get_value("status") == "finished" && $current_user->have_role("admin")) {
+            $this->set_value("status", "admin");
+        } else if ($this->get_value("status") == "admin" && $current_user->have_role("admin")) {
+            $this->set_value("status", "allocate");
+        } else if ($this->get_value("status") == "allocate") {
+            $this->set_value("status", "edit");
+        }
     }
 
-    $id_fields = array("clientID","projectID","personID","tfID","productSaleCreatedUser","productSaleModifiedUser");
-    foreach($id_fields as $f) {
-      $filter[$f] and $sql[] = sprintf_implode("productSale.".$f." = %d", $filter[$f]);
-    }
+    public static function get_list_filter($filter = array())
+    {
+        $current_user = &singleton("current_user");
 
-    $filter["status"] and $sql[] = sprintf_implode("productSale.status = '%s'", $filter["status"]);
+      // If they want starred, load up the productSaleID filter element
+        if ($filter["starred"]) {
+            foreach ((array)$current_user->prefs["stars"]["productSale"] as $k => $v) {
+                $filter["productSaleID"][] = $k;
+            }
+            is_array($filter["productSaleID"]) or $filter["productSaleID"][] = -1;
+        }
+
+      // Filter productSaleID
+        $filter["productSaleID"] and $sql[] = sprintf_implode("productSale.productSaleID = %d", $filter["productSaleID"]);
+
+      // No point continuing if primary key specified, so return
+        if ($filter["productSaleID"] || $filter["starred"]) {
+            return $sql;
+        }
+
+        $id_fields = array("clientID","projectID","personID","tfID","productSaleCreatedUser","productSaleModifiedUser");
+        foreach ($id_fields as $f) {
+            $filter[$f] and $sql[] = sprintf_implode("productSale.".$f." = %d", $filter[$f]);
+        }
+
+        $filter["status"] and $sql[] = sprintf_implode("productSale.status = '%s'", $filter["status"]);
     
-    return $sql;
-  }
-
-  public static function get_list($_FORM=array()) {
-
-    $filter = productSale::get_list_filter($_FORM);
-
-    $debug = $_FORM["debug"];
-    $debug and print "\n<pre>_FORM: ".print_r($_FORM,1)."</pre>";
-    $debug and print "\n<pre>filter: ".print_r($filter,1)."</pre>";
-
-    if (is_array($filter) && count($filter)) {
-      $f = " WHERE ".implode(" AND ",$filter);
+        return $sql;
     }
 
-    $f.= " ORDER BY IFNULL(productSaleDate,productSaleCreatedTime)";
+    public static function get_list($_FORM = array())
+    {
 
-    $db = new db_alloc();
-    $query = prepare("SELECT productSale.*, project.projectName, client.clientName
+        $filter = productSale::get_list_filter($_FORM);
+
+        $debug = $_FORM["debug"];
+        $debug and print "\n<pre>_FORM: ".print_r($_FORM, 1)."</pre>";
+        $debug and print "\n<pre>filter: ".print_r($filter, 1)."</pre>";
+
+        if (is_array($filter) && count($filter)) {
+            $f = " WHERE ".implode(" AND ", $filter);
+        }
+
+        $f.= " ORDER BY IFNULL(productSaleDate,productSaleCreatedTime)";
+
+        $db = new db_alloc();
+        $query = prepare("SELECT productSale.*, project.projectName, client.clientName
                         FROM productSale 
                    LEFT JOIN client ON productSale.clientID = client.clientID
                    LEFT JOIN project ON productSale.projectID = project.projectID
                     ".$f);
-    $db->query($query);
-    $statii = productSale::get_statii();
-    $people =& get_cached_table("person");
-    $rows = array();
-    while ($row = $db->next_record()) {
-      $productSale = new productSale();
-      $productSale->read_db_record($db);
-      $row["amounts"] = $productSale->get_amounts();
-      $row["statusLabel"] = $statii[$row["status"]];
-      $row["salespersonLabel"] = $people[$row["personID"]]["name"];
-      $row["creatorLabel"] = $people[$row["productSaleCreatedUser"]]["name"];
-      $row["productSaleLink"] = $productSale->get_link();
-      $rows[] = $row;
+        $db->query($query);
+        $statii = productSale::get_statii();
+        $people =& get_cached_table("person");
+        $rows = array();
+        while ($row = $db->next_record()) {
+            $productSale = new productSale();
+            $productSale->read_db_record($db);
+            $row["amounts"] = $productSale->get_amounts();
+            $row["statusLabel"] = $statii[$row["status"]];
+            $row["salespersonLabel"] = $people[$row["personID"]]["name"];
+            $row["creatorLabel"] = $people[$row["productSaleCreatedUser"]]["name"];
+            $row["productSaleLink"] = $productSale->get_link();
+            $rows[] = $row;
+        }
+
+        return (array)$rows;
     }
 
-    return (array)$rows;
-  }
-
-  function get_link($row=array()) {
-    global $TPL;
-    if (is_object($this)) {
-      return "<a href=\"".$TPL["url_alloc_productSale"]."productSaleID=".$this->get_id()."\">".$this->get_id()."</a>";
-    } else {
-      return "<a href=\"".$TPL["url_alloc_productSale"]."productSaleID=".$row["productSaleID"]."\">".$row["productSaleID"]."</a>";
-    }
-  }
-
-  public static function get_statii() {
-    return array("create"=>"Create", "edit"=>"Add Sale Items", "allocate" =>"Allocate", "admin"=>"Administrator", "finished"=>"Completed");
-  }
-
-  function get_all_parties($projectID="") {
-    $db = new db_alloc();
-    $interestedPartyOptions = array();
-
-    if (!$projectID && is_object($this)) {
-      $projectID = $this->get_value("projectID");
+    function get_link($row = array())
+    {
+        global $TPL;
+        if (is_object($this)) {
+            return "<a href=\"".$TPL["url_alloc_productSale"]."productSaleID=".$this->get_id()."\">".$this->get_id()."</a>";
+        } else {
+            return "<a href=\"".$TPL["url_alloc_productSale"]."productSaleID=".$row["productSaleID"]."\">".$row["productSaleID"]."</a>";
+        }
     }
 
-    if ($projectID) {
-      $project = new project($projectID);
-      $interestedPartyOptions = $project->get_all_parties();
+    public static function get_statii()
+    {
+        return array("create"=>"Create", "edit"=>"Add Sale Items", "allocate" =>"Allocate", "admin"=>"Administrator", "finished"=>"Completed");
     }
 
-    $extra_interested_parties = config::get_config_item("defaultInterestedParties") or $extra_interested_parties=array();
-    foreach ($extra_interested_parties as $name => $email) {
-      $interestedPartyOptions[$email] = array("name"=>$name);
+    function get_all_parties($projectID = "")
+    {
+        $db = new db_alloc();
+        $interestedPartyOptions = array();
+
+        if (!$projectID && is_object($this)) {
+            $projectID = $this->get_value("projectID");
+        }
+
+        if ($projectID) {
+            $project = new project($projectID);
+            $interestedPartyOptions = $project->get_all_parties();
+        }
+
+        $extra_interested_parties = config::get_config_item("defaultInterestedParties") or $extra_interested_parties=array();
+        foreach ($extra_interested_parties as $name => $email) {
+            $interestedPartyOptions[$email] = array("name"=>$name);
+        }
+
+        if (is_object($this)) {
+            if ($this->get_value("personID")) {
+                $p = new person();
+                $p->set_id($this->get_value("personID"));
+                $p->select();
+                $p->get_value("emailAddress") and $interestedPartyOptions[$p->get_value("emailAddress")] = array("name"=>$p->get_name(), "selected"=>true, "personID"=>$this->get_value("personID"));
+            }
+            if ($this->get_value("productSaleCreatedUser")) {
+                $p = new person();
+                $p->set_id($this->get_value("productSaleCreatedUser"));
+                $p->select();
+                $p->get_value("emailAddress") and $interestedPartyOptions[$p->get_value("emailAddress")] = array("name"=>$p->get_name(), "selected"=>true, "personID"=>$this->get_value("productSaleCreatedUser"));
+            }
+            $this_id = $this->get_id();
+        }
+      // return an aggregation of the current proj/client parties + the existing interested parties
+        $interestedPartyOptions = interestedParty::get_interested_parties("productSale", $this_id, $interestedPartyOptions);
+        return $interestedPartyOptions;
     }
 
-    if (is_object($this)) {
-      if ($this->get_value("personID")) {
-        $p = new person();
-        $p->set_id($this->get_value("personID"));
-        $p->select();
-        $p->get_value("emailAddress") and $interestedPartyOptions[$p->get_value("emailAddress")] = array("name"=>$p->get_name(), "selected"=>true, "personID"=>$this->get_value("personID"));
-      }
-      if ($this->get_value("productSaleCreatedUser")) {
-        $p = new person();
-        $p->set_id($this->get_value("productSaleCreatedUser"));
-        $p->select();
-        $p->get_value("emailAddress") and $interestedPartyOptions[$p->get_value("emailAddress")] = array("name"=>$p->get_name(), "selected"=>true, "personID"=>$this->get_value("productSaleCreatedUser"));
-      }
-      $this_id = $this->get_id();
-    }
-    // return an aggregation of the current proj/client parties + the existing interested parties
-    $interestedPartyOptions = interestedParty::get_interested_parties("productSale",$this_id,$interestedPartyOptions);
-    return $interestedPartyOptions;
-  }
-
-  function get_list_vars() {
-    return array("return"                         => "[MANDATORY] eg: array | html"
+    function get_list_vars()
+    {
+        return array("return"                         => "[MANDATORY] eg: array | html"
                 ,"productSaleID"                  => "Sale that has this ID"
                 ,"starred"                        => "Sale that have been starred"
                 ,"clientID"                       => "Sales that belong to this Client"
@@ -559,85 +596,83 @@ class productSale extends db_entity {
                 ,"dontSave"                       => "Specify that the filter preferences should not be saved this time"
                 ,"applyFilter"                    => "Saves this filter as the persons preference"
                 );
-  }
-
-  function load_form_data($defaults=array()) {
-    $current_user = &singleton("current_user");
-
-    $page_vars = array_keys(productSale::get_list_vars());
-
-    $_FORM = get_all_form_data($page_vars,$defaults);
-
-    if (!$_FORM["applyFilter"]) {
-      $_FORM = $current_user->prefs[$_FORM["form_name"]];
-      if (!isset($current_user->prefs[$_FORM["form_name"]])) {
-        $_FORM["status"] = "edit";
-        $_FORM["personID"] = $current_user->get_id();
-      }
-
-    } else if ($_FORM["applyFilter"] && is_object($current_user) && !$_FORM["dontSave"]) {
-      $url = $_FORM["url_form_action"];
-      unset($_FORM["url_form_action"]);
-      $current_user->prefs[$_FORM["form_name"]] = $_FORM;
-      $_FORM["url_form_action"] = $url;
     }
 
-    return $_FORM;
-  }
+    function load_form_data($defaults = array())
+    {
+        $current_user = &singleton("current_user");
 
-  function load_productSale_filter($_FORM) {
-    $current_user = &singleton("current_user");
+        $page_vars = array_keys(productSale::get_list_vars());
 
-    // display the list of project name.
-    $db = new db_alloc();
-    if (!$_FORM['showAllProjects']) {
-      $filter = "WHERE projectStatus = 'Current' ";
+        $_FORM = get_all_form_data($page_vars, $defaults);
+
+        if (!$_FORM["applyFilter"]) {
+            $_FORM = $current_user->prefs[$_FORM["form_name"]];
+            if (!isset($current_user->prefs[$_FORM["form_name"]])) {
+                $_FORM["status"] = "edit";
+                $_FORM["personID"] = $current_user->get_id();
+            }
+        } else if ($_FORM["applyFilter"] && is_object($current_user) && !$_FORM["dontSave"]) {
+            $url = $_FORM["url_form_action"];
+            unset($_FORM["url_form_action"]);
+            $current_user->prefs[$_FORM["form_name"]] = $_FORM;
+            $_FORM["url_form_action"] = $url;
+        }
+
+        return $_FORM;
     }
-    $query = prepare("SELECT projectID AS value, projectName AS label FROM project $filter ORDER by projectName");
-    $rtn["show_project_options"] = page::select_options($query, $_FORM["projectID"],70);
 
-    // display the list of user name.
-    if (have_entity_perm("productSale", PERM_READ, $current_user, false)) {
-      $rtn["show_userID_options"] = page::select_options(person::get_username_list(), $_FORM["personID"]);
-      
-    } else {
-      $person = new person();
-      $person->set_id($current_user->get_id());
-      $person->select();
-      $person_array = array($current_user->get_id()=>$person->get_name());
-      $rtn["show_userID_options"] = page::select_options($person_array, $_FORM["personID"]);
-    } 
+    function load_productSale_filter($_FORM)
+    {
+        $current_user = &singleton("current_user");
 
-    // display a list of status
-    $status_array = productSale::get_statii();
-    unset($status_array["create"]);
+      // display the list of project name.
+        $db = new db_alloc();
+        if (!$_FORM['showAllProjects']) {
+            $filter = "WHERE projectStatus = 'Current' ";
+        }
+        $query = prepare("SELECT projectID AS value, projectName AS label FROM project $filter ORDER by projectName");
+        $rtn["show_project_options"] = page::select_options($query, $_FORM["projectID"], 70);
 
-    $rtn["show_status_options"] = page::select_options($status_array,$_FORM["status"]);
+      // display the list of user name.
+        if (have_entity_perm("productSale", PERM_READ, $current_user, false)) {
+            $rtn["show_userID_options"] = page::select_options(person::get_username_list(), $_FORM["personID"]);
+        } else {
+            $person = new person();
+            $person->set_id($current_user->get_id());
+            $person->select();
+            $person_array = array($current_user->get_id()=>$person->get_name());
+            $rtn["show_userID_options"] = page::select_options($person_array, $_FORM["personID"]);
+        }
 
-    // display the date from filter value
-    $rtn["showAllProjects"] = $_FORM["showAllProjects"];
+      // display a list of status
+        $status_array = productSale::get_statii();
+        unset($status_array["create"]);
+
+        $rtn["show_status_options"] = page::select_options($status_array, $_FORM["status"]);
+
+      // display the date from filter value
+        $rtn["showAllProjects"] = $_FORM["showAllProjects"];
 
  
-    $options["clientStatus"] = array("Current");
-    $options["return"] = "dropdown_options";
-    $ops = client::get_list($options);
-    $ops = array_kv($ops,"clientID","clientName");
-    $rtn["clientOptions"] = page::select_options($ops,$_FORM["clientID"]);
+        $options["clientStatus"] = array("Current");
+        $options["return"] = "dropdown_options";
+        $ops = client::get_list($options);
+        $ops = array_kv($ops, "clientID", "clientName");
+        $rtn["clientOptions"] = page::select_options($ops, $_FORM["clientID"]);
 
-    // Get
-    $rtn["FORM"] = "FORM=".urlencode(serialize($_FORM));
+      // Get
+        $rtn["FORM"] = "FORM=".urlencode(serialize($_FORM));
 
-    return $rtn;
-  }
+        return $rtn;
+    }
 
-  function get_list_html($rows=array(),$_FORM=array()) {
-    global $TPL;
-    $TPL["productSaleListRows"] = $rows;
-    $_FORM["taxName"] = config::get_config_item("taxName");
-    $TPL["_FORM"] = $_FORM;
-    include_template(dirname(__FILE__)."/../templates/productSaleListS.tpl");
-  }
+    function get_list_html($rows = array(), $_FORM = array())
+    {
+        global $TPL;
+        $TPL["productSaleListRows"] = $rows;
+        $_FORM["taxName"] = config::get_config_item("taxName");
+        $TPL["_FORM"] = $_FORM;
+        include_template(dirname(__FILE__)."/../templates/productSaleListS.tpl");
+    }
 }
-
-
-?>

--- a/sale/lib/productSaleItem.inc.php
+++ b/sale/lib/productSaleItem.inc.php
@@ -3,29 +3,30 @@
 /*
  *
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions Pty. Ltd.
- * 
+ *
  * This file is part of allocPSA <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software; you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software
  * Foundation; either version 2 of the License, or (at your option) any later
  * version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with
  * allocPSA; if not, write to the Free Software Foundation, Inc., 51 Franklin
  * St, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 
-class productSaleItem extends db_entity {
-  public $classname = "productSaleItem";
-  public $data_table = "productSaleItem";
-  public $key_field = "productSaleItemID";
-  public $data_fields = array("productID"
+class productSaleItem extends db_entity
+{
+    public $classname = "productSaleItem";
+    public $data_table = "productSaleItem";
+    public $key_field = "productSaleItemID";
+    public $data_fields = array("productID"
                              ,"productSaleID"
                              ,"sellPrice" => array("type"=>"money", "currency"=>"sellPriceCurrencyTypeID")
                              ,"sellPriceCurrencyTypeID"
@@ -33,22 +34,26 @@ class productSaleItem extends db_entity {
                              ,"quantity"
                              ,"description"
                              );
-  function is_owner() {
-    $productSale = $this->get_foreign_object("productSale");
-    return $productSale->is_owner();
-  }
+    function is_owner()
+    {
+        $productSale = $this->get_foreign_object("productSale");
+        return $productSale->is_owner();
+    }
 
-  function validate() {
-    $this->get_value("productID")     or $err[] = "Please select a Product.";
-    $this->get_value("productSaleID") or $err[] = "Please select a Product Sale.";
-    $this->get_value("sellPrice")     or $err[] = "Please enter a Sell Price.";
-    $this->get_value("quantity")      or $err[] = "Please enter a Quantity.";
-    return parent::validate($err);
-  }
+    function validate()
+    {
+        $this->get_value("productID")     or $err[] = "Please select a Product.";
+        $this->get_value("productSaleID") or $err[] = "Please select a Product Sale.";
+        $this->get_value("sellPrice")     or $err[] = "Please enter a Sell Price.";
+        $this->get_value("quantity")      or $err[] = "Please enter a Quantity.";
+        return parent::validate($err);
+    }
 
-  function get_amount_spent() {
-    $db = new db_alloc();
-    $q = prepare("SELECT fromTfID, tfID,
+    function get_amount_spent()
+    {
+        $db = new db_alloc();
+        $q = prepare(
+            "SELECT fromTfID, tfID,
                          (amount * pow(10,-currencyType.numberToBasic) * exchangeRate) as amount
                     FROM transaction 
                LEFT JOIN currencyType ON currencyType.currencyTypeID = transaction.currencyTypeID
@@ -56,20 +61,24 @@ class productSaleItem extends db_entity {
                      AND productSaleID = %d
                      AND status != 'rejected'
                      AND productSaleItemID = %d
-                ",config::get_config_item("outTfID")
-                 ,$this->get_value("productSaleID")
-                 ,$this->get_id());
-    $db->query($q);
-    $rows = array();
-    while ($row = $db->row()) {
-      $rows[] = $row;
+                ",
+            config::get_config_item("outTfID"),
+            $this->get_value("productSaleID"),
+            $this->get_id()
+        );
+        $db->query($q);
+        $rows = array();
+        while ($row = $db->row()) {
+            $rows[] = $row;
+        }
+        return transaction::get_actual_amount_used($rows);
     }
-    return transaction::get_actual_amount_used($rows);
-  }
 
-  function get_amount_earnt() {
-    $db = new db_alloc();
-    $q = prepare("SELECT fromTfID, tfID,
+    function get_amount_earnt()
+    {
+        $db = new db_alloc();
+        $q = prepare(
+            "SELECT fromTfID, tfID,
                          (amount * pow(10,-currencyType.numberToBasic) * exchangeRate) as amount
                     FROM transaction 
                LEFT JOIN currencyType ON currencyType.currencyTypeID = transaction.currencyTypeID
@@ -77,21 +86,25 @@ class productSaleItem extends db_entity {
                      AND productSaleID = %d
                      AND status != 'rejected'
                      AND productSaleItemID = %d
-                ",config::get_config_item("inTfID")
-                 ,$this->get_value("productSaleID")
-                 ,$this->get_id());
-    $db->query($q);
-    $rows = array();
-    while ($row = $db->row()) {
-      $rows[] = $row;
-    } 
-    return transaction::get_actual_amount_used($rows);
-  }
+                ",
+            config::get_config_item("inTfID"),
+            $this->get_value("productSaleID"),
+            $this->get_id()
+        );
+        $db->query($q);
+        $rows = array();
+        while ($row = $db->row()) {
+            $rows[] = $row;
+        }
+        return transaction::get_actual_amount_used($rows);
+    }
 
-  function get_amount_other() {
-    $db = new db_alloc();
-    // Don't need to do numberToBasic conversion here
-    $q = prepare("SELECT fromTfID, tfID,
+    function get_amount_other()
+    {
+        $db = new db_alloc();
+      // Don't need to do numberToBasic conversion here
+        $q = prepare(
+            "SELECT fromTfID, tfID,
                          (amount * exchangeRate) as amount
                     FROM transaction 
                LEFT JOIN currencyType ON currencyType.currencyTypeID = transaction.currencyTypeID
@@ -102,175 +115,207 @@ class productSaleItem extends db_entity {
                      AND productSaleItemID = %d
                      AND status != 'rejected'
                      AND productCostID IS NULL
-                ",config::get_config_item("inTfID")
-                 ,config::get_config_item("outTfID")
-                 ,config::get_config_item("taxTfID")
-                 ,$this->get_value("productSaleID")
-                 ,$this->get_id());
-    $db->query($q);
-    $rows = array();
-    while ($row = $db->row()) {
-      $rows[] = $row;
+                ",
+            config::get_config_item("inTfID"),
+            config::get_config_item("outTfID"),
+            config::get_config_item("taxTfID"),
+            $this->get_value("productSaleID"),
+            $this->get_id()
+        );
+        $db->query($q);
+        $rows = array();
+        while ($row = $db->row()) {
+            $rows[] = $row;
+        }
+        return transaction::get_actual_amount_used($rows);
     }
-    return transaction::get_actual_amount_used($rows);
-  }
 
-  function get_amount_margin() {
+    function get_amount_margin()
+    {
 
-    $productSale = $this->get_foreign_object("productSale");
-    $transactions = $productSale->get_transactions($this->get_id());
+        $productSale = $this->get_foreign_object("productSale");
+        $transactions = $productSale->get_transactions($this->get_id());
 
-    // margin = sellPrice - GST - costs
-    foreach ($transactions as $row) {
-      $row["saleTransactionType"] == "sellPrice" and $sellPrice = exchangeRate::convert($row["currencyTypeID"],$row["amount"]);
-      $row["saleTransactionType"] == "tax"       and $tax      += exchangeRate::convert($row["currencyTypeID"],$row["amount"]);
-      $row["saleTransactionType"] == "aCost"     and $costs    += exchangeRate::convert($row["currencyTypeID"],$row["amount"]);
+      // margin = sellPrice - GST - costs
+        foreach ($transactions as $row) {
+            $row["saleTransactionType"] == "sellPrice" and $sellPrice = exchangeRate::convert($row["currencyTypeID"], $row["amount"]);
+            $row["saleTransactionType"] == "tax"       and $tax      += exchangeRate::convert($row["currencyTypeID"], $row["amount"]);
+            $row["saleTransactionType"] == "aCost"     and $costs    += exchangeRate::convert($row["currencyTypeID"], $row["amount"]);
+        }
+        $margin = $sellPrice - $costs;
+        return $margin;
     }
-    $margin = $sellPrice - $costs;
-    return $margin;
-  }
 
-  function get_amount_unallocated() {
-    return $this->get_amount_margin() - $this->get_amount_other();
-  }
+    function get_amount_unallocated()
+    {
+        return $this->get_amount_margin() - $this->get_amount_other();
+    }
 
-  function create_transaction($fromTfID, $tfID, $amount, $description, $currency=false, $productCostID=false,$transactionType='sale') {
-    global $TPL;
-    $currency or $currency = config::get_config_item("currency");
-    $productSale = $this->get_foreign_object("productSale");
-    $date = $productSale->get_value("productSaleDate") or $date = date("Y-m-d");
-    $tfID = $productSale->translate_meta_tfID($tfID);
-    $fromTfID = $productSale->translate_meta_tfID($fromTfID);
-    $transaction = new transaction();
-    $transaction->set_value("productSaleID", $this->get_value("productSaleID"));
-    $transaction->set_value("productSaleItemID", $this->get_id());
-    $transaction->set_value("productCostID",$productCostID);
-    $transaction->set_value("fromTfID", $fromTfID);
-    $transaction->set_value("tfID", $tfID);
-    $transaction->set_value("amount", $amount);
-    $transaction->set_value("currencyTypeID", $currency);
-    $transaction->set_value("status", 'pending');
-    $transaction->set_value("transactionDate", $date);
-    $transaction->set_value("transactionType", $transactionType);
-    $transaction->set_value("product", $description);
-    $transaction->save();
-  }
+    function create_transaction($fromTfID, $tfID, $amount, $description, $currency = false, $productCostID = false, $transactionType = 'sale')
+    {
+        global $TPL;
+        $currency or $currency = config::get_config_item("currency");
+        $productSale = $this->get_foreign_object("productSale");
+        $date = $productSale->get_value("productSaleDate") or $date = date("Y-m-d");
+        $tfID = $productSale->translate_meta_tfID($tfID);
+        $fromTfID = $productSale->translate_meta_tfID($fromTfID);
+        $transaction = new transaction();
+        $transaction->set_value("productSaleID", $this->get_value("productSaleID"));
+        $transaction->set_value("productSaleItemID", $this->get_id());
+        $transaction->set_value("productCostID", $productCostID);
+        $transaction->set_value("fromTfID", $fromTfID);
+        $transaction->set_value("tfID", $tfID);
+        $transaction->set_value("amount", $amount);
+        $transaction->set_value("currencyTypeID", $currency);
+        $transaction->set_value("status", 'pending');
+        $transaction->set_value("transactionDate", $date);
+        $transaction->set_value("transactionType", $transactionType);
+        $transaction->set_value("product", $description);
+        $transaction->save();
+    }
 
-  function create_transactions() {
-    $db = new db_alloc();
-    $db2 = new db_alloc();
+    function create_transactions()
+    {
+        $db = new db_alloc();
+        $db2 = new db_alloc();
 
-    $product = $this->get_foreign_object("product");
-    $productSale = $this->get_foreign_object("productSale");
-    $productName = $product->get_value("productName");
-    $taxName = config::get_config_item("taxName");
-    $taxTfID = config::get_config_item("taxTfID");
-    $mainTfID = $productSale->get_value("tfID");
+        $product = $this->get_foreign_object("product");
+        $productSale = $this->get_foreign_object("productSale");
+        $productName = $product->get_value("productName");
+        $taxName = config::get_config_item("taxName");
+        $taxTfID = config::get_config_item("taxTfID");
+        $mainTfID = $productSale->get_value("tfID");
 
-    // Next transaction represents the amount that someone has paid the
-    // sellPrice amount for the product. This money is transferred from 
-    // the Incoming transactions TF, to the Main Finance TF.
-    $this->create_transaction(config::get_config_item("inTfID"),$mainTfID
-                             ,page::money($this->get_value("sellPriceCurrencyTypeID"),$this->get_value("sellPrice"),"%mo")
-                             ,"Product Sale: ".$productName
-                             ,$this->get_value("sellPriceCurrencyTypeID"));
+      // Next transaction represents the amount that someone has paid the
+      // sellPrice amount for the product. This money is transferred from
+      // the Incoming transactions TF, to the Main Finance TF.
+        $this->create_transaction(
+            config::get_config_item("inTfID"),
+            $mainTfID,
+            page::money($this->get_value("sellPriceCurrencyTypeID"), $this->get_value("sellPrice"), "%mo"),
+            "Product Sale: ".$productName,
+            $this->get_value("sellPriceCurrencyTypeID")
+        );
 
-    // Now loop through all the productCosts for the sale items product.
-    $query = prepare("SELECT productCost.*, product.productName
+      // Now loop through all the productCosts for the sale items product.
+        $query = prepare(
+            "SELECT productCost.*, product.productName
                         FROM productCost 
                    LEFT JOIN product ON product.productID = productCost.productID
                        WHERE productCost.productID = %d 
                          AND isPercentage != 1
                          AND productCostActive = true
-                    ORDER BY productCostID"
-                    , $this->get_value("productID"));
+                    ORDER BY productCostID",
+            $this->get_value("productID")
+        );
 
-    $db2->query($query);
-    while ($productCost_row = $db2->next_record()) {
-      $amount = page::money($productCost_row["currencyTypeID"],$productCost_row["amount"] * $this->get_value("quantity"),"%mo");
-      $this->create_transaction($productCost_row["tfID"],config::get_config_item("outTfID")
-                               ,$amount
-                               ,"Product Cost: ".$productCost_row["productName"]." ".$productCost_row["description"]
-                               ,$productCost_row["currencyTypeID"],$productCost_row["productCostID"]);
-    }
+        $db2->query($query);
+        while ($productCost_row = $db2->next_record()) {
+            $amount = page::money($productCost_row["currencyTypeID"], $productCost_row["amount"] * $this->get_value("quantity"), "%mo");
+            $this->create_transaction(
+                $productCost_row["tfID"],
+                config::get_config_item("outTfID"),
+                $amount,
+                "Product Cost: ".$productCost_row["productName"]." ".$productCost_row["description"],
+                $productCost_row["currencyTypeID"],
+                $productCost_row["productCostID"]
+            );
+        }
 
-    // Need to do the percentages separately because they rely on the $totalUnallocated figure
-    $totalUnallocated = page::money(config::get_config_item("currency"),$this->get_amount_unallocated(),"%mo");
+      // Need to do the percentages separately because they rely on the $totalUnallocated figure
+        $totalUnallocated = page::money(config::get_config_item("currency"), $this->get_amount_unallocated(), "%mo");
 
-    // Now loop through all the productCosts % COMMISSIONS for the sale items product.
-    $query = prepare("SELECT productCost.*, product.productName
+      // Now loop through all the productCosts % COMMISSIONS for the sale items product.
+        $query = prepare(
+            "SELECT productCost.*, product.productName
                         FROM productCost 
                    LEFT JOIN product ON product.productID = productCost.productID
                        WHERE productCost.productID = %d 
                          AND isPercentage = 1
                          AND productCostActive = true
-                    ORDER BY productCostID"
-                    , $this->get_value("productID"));
+                    ORDER BY productCostID",
+            $this->get_value("productID")
+        );
 
-    $db2->query($query);
-    while ($productComm_row = $db2->next_record()) {
-      $amount = page::money($productComm_row["currencyTypeID"],$totalUnallocated * $productComm_row["amount"]/100,"%mo");
-      $this->create_transaction($mainTfID, $productComm_row["tfID"]
-                               ,$amount
-                               ,"Product Commission: ".$productComm_row["productName"]." ".$productComm_row["description"]
-                               ,config::get_config_item("currency"),$productComm_row["productCostID"]);
+        $db2->query($query);
+        while ($productComm_row = $db2->next_record()) {
+            $amount = page::money($productComm_row["currencyTypeID"], $totalUnallocated * $productComm_row["amount"]/100, "%mo");
+            $this->create_transaction(
+                $mainTfID,
+                $productComm_row["tfID"],
+                $amount,
+                "Product Commission: ".$productComm_row["productName"]." ".$productComm_row["description"],
+                config::get_config_item("currency"),
+                $productComm_row["productCostID"]
+            );
+        }
     }
-  }
 
-  function create_transactions_tax() {
-    $db = new db_alloc();
-    $db2 = new db_alloc();
+    function create_transactions_tax()
+    {
+        $db = new db_alloc();
+        $db2 = new db_alloc();
 
-    $product = $this->get_foreign_object("product");
-    $productSale = $this->get_foreign_object("productSale");
-    $productName = $product->get_value("productName");
-    $taxName = config::get_config_item("taxName");
-    $taxTfID = config::get_config_item("taxTfID");
-    $mainTfID = $productSale->get_value("tfID");
-    $taxPercent = config::get_config_item("taxPercent");
+        $product = $this->get_foreign_object("product");
+        $productSale = $this->get_foreign_object("productSale");
+        $productName = $product->get_value("productName");
+        $taxName = config::get_config_item("taxName");
+        $taxTfID = config::get_config_item("taxTfID");
+        $mainTfID = $productSale->get_value("tfID");
+        $taxPercent = config::get_config_item("taxPercent");
 
 
-    // If this price includes tax, then perform a tax transfer
-    $amount_of_tax = $this->get_value("sellPrice") * ($taxPercent/100);
-    $amount_of_tax = exchangeRate::convert($this->get_value("sellPriceCurrencyTypeID"),$amount_of_tax,null,null,"%mo");
-    $this->create_transaction($mainTfID, $taxTfID
-                             ,$amount_of_tax
-                             ,"Product Sale ".$taxName.": ".$productName
-                             ,false, false, 'tax');
+      // If this price includes tax, then perform a tax transfer
+        $amount_of_tax = $this->get_value("sellPrice") * ($taxPercent/100);
+        $amount_of_tax = exchangeRate::convert($this->get_value("sellPriceCurrencyTypeID"), $amount_of_tax, null, null, "%mo");
+        $this->create_transaction(
+            $mainTfID,
+            $taxTfID,
+            $amount_of_tax,
+            "Product Sale ".$taxName.": ".$productName,
+            false,
+            false,
+            'tax'
+        );
 
-    // Now loop through all the productCosts for the sale items product.
-    $query = prepare("SELECT productCost.*, product.productName
+      // Now loop through all the productCosts for the sale items product.
+        $query = prepare(
+            "SELECT productCost.*, product.productName
                         FROM productCost 
                    LEFT JOIN product ON product.productID = productCost.productID
                        WHERE productCost.productID = %d 
                          AND isPercentage != 1
                          AND productCostActive = true
-                    ORDER BY productCostID"
-                    , $this->get_value("productID"));
+                    ORDER BY productCostID",
+            $this->get_value("productID")
+        );
 
-    $db2->query($query);
-    while ($productCost_row = $db2->next_record()) {
-      $amount_of_tax = $productCost_row["amount"] * ($taxPercent/100);
-      $amount_of_tax = exchangeRate::convert($productCost_row["currencyTypeID"],$amount_of_tax,null,null,"%mo");
-      $productCost_row["amount"] = $amount_minus_tax;
-      $this->create_transaction($mainTfID, $taxTfID
-                               ,$amount_of_tax * $this->get_value("quantity")
-                               ,"Product Cost ".$taxName.": ".$productCost_row["productName"]." ".$productCost_row["description"]
-                               ,false,$productCost_row["productCostID"],'tax');
+        $db2->query($query);
+        while ($productCost_row = $db2->next_record()) {
+            $amount_of_tax = $productCost_row["amount"] * ($taxPercent/100);
+            $amount_of_tax = exchangeRate::convert($productCost_row["currencyTypeID"], $amount_of_tax, null, null, "%mo");
+            $productCost_row["amount"] = $amount_minus_tax;
+            $this->create_transaction(
+                $mainTfID,
+                $taxTfID,
+                $amount_of_tax * $this->get_value("quantity"),
+                "Product Cost ".$taxName.": ".$productCost_row["productName"]." ".$productCost_row["description"],
+                false,
+                $productCost_row["productCostID"],
+                'tax'
+            );
+        }
     }
-  }
 
-  function delete_transactions() {
-    $q = prepare("SELECT * FROM transaction WHERE productSaleItemID = %d",$this->get_id());
-    $db = new db_alloc();
-    $db->query($q);
-    while ($db->row()) {
-      $transaction = new transaction();
-      $transaction->read_db_record($db);
-      $transaction->delete();
+    function delete_transactions()
+    {
+        $q = prepare("SELECT * FROM transaction WHERE productSaleItemID = %d", $this->get_id());
+        $db = new db_alloc();
+        $db->query($q);
+        while ($db->row()) {
+            $transaction = new transaction();
+            $transaction->read_db_record($db);
+            $transaction->delete();
+        }
     }
-  }
-
-
 }
-?>

--- a/sale/lib/saleListHomeItem.inc.php
+++ b/sale/lib/saleListHomeItem.inc.php
@@ -3,47 +3,48 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class saleListHomeItem extends home_item {
+class saleListHomeItem extends home_item
+{
 
-  function __construct() {
-    parent::__construct("sale_list", "Sales", "sale", "saleListHomeM.tpl", "narrow", 39);
-  }
-
-  function visible() {
-    $current_user = &singleton("current_user");
-    return isset($current_user) && $current_user->is_employee();
-  }
-  
-  function render() {
-    $current_user = &singleton("current_user");
-    global $TPL;
-    $ops["return"] = "array";
-    $ops["personID"] = $current_user->get_id();
-    $ops["status"] = array("admin","allocate","edit");
-    $rows = productSale::get_list($ops);
-    $TPL["saleListRows"] = $rows;
-    if ($TPL["saleListRows"]) {
-      return true;
+    function __construct()
+    {
+        parent::__construct("sale_list", "Sales", "sale", "saleListHomeM.tpl", "narrow", 39);
     }
-  }
 
+    function visible()
+    {
+        $current_user = &singleton("current_user");
+        return isset($current_user) && $current_user->is_employee();
+    }
+  
+    function render()
+    {
+        $current_user = &singleton("current_user");
+        global $TPL;
+        $ops["return"] = "array";
+        $ops["personID"] = $current_user->get_id();
+        $ops["status"] = array("admin","allocate","edit");
+        $rows = productSale::get_list($ops);
+        $TPL["saleListRows"] = $rows;
+        if ($TPL["saleListRows"]) {
+            return true;
+        }
+    }
 }
-
-?>

--- a/sale/lib/saleListHomeItemAdmin.inc.php
+++ b/sale/lib/saleListHomeItemAdmin.inc.php
@@ -3,45 +3,47 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class saleListHomeItemAdmin extends home_item {
+class saleListHomeItemAdmin extends home_item
+{
 
-  function __construct() {
-    parent::__construct("sale_list_admin", "Sales Pending Admin", "sale", "saleListHomeM.tpl", "narrow", 38);
-  }
-
-  function visible() {
-    $current_user = &singleton("current_user");
-    return isset($current_user) && $current_user->have_role("admin");
-  }
-
-  function render() {
-    $current_user = &singleton("current_user");
-    global $TPL;
-    $ops["return"] = "array";
-    $ops["status"] = array("admin");
-    $rows = productSale::get_list($ops);
-    $TPL["saleListRows"] = $rows;
-    if ($TPL["saleListRows"]) {
-      return true;
+    function __construct()
+    {
+        parent::__construct("sale_list_admin", "Sales Pending Admin", "sale", "saleListHomeM.tpl", "narrow", 38);
     }
-  }
-}
 
-?>
+    function visible()
+    {
+        $current_user = &singleton("current_user");
+        return isset($current_user) && $current_user->have_role("admin");
+    }
+
+    function render()
+    {
+        $current_user = &singleton("current_user");
+        global $TPL;
+        $ops["return"] = "array";
+        $ops["status"] = array("admin");
+        $rows = productSale::get_list($ops);
+        $TPL["saleListRows"] = $rows;
+        if ($TPL["saleListRows"]) {
+            return true;
+        }
+    }
+}

--- a/sale/product.php
+++ b/sale/product.php
@@ -3,88 +3,93 @@
   /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function show_productCost_list($productID, $template, $percent = false) {
-  global $TPL;
-  unset($TPL["display"],$TPL["taxOptions"]); // otherwise the commissions don't display.
-  if ($productID) {
+function show_productCost_list($productID, $template, $percent = false)
+{
+    global $TPL;
+    unset($TPL["display"], $TPL["taxOptions"]); // otherwise the commissions don't display.
+    if ($productID) {
+        $t = new meta("currencyType");
+        $currency_array = $t->get_assoc_array("currencyTypeID", "currencyTypeID");
 
-    $t = new meta("currencyType");
-    $currency_array = $t->get_assoc_array("currencyTypeID","currencyTypeID");
-
-    $db = new db_alloc();
-    $query = prepare("SELECT * 
+        $db = new db_alloc();
+        $query = prepare(
+            "SELECT * 
                         FROM productCost 
                        WHERE productID = %d 
                          AND isPercentage = %d
                          AND productCostActive = true
-                    ORDER BY productCostID"
-                    ,$productID, $percent);
-    $db->query($query);
-    while ($db->next_record()) {
-      $productCost = new productCost();
-      $productCost->read_db_record($db);
-      $productCost->set_tpl_values();
-      $TPL["currencyOptions"] = page::select_options($currency_array,$productCost->get_value("currencyTypeID"));
-      $TPL["taxOptions"] = page::select_options(array(""=>"Exempt",1=>"Included",0=>"Excluded"),$productCost->get_value("tax"));
+                    ORDER BY productCostID",
+            $productID,
+            $percent
+        );
+        $db->query($query);
+        while ($db->next_record()) {
+            $productCost = new productCost();
+            $productCost->read_db_record($db);
+            $productCost->set_tpl_values();
+            $TPL["currencyOptions"] = page::select_options($currency_array, $productCost->get_value("currencyTypeID"));
+            $TPL["taxOptions"] = page::select_options(array(""=>"Exempt",1=>"Included",0=>"Excluded"), $productCost->get_value("tax"));
 
-      // Hardcoded AUD because productCost table uses percent and dollars in same field
-      $percent and $TPL["amount"] = page::money("AUD",$productCost->get_value("amount"),"%mo");
-      include_template($template);
+            // Hardcoded AUD because productCost table uses percent and dollars in same field
+            $percent and $TPL["amount"] = page::money("AUD", $productCost->get_value("amount"), "%mo");
+            include_template($template);
+        }
     }
-  }
 }
 
-function show_productCost_new($template, $percent = false) {
-  global $TPL;
-  $t = new meta("currencyType");
-  $currency_array = $t->get_assoc_array("currencyTypeID","currencyTypeID");
-  $productCost = new productCost();
-  $productCost->set_values(); // wipe clean
-  $TPL["currencyOptions"] = page::select_options($currency_array,$productCost->get_value("currencyTypeID"));
-  $TPL["taxOptions"] = page::select_options(array(""=>"Exempt",1=>"Included",0=>"Excluded"),"1");
-  $TPL["display"] = "display:none";
-  include_template($template);
+function show_productCost_new($template, $percent = false)
+{
+    global $TPL;
+    $t = new meta("currencyType");
+    $currency_array = $t->get_assoc_array("currencyTypeID", "currencyTypeID");
+    $productCost = new productCost();
+    $productCost->set_values(); // wipe clean
+    $TPL["currencyOptions"] = page::select_options($currency_array, $productCost->get_value("currencyTypeID"));
+    $TPL["taxOptions"] = page::select_options(array(""=>"Exempt",1=>"Included",0=>"Excluded"), "1");
+    $TPL["display"] = "display:none";
+    include_template($template);
 }
 
-function tf_list($selected="",$remove_these=array()) {
-  global $tflist;
-  $temp = $tflist;
-  foreach ($remove_these as $dud) {
-    unset($temp[$dud]);
-  }
-  echo page::select_options($temp, $selected);
-  return;
+function tf_list($selected = "", $remove_these = array())
+{
+    global $tflist;
+    $temp = $tflist;
+    foreach ($remove_these as $dud) {
+        unset($temp[$dud]);
+    }
+    echo page::select_options($temp, $selected);
+    return;
 }
 
 $productID = $_GET["productID"] or $productID = $_POST["productID"];
 $product = new product();
 
 if ($productID) {
-  $product->set_id($productID);
-  $product->select();
+    $product->set_id($productID);
+    $product->select();
 }
 
 $tf = new tf();
-$tflist = $tf->get_assoc_array("tfID","tfName");
+$tflist = $tf->get_assoc_array("tfID", "tfName");
 $extra_options = array(
                        //"-3"=>"META: Sale TF"
                       "-1"=>"META: Project TF"
@@ -94,7 +99,7 @@ $extra_options = array(
                       ,config::get_config_item("inTfID") => "Incoming Funds TF (".tf::get_name(config::get_config_item("inTfID")).")"
                       );
 // Prepend the META options to the tflist.
-$tflist = $extra_options + $tflist; 
+$tflist = $extra_options + $tflist;
 
 $TPL["companyTF"] = $tflist[config::get_config_item("mainTfID")];
 $TPL["taxTF"] = $tflist[config::get_config_item("taxTfID")];
@@ -103,46 +108,43 @@ $TPL["taxRate"] = $taxRate;
 
 
 if ($_POST["save"]) {
-  $product->read_globals();
-  $product->set_value("productActive", isset($_POST["productActive"]) ? 1 : 0);
-  !$product->get_value("productName") and alloc_error("Please enter a Product Name.");
-  !$product->get_value("sellPrice")   and alloc_error("Please enter a Sell Price.");
+    $product->read_globals();
+    $product->set_value("productActive", isset($_POST["productActive"]) ? 1 : 0);
+    !$product->get_value("productName") and alloc_error("Please enter a Product Name.");
+    !$product->get_value("sellPrice")   and alloc_error("Please enter a Sell Price.");
 
-  if (!$TPL["message"]) {
-    $product->save();
-    $productID = $product->get_id();
+    if (!$TPL["message"]) {
+        $product->save();
+        $productID = $product->get_id();
 
-    // If they were in the middle of creating a sale, return them back there
-    if ($_REQUEST["productSaleID"]) {
-      alloc_redirect($TPL["url_alloc_productSale"]."productSaleID=".$_REQUEST["productSaleID"]);
-    } else {
-      alloc_redirect($TPL["url_alloc_product"]."productID=".$productID);
+      // If they were in the middle of creating a sale, return them back there
+        if ($_REQUEST["productSaleID"]) {
+            alloc_redirect($TPL["url_alloc_productSale"]."productSaleID=".$_REQUEST["productSaleID"]);
+        } else {
+            alloc_redirect($TPL["url_alloc_product"]."productID=".$productID);
+        }
     }
-  }
-  $product->set_values();
-
+    $product->set_values();
 } else if ($_POST["delete"]) {
-  $product->read_globals();
-  $product->delete();
-  alloc_redirect($TPL["url_alloc_productList"]);
+    $product->read_globals();
+    $product->delete();
+    alloc_redirect($TPL["url_alloc_productList"]);
 }
 
 
 # Fixed costs
 if ($_POST["save_costs"] || $_POST["save_commissions"]) {
+    foreach ((array)$_POST["productCostID"] as $k => $productCostID) {
+      // Delete
+        if (in_array($productCostID, (array)$_POST["deleteCost"])) {
+            $productCost = new productCost();
+            $productCost->set_id($productCostID);
+            $productCost->select();
+            $productCost->delete();
 
-  foreach ((array)$_POST["productCostID"] as $k => $productCostID) {
-    // Delete
-    if (in_array($productCostID, (array)$_POST["deleteCost"])) {
-      $productCost = new productCost();
-      $productCost->set_id($productCostID);
-      $productCost->select();
-      $productCost->delete();
-
-    // Save
-    } else if (imp($_POST["amount"][$k])) {
-
-      $a = array("productCostID"=>$productCostID
+        // Save
+        } else if (imp($_POST["amount"][$k])) {
+            $a = array("productCostID"=>$productCostID
                 ,"productID"=>$productID
                 ,"tfID"=>$_POST["tfID"][$k]
                 ,"amount"=>$_POST["amount"][$k]
@@ -153,34 +155,34 @@ if ($_POST["save_costs"] || $_POST["save_commissions"]) {
                 ,"productCostActive"=>1
                 );
 
-      // Hardcode AUD for commissions because productCost table uses percent and dollars in same field
-      $_POST["save_commissions"] and $a["currencyTypeID"] = "AUD";
+          // Hardcode AUD for commissions because productCost table uses percent and dollars in same field
+            $_POST["save_commissions"] and $a["currencyTypeID"] = "AUD";
 
-      $productCost = new productCost();
-      $productCost->read_array($a);
-      //$errs = $productCost->validate();
-      if (!$errs) {
-        $productCost->save();
-      }
+            $productCost = new productCost();
+            $productCost->read_array($a);
+          //$errs = $productCost->validate();
+            if (!$errs) {
+                $productCost->save();
+            }
+        }
     }
-  }
-  alloc_redirect($TPL["url_alloc_product"]."productID=".$product->get_id());
+    alloc_redirect($TPL["url_alloc_product"]."productID=".$product->get_id());
 }
 
 $m = new meta("currencyType");
-$ops = $m->get_assoc_array("currencyTypeID","currencyTypeID");
-$TPL["sellPriceCurrencyOptions"] = page::select_options($ops,$product->get_value("sellPriceCurrencyTypeID"));
+$ops = $m->get_assoc_array("currencyTypeID", "currencyTypeID");
+$TPL["sellPriceCurrencyOptions"] = page::select_options($ops, $product->get_value("sellPriceCurrencyTypeID"));
 
 $TPL["main_alloc_title"] = "Product: ".$product->get_value("productName")." - ".APPLICATION_NAME;
 $product->set_values();
 $product->set_tpl_values();
 
 if (!$productID) {
-  $TPL["main_alloc_title"] = "New Product - ".APPLICATION_NAME;
-  $TPL["message_help"][] = "To create a new Product enter its Name and Sell Price."; 
+    $TPL["main_alloc_title"] = "New Product - ".APPLICATION_NAME;
+    $TPL["message_help"][] = "To create a new Product enter its Name and Sell Price.";
 } else {
-  $TPL["message_help"][] = "Every sale of this Product can result in customised Cost and Commission transactions being automatically generated. 
-                            <br><br>Click the 'New' link in the Costs/Commissions boxes below to add fixed Costs and percentage Commissions."; 
+    $TPL["message_help"][] = "Every sale of this Product can result in customised Cost and Commission transactions being automatically generated. 
+                            <br><br>Click the 'New' link in the Costs/Commissions boxes below to add fixed Costs and percentage Commissions.";
 }
 
 
@@ -188,5 +190,3 @@ $TPL["taxName"] = config::get_config_item("taxName");
 $TPL["taxPercent"] = config::get_config_item("taxPercent");
 
 include_template("templates/productM.tpl");
-
-?>

--- a/sale/productList.php
+++ b/sale/productList.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -26,5 +26,3 @@ $TPL["productListRows"] = product::get_list($_FORM);
 
 $TPL["main_alloc_title"] = "Product List - ".APPLICATION_NAME;
 include_template("templates/productListM.tpl");
-
-?>

--- a/sale/productSale.php
+++ b/sale/productSale.php
@@ -3,177 +3,194 @@
   /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function tf_list($selected) {
-  global $tfList;
-  echo page::select_options($tfList, $selected);
+function tf_list($selected)
+{
+    global $tfList;
+    echo page::select_options($tfList, $selected);
 }
 
-function tf_name($selected) {
-  global $tfList;
-  echo $tfList[$selected];
+function tf_name($selected)
+{
+    global $tfList;
+    echo $tfList[$selected];
 }
 
-function transaction_status_list($status) {
-  $statusList = transaction::get_transactionStatii();
-  echo page::select_options($statusList, $status);
+function transaction_status_list($status)
+{
+    $statusList = transaction::get_transactionStatii();
+    echo page::select_options($statusList, $status);
 }
 
-function show_productSale_list($productSaleID, $template) {
-  global $TPL;
-  global $productSaleItemsDoExist;
+function show_productSale_list($productSaleID, $template)
+{
+    global $TPL;
+    global $productSaleItemsDoExist;
 
-  $productSale = new productSale();
-  $productSale->set_id($productSaleID);
-  $productSale->select();
-  $productSale->set_tpl_values();
+    $productSale = new productSale();
+    $productSale->set_id($productSaleID);
+    $productSale->select();
+    $productSale->set_tpl_values();
 
-  $taxName = config::get_config_item("taxName");
+    $taxName = config::get_config_item("taxName");
 
-  $product = new product();
-  $ops = $product->get_assoc_array("productID","productName");
-  $query = prepare("SELECT *
+    $product = new product();
+    $ops = $product->get_assoc_array("productID", "productName");
+    $query = prepare(
+        "SELECT *
                       FROM productSaleItem 
-                     WHERE productSaleID = %d"
-                  , $productSaleID);
-  $db = new db_alloc();
-  $db->query($query);
-  while ($db->next_record()) {
-    $productSaleItemsDoExist = true;
-    $productSaleItem = new productSaleItem();
-    $productSaleItem->read_db_record($db);
-    $productSaleItem->set_tpl_values();
+                     WHERE productSaleID = %d",
+        $productSaleID
+    );
+    $db = new db_alloc();
+    $db->query($query);
+    while ($db->next_record()) {
+        $productSaleItemsDoExist = true;
+        $productSaleItem = new productSaleItem();
+        $productSaleItem->read_db_record($db);
+        $productSaleItem->set_tpl_values();
 
-    $TPL["itemSellPrice"] = $productSaleItem->get_value("sellPrice");
-    $TPL["itemMargin"] = $productSaleItem->get_amount_margin();
-    $TPL["itemSpent"] = $productSaleItem->get_amount_spent();
-    $TPL["itemEarnt"] = $productSaleItem->get_amount_earnt();
-    $TPL["itemOther"] = $productSaleItem->get_amount_other();
-    $TPL["itemCosts"] = page::money(config::get_config_item("currency"),product::get_buy_cost($productSaleItem->get_value("productID")) * $productSaleItem->get_value("quantity"),"%s%mo %c");
-    $TPL["itemTotalUnallocated"] = $productSaleItem->get_amount_unallocated();
+        $TPL["itemSellPrice"] = $productSaleItem->get_value("sellPrice");
+        $TPL["itemMargin"] = $productSaleItem->get_amount_margin();
+        $TPL["itemSpent"] = $productSaleItem->get_amount_spent();
+        $TPL["itemEarnt"] = $productSaleItem->get_amount_earnt();
+        $TPL["itemOther"] = $productSaleItem->get_amount_other();
+        $TPL["itemCosts"] = page::money(config::get_config_item("currency"), product::get_buy_cost($productSaleItem->get_value("productID")) * $productSaleItem->get_value("quantity"), "%s%mo %c");
+        $TPL["itemTotalUnallocated"] = $productSaleItem->get_amount_unallocated();
 
-    $TPL["productList_dropdown"] = page::select_options($ops, $productSaleItem->get_value("productID"));
-    $TPL["productLink"] = "<a href=\"".$TPL["url_alloc_product"]."productID=".$productSaleItem->get_value("productID")."\">".page::htmlentities($ops[$productSaleItem->get_value("productID")])."</a>";
-    $TPL["transactions"] = $productSale->get_transactions($productSaleItem->get_id());
+        $TPL["productList_dropdown"] = page::select_options($ops, $productSaleItem->get_value("productID"));
+        $TPL["productLink"] = "<a href=\"".$TPL["url_alloc_product"]."productID=".$productSaleItem->get_value("productID")."\">".page::htmlentities($ops[$productSaleItem->get_value("productID")])."</a>";
+        $TPL["transactions"] = $productSale->get_transactions($productSaleItem->get_id());
  
-    if ($taxName) {
-      $TPL["sellPriceTax_check"] = sprintf(" <input type='checkbox' name='sellPriceIncTax[]' value='%d'%s> inc %s"
-                                      ,$productSaleItem->get_id(),$productSaleItem->get_value("sellPriceIncTax") ? ' checked':'',$taxName);
-      $TPL["sellPriceTax_label"] = $productSaleItem->get_value("sellPriceIncTax") ? " inc ".$taxName : " ex ".$taxName;
+        if ($taxName) {
+            $TPL["sellPriceTax_check"] = sprintf(
+                " <input type='checkbox' name='sellPriceIncTax[]' value='%d'%s> inc %s",
+                $productSaleItem->get_id(),
+                $productSaleItem->get_value("sellPriceIncTax") ? ' checked':'',
+                $taxName
+            );
+            $TPL["sellPriceTax_label"] = $productSaleItem->get_value("sellPriceIncTax") ? " inc ".$taxName : " ex ".$taxName;
+        }
+        include_template($template);
     }
-   include_template($template);
-  }
 }
 
-function show_productSale_new($template) {
-  global $TPL;
-  global $productSaleItemsDoExist;
-  global $productSaleID;
-  $taxName = config::get_config_item("taxName");
-  $productSaleItem = new productSaleItem();
-  $productSaleItem->set_values(); // wipe clean
-  $product = new product();
-  $ops = $product->get_assoc_array("productID","productName");
-  $TPL["productList_dropdown"] = page::select_options($ops, $productSaleItem->get_value("productID"));
-  $productSaleItemsDoExist and $TPL["display"] = "display:none";
-  if ($taxName) {
-    $TPL["sellPriceTax_check"] = sprintf(" <input type='checkbox' name='sellPriceIncTax[]' value='1'%s> inc %s"
-                                      ,$productSaleItem->get_value("sellPriceIncTax") ? ' checked':'',$taxName);
-  }
-  $TPL["psid"] = $productSaleID; // poorly named template variable to prevent clobbering
-  include_template($template);
+function show_productSale_new($template)
+{
+    global $TPL;
+    global $productSaleItemsDoExist;
+    global $productSaleID;
+    $taxName = config::get_config_item("taxName");
+    $productSaleItem = new productSaleItem();
+    $productSaleItem->set_values(); // wipe clean
+    $product = new product();
+    $ops = $product->get_assoc_array("productID", "productName");
+    $TPL["productList_dropdown"] = page::select_options($ops, $productSaleItem->get_value("productID"));
+    $productSaleItemsDoExist and $TPL["display"] = "display:none";
+    if ($taxName) {
+        $TPL["sellPriceTax_check"] = sprintf(
+            " <input type='checkbox' name='sellPriceIncTax[]' value='1'%s> inc %s",
+            $productSaleItem->get_value("sellPriceIncTax") ? ' checked':'',
+            $taxName
+        );
+    }
+    $TPL["psid"] = $productSaleID; // poorly named template variable to prevent clobbering
+    include_template($template);
 }
 
-function show_transaction_list($transactions=array(), $template) {
-  global $TPL;
-  global $tflist;
-  foreach ($transactions as $row) {
+function show_transaction_list($transactions = array(), $template)
+{
+    global $TPL;
+    global $tflist;
+    foreach ($transactions as $row) {
+        $transaction = new transaction();
+        $transaction->read_array($row);
+        $transaction->set_values();
+        $TPL["display"] = "";
+
+
+        $m = new meta("currencyType");
+        $currencyOptions = $m->get_assoc_array("currencyTypeID", "currencyTypeID");
+        $TPL["currencyOptions"] = page::select_options($currencyOptions, $transaction->get_value("currencyTypeID"));
+        $TPL["tfList_dropdown"] = page::select_options($tflist, $transaction->get_value("tfID"));
+        $TPL["fromTfList_dropdown"] = page::select_options($tflist, $transaction->get_value("fromTfID"));
+        $TPL["tfID_label"] = $tflist[$transaction->get_value("tfID")];
+        $TPL["fromTfID_label"] = $tflist[$transaction->get_value("fromTfID")];
+        if (CAN_APPROVE_TRANSACTIONS && $TPL["productSale_status"] == "admin") {
+            $TPL["status"] = "<select name='status[]' class='txStatus'>";
+            $TPL["status"].= page::select_options(transaction::get_transactionStatii(), $transaction->get_value("status"))."</select>";
+        }
+
+        $TPL["pc_productCostID"] = $row["pc_productCostID"];
+        $TPL["pc_amount"]        = $row["pc_amount"];
+        $TPL["pc_isPercentage"]  = $row["pc_isPercentage"];
+        $TPL["pc_currency"]      = $row["pc_currency"];
+        $TPL["amountClass"]      = $row["saleTransactionType"];
+        include_template($template);
+    }
+}
+
+function show_transaction_new($template)
+{
+    global $TPL;
+    global $tflist;
     $transaction = new transaction();
-    $transaction->read_array($row);
-    $transaction->set_values();
-    $TPL["display"] = "";
-
-
+    $transaction->set_values(); // wipe clean
+    $TPL["display"] = "display:none";
     $m = new meta("currencyType");
     $currencyOptions = $m->get_assoc_array("currencyTypeID", "currencyTypeID");
-    $TPL["currencyOptions"] = page::select_options($currencyOptions, $transaction->get_value("currencyTypeID"));
-    $TPL["tfList_dropdown"] = page::select_options($tflist, $transaction->get_value("tfID"));
-    $TPL["fromTfList_dropdown"] = page::select_options($tflist, $transaction->get_value("fromTfID"));
-    $TPL["tfID_label"] = $tflist[$transaction->get_value("tfID")];
-    $TPL["fromTfID_label"] = $tflist[$transaction->get_value("fromTfID")];
+    $TPL["currencyOptions"] = page::select_options($currencyOptions);
+    $TPL["tfList_dropdown"] = page::select_options($tflist);
+    $TPL["fromTfList_dropdown"] = page::select_options($tflist);
     if (CAN_APPROVE_TRANSACTIONS && $TPL["productSale_status"] == "admin") {
-      $TPL["status"] = "<select name='status[]' class='txStatus'>";
-      $TPL["status"].= page::select_options(transaction::get_transactionStatii(),$transaction->get_value("status"))."</select>";
+        $TPL["status"] = "<select name='status[]' class='txStatus'>";
+        $TPL["status"].= page::select_options(transaction::get_transactionStatii())."</select>";
     }
-
-    $TPL["pc_productCostID"] = $row["pc_productCostID"];
-    $TPL["pc_amount"]        = $row["pc_amount"];   
-    $TPL["pc_isPercentage"]  = $row["pc_isPercentage"];
-    $TPL["pc_currency"]      = $row["pc_currency"];
-    $TPL["amountClass"]      = $row["saleTransactionType"];
+    $TPL["pc_productCostID"] = '';
+    $TPL["pc_amount"]        = '';
+    $TPL["pc_isPercentage"]  = '';
+    $TPL["pc_currency"]      = '';
+    $TPL["amountClass"]      = '';
     include_template($template);
-  }
 }
 
-function show_transaction_new($template) {
-  global $TPL;
-  global $tflist;
-  $transaction = new transaction();
-  $transaction->set_values(); // wipe clean
-  $TPL["display"] = "display:none";
-  $m = new meta("currencyType");
-  $currencyOptions = $m->get_assoc_array("currencyTypeID", "currencyTypeID");
-  $TPL["currencyOptions"] = page::select_options($currencyOptions);
-  $TPL["tfList_dropdown"] = page::select_options($tflist);
-  $TPL["fromTfList_dropdown"] = page::select_options($tflist);
-  if (CAN_APPROVE_TRANSACTIONS && $TPL["productSale_status"] == "admin") {
-    $TPL["status"] = "<select name='status[]' class='txStatus'>";
-    $TPL["status"].= page::select_options(transaction::get_transactionStatii())."</select>";
-  }
-  $TPL["pc_productCostID"] = '';
-  $TPL["pc_amount"]        = '';
-  $TPL["pc_isPercentage"]  = '';
-  $TPL["pc_currency"]      = '';
-  $TPL["amountClass"]      = '';
-  include_template($template);
-}
-
-  function show_comments() {
+function show_comments()
+{
     global $productSaleID;
     global $TPL;
     global $productSale;
     if ($productSaleID) {
-      $TPL["commentsR"] = comment::util_get_comments("productSale",$productSaleID);
-      $TPL["class_new_comment"] = "hidden";
-      $TPL["entity"] = "productSale";
-      $TPL["entityID"] = $productSale->get_id();
-      $project = $productSale->get_foreign_object('project');
-      $TPL["clientID"] = $project->get_value("clientID");
-      $TPL["allParties"] = $productSale->get_all_parties($productSale->get_value("projectID")) or $TPL["allParties"] = array();
-      $commentTemplate = new commentTemplate();
-      $ops = $commentTemplate->get_assoc_array("commentTemplateID","commentTemplateName","",array("commentTemplateType"=>"productSale"));
-      $TPL["commentTemplateOptions"] = "<option value=\"\">Comment Templates</option>".page::select_options($ops);
-      include_template("../comment/templates/commentM.tpl");
+        $TPL["commentsR"] = comment::util_get_comments("productSale", $productSaleID);
+        $TPL["class_new_comment"] = "hidden";
+        $TPL["entity"] = "productSale";
+        $TPL["entityID"] = $productSale->get_id();
+        $project = $productSale->get_foreign_object('project');
+        $TPL["clientID"] = $project->get_value("clientID");
+        $TPL["allParties"] = $productSale->get_all_parties($productSale->get_value("projectID")) or $TPL["allParties"] = array();
+        $commentTemplate = new commentTemplate();
+        $ops = $commentTemplate->get_assoc_array("commentTemplateID", "commentTemplateName", "", array("commentTemplateType"=>"productSale"));
+        $TPL["commentTemplateOptions"] = "<option value=\"\">Comment Templates</option>".page::select_options($ops);
+        include_template("../comment/templates/commentM.tpl");
     }
-  }
+}
 
 
 $productID = $_GET["productID"] or $productID = $_POST["productID"];
@@ -185,105 +202,96 @@ $TPL["projectID"] = $projectID;
 $productSale = new productSale();
 $productSale->read_globals();
 if ($productSaleID) {
-  $productSale->set_id($productSaleID);
-  $productSale->select();
-  $productSale->set_values();
-  $clientID = $productSale->get_value("clientID");
-  $projectID = $productSale->get_value("projectID");
-  $productSaleID = $productSale->get_id();
-
+    $productSale->set_id($productSaleID);
+    $productSale->select();
+    $productSale->set_values();
+    $clientID = $productSale->get_value("clientID");
+    $projectID = $productSale->get_value("projectID");
+    $productSaleID = $productSale->get_id();
 } else {
-  $TPL["status"] = "create";
+    $TPL["status"] = "create";
 }
 
 
 $db = new db_alloc();
 $tf = new tf();
-$tflist = $tf->get_assoc_array("tfID","tfName");
+$tflist = $tf->get_assoc_array("tfID", "tfName");
 
 
 if ($_POST["move_forwards"]) {
-  $productSale->move_forwards();
-  $_POST["save"] = true;
-
+    $productSale->move_forwards();
+    $_POST["save"] = true;
 } else if ($_POST["move_backwards"]) {
-  $productSale->move_backwards();
-  $_POST["save"] = true;
+    $productSale->move_backwards();
+    $_POST["save"] = true;
 }
 
-// Code to respond to form buttons 
+// Code to respond to form buttons
 if (!$TPL["message"] && $_POST["save"]) {
-  !$productSaleID && $productSale->set_value("status", "edit");
-  $productSale->read_globals();
-  $productSale->save(); 
-  $productSaleID = $productSale->get_id();
-  alloc_redirect($TPL["url_alloc_productSale"]."productSaleID=".$productSaleID);
-
+    !$productSaleID && $productSale->set_value("status", "edit");
+    $productSale->read_globals();
+    $productSale->save();
+    $productSaleID = $productSale->get_id();
+    alloc_redirect($TPL["url_alloc_productSale"]."productSaleID=".$productSaleID);
 } else if ($_POST["save_items"] && $productSaleID) {
-  
-  is_array($_POST["deleteProductSaleItem"]) or $_POST["deleteProductSaleItem"] = array();
+    is_array($_POST["deleteProductSaleItem"]) or $_POST["deleteProductSaleItem"] = array();
 
-  if (is_array($_POST["productSaleItemID"]) && count($_POST["productSaleItemID"])) {
-    is_array($_POST["sellPriceIncTax"]) or $_POST["sellPriceIncTax"] = array();
+    if (is_array($_POST["productSaleItemID"]) && count($_POST["productSaleItemID"])) {
+        is_array($_POST["sellPriceIncTax"]) or $_POST["sellPriceIncTax"] = array();
 
-    foreach ($_POST["productSaleItemID"] as $k => $productSaleItemID) {
-      // Delete
-      if (in_array($productSaleItemID, $_POST["deleteProductSaleItem"])) {
-        $productSaleItem = new productSaleItem();
-        $productSaleItem->set_id($productSaleItemID);
-        $productSaleItem->delete();
+        foreach ($_POST["productSaleItemID"] as $k => $productSaleItemID) {
+          // Delete
+            if (in_array($productSaleItemID, $_POST["deleteProductSaleItem"])) {
+                $productSaleItem = new productSaleItem();
+                $productSaleItem->set_id($productSaleItemID);
+                $productSaleItem->delete();
 
-      // Save
-      } else {
-        $a = array("productID"=>$_POST["productID"][$k]
+              // Save
+            } else {
+                $a = array("productID"=>$_POST["productID"][$k]
                   ,"sellPrice"=>$_POST["sellPrice"][$k]
                   ,"sellPriceCurrencyTypeID"=>$_POST["sellPriceCurrencyTypeID"][$k]
                   ,"quantity"=>$_POST["quantity"][$k]
                   ,"description"=>$_POST["description"][$k]
                   ,"productSaleID"=>$productSaleID);
 
-        if ($productSaleItemID) {
-          $a["sellPriceIncTax"] = sprintf("%d",in_array($productSaleItemID, $_POST["sellPriceIncTax"]));
-        } else {
-          $a["sellPriceIncTax"] = sprintf("%d",isset($_POST["sellPriceIncTax"][$k]));
-        }
+                if ($productSaleItemID) {
+                    $a["sellPriceIncTax"] = sprintf("%d", in_array($productSaleItemID, $_POST["sellPriceIncTax"]));
+                } else {
+                    $a["sellPriceIncTax"] = sprintf("%d", isset($_POST["sellPriceIncTax"][$k]));
+                }
 
-        if(substr($productSaleItemID, 0, 3) == "new") {
-          $productSaleItemID = "";
-        }
-        $a["productSaleItemID"] = $productSaleItemID;
+                if (substr($productSaleItemID, 0, 3) == "new") {
+                    $productSaleItemID = "";
+                }
+                $a["productSaleItemID"] = $productSaleItemID;
 
-        $productSaleItem = new productSaleItem();
-        $productSaleItem->read_array($a);
-        if ($productSaleItem->validate() == "") {
-          $productSaleItem->save();
+                $productSaleItem = new productSaleItem();
+                $productSaleItem->read_array($a);
+                if ($productSaleItem->validate() == "") {
+                    $productSaleItem->save();
+                }
+            }
         }
-      }
     }
-  } 
-  alloc_redirect($TPL["url_alloc_productSale"]."productSaleID=".$productSaleID);
-
-
+    alloc_redirect($TPL["url_alloc_productSale"]."productSaleID=".$productSaleID);
 } else if ($_POST["save_transactions"]) {
-   
-  is_array($_POST["deleteTransaction"]) or $_POST["deleteTransaction"] = array();
+    is_array($_POST["deleteTransaction"]) or $_POST["deleteTransaction"] = array();
 
-  if (is_array($_POST["transactionID"]) && count($_POST["transactionID"])) {
+    if (is_array($_POST["transactionID"]) && count($_POST["transactionID"])) {
+        foreach ($_POST["transactionID"] as $k => $transactionID) {
+          // Delete
+            if (in_array($transactionID, $_POST["deleteTransaction"])) {
+                $transaction = new transaction();
+                $transaction->set_id($transactionID);
+                $transaction->select();
+                $transaction->delete();
 
-    foreach ($_POST["transactionID"] as $k => $transactionID) {
-      // Delete
-      if (in_array($transactionID, $_POST["deleteTransaction"])) {
-        $transaction = new transaction();
-        $transaction->set_id($transactionID);
-        $transaction->select();
-        $transaction->delete();
+              // Save
+            } else if (imp($_POST["amount"][$k])) {
+                $type = $_POST["transactionType"][$k] or $type = 'sale';
 
-      // Save
-      } else if (imp($_POST["amount"][$k])) {
-
-        $type = $_POST["transactionType"][$k] or $type = 'sale';
-
-        $a = array("amount"            => $_POST["amount"][$k]
+                $a = array("amount"            => $_POST["amount"][$k]
                   ,"tfID"              => $_POST["tfID"][$k]
                   ,"fromTfID"          => $_POST["fromTfID"][$k]
                   ,"product"           => $_POST["product"][$k]
@@ -297,49 +305,44 @@ if (!$TPL["message"] && $_POST["save"]) {
                   ,"currencyTypeID"    => $_POST["currencyTypeID"][$k]
                   ,"transactionID"     => $transactionID);
   
-        if (CAN_APPROVE_TRANSACTIONS && $_POST["status"][$k]) {
-          $a["status"] = $_POST["status"][$k];
-        }
+                if (CAN_APPROVE_TRANSACTIONS && $_POST["status"][$k]) {
+                    $a["status"] = $_POST["status"][$k];
+                }
 
-        $transaction = new transaction();
-        $transaction->read_array($a);
-        if ($transaction->validate() == "") {
-          $transaction->save();
+                $transaction = new transaction();
+                $transaction->read_array($a);
+                if ($transaction->validate() == "") {
+                    $transaction->save();
+                }
+            }
         }
-      }
     }
-  } 
-  alloc_redirect($TPL["url_alloc_productSale"]."productSaleID=".$productSaleID);
-
-
+    alloc_redirect($TPL["url_alloc_productSale"]."productSaleID=".$productSaleID);
 } else if ($_POST["create_default_transactions"] && $_POST["productSaleItemID"]) {
-  $productSaleItem = new productSaleItem();
-  $productSaleItem->set_id($_POST["productSaleItemID"]);
-  $productSaleItem->select();
-  $productSaleItem->create_transactions();
-
+    $productSaleItem = new productSaleItem();
+    $productSaleItem->set_id($_POST["productSaleItemID"]);
+    $productSaleItem->select();
+    $productSaleItem->create_transactions();
 } else if ($_POST["add_tax"] && $_POST["productSaleItemID"]) {
-  $productSaleItem = new productSaleItem();
-  $productSaleItem->set_id($_POST["productSaleItemID"]);
-  $productSaleItem->select();
-  $productSaleItem->create_transactions_tax();
-
+    $productSaleItem = new productSaleItem();
+    $productSaleItem->set_id($_POST["productSaleItemID"]);
+    $productSaleItem->select();
+    $productSaleItem->create_transactions_tax();
 } else if ($_POST["delete_transactions"] && $_POST["productSaleItemID"]) {
-  $productSaleItem = new productSaleItem();
-  $productSaleItem->set_id($_POST["productSaleItemID"]);
-  $productSaleItem->select();
-  $productSaleItem->delete_transactions();
-
+    $productSaleItem = new productSaleItem();
+    $productSaleItem->set_id($_POST["productSaleItemID"]);
+    $productSaleItem->select();
+    $productSaleItem->delete_transactions();
 } else if ($_POST["delete_productSale"]) {
-  $productSale->delete();
-  alloc_redirect($TPL["url_alloc_productSaleList"]);
+    $productSale->delete();
+    alloc_redirect($TPL["url_alloc_productSaleList"]);
 }
 
 
 if ($productSale->have_perm(PERM_APPROVE_PRODUCT_TRANSACTIONS)) {
-  define("CAN_APPROVE_TRANSACTIONS",1);
+    define("CAN_APPROVE_TRANSACTIONS", 1);
 } else {
-  define("CAN_APPROVE_TRANSACTIONS",0);
+    define("CAN_APPROVE_TRANSACTIONS", 0);
 }
 
 $statuses = productSale::get_statii();
@@ -352,7 +355,7 @@ $showCosts = $_POST["showCosts"] or $_showCosts = $_GET["showCosts"];
 $productSale->set_values();
 
 
-list($client_select, $client_link, $project_select, $project_link) 
+list($client_select, $client_link, $project_select, $project_link)
   = client::get_client_and_project_dropdowns_and_links($clientID, $projectID);
 
 $TPL["show_client_options"] = $client_link;
@@ -360,13 +363,13 @@ $TPL["show_project_options"] = $project_link;
 
 $tf = new tf();
 if ($productSale->get_value("tfID")) {
-  $tf->set_id($productSale->get_value("tfID"));
-  $tf->select();
-  $TPL["show_tf_options"] = $tf->get_link();
-  $tf_sel = $productSale->get_value("tfID");
+    $tf->set_id($productSale->get_value("tfID"));
+    $tf->select();
+    $TPL["show_tf_options"] = $tf->get_link();
+    $tf_sel = $productSale->get_value("tfID");
 }
 $tf_sel or $tf_sel = config::get_config_item("mainTfID");
-$tf_select = "<select name='tfID'>".page::select_options($tflist,$tf_sel)."</select>";
+$tf_select = "<select name='tfID'>".page::select_options($tflist, $tf_sel)."</select>";
 $TPL["show_person_options"] = person::get_fullname($productSale->get_value("personID"));
 $TPL["show_date"] = $productSale->get_value("productSaleDate");
 
@@ -374,78 +377,74 @@ $TPL["show_extRef"] = $productSale->get_value("extRef");
 $TPL["show_extRefDate"] = $productSale->get_value("extRefDate");
 
 if (!$productSale->get_id() || $productSale->get_value("status") != "finished" && !($productSale->get_value("status") == "admin" && !CAN_APPROVE_TRANSACTIONS)) {
-  $TPL["show_client_options"] = $client_select;
-  $TPL["show_project_options"] = $project_select;
-  $TPL["show_tf_options"] = $tf_select;
+    $TPL["show_client_options"] = $client_select;
+    $TPL["show_project_options"] = $project_select;
+    $TPL["show_tf_options"] = $tf_select;
 
-  $personID = $productSale->get_value("personID") or $personID = $current_user->get_id();
-  $TPL["show_person_options"] = "<select name='personID'>".page::select_options(person::get_username_list($personID), $personID)."</select>";
+    $personID = $productSale->get_value("personID") or $personID = $current_user->get_id();
+    $TPL["show_person_options"] = "<select name='personID'>".page::select_options(person::get_username_list($personID), $personID)."</select>";
 
-  $TPL["show_date"] = page::calendar("productSaleDate", $productSale->get_value("productSaleDate"));
-  $TPL["show_extRef"] = "<input type='text' name='extRef' value='".$productSale->get_value("extRef")."' size='10'>";
-  $TPL["show_extRefDate"] = page::calendar("extRefDate", $productSale->get_value("extRefDate"));
+    $TPL["show_date"] = page::calendar("productSaleDate", $productSale->get_value("productSaleDate"));
+    $TPL["show_extRef"] = "<input type='text' name='extRef' value='".$productSale->get_value("extRef")."' size='10'>";
+    $TPL["show_extRefDate"] = page::calendar("extRefDate", $productSale->get_value("extRefDate"));
 }
 
 
 $TPL["productSale_status"] = $productSale->get_value("status");
 
 $amounts = $productSale->get_amounts();
-$TPL = array_merge($TPL,$amounts);
+$TPL = array_merge($TPL, $amounts);
 
-define("DISPLAY_PRODUCT_SALE_ITEM_EDIT",1);
-define("DISPLAY_PRODUCT_SALE_ITEM_TRANSACTION_EDIT",2);
-define("DISPLAY_PRODUCT_SALE_ITEM_TRANSACTION_VIEW",3);
-define("DISPLAY_PRODUCT_SALE_EDIT",4);
+define("DISPLAY_PRODUCT_SALE_ITEM_EDIT", 1);
+define("DISPLAY_PRODUCT_SALE_ITEM_TRANSACTION_EDIT", 2);
+define("DISPLAY_PRODUCT_SALE_ITEM_TRANSACTION_VIEW", 3);
+define("DISPLAY_PRODUCT_SALE_EDIT", 4);
 
 // Show line item edit
 $productSaleID = $productSale->get_id();
 $status = $productSale->get_value("status");
 if ($productSaleID && $status == "edit") {
-  define("DISPLAY",DISPLAY_PRODUCT_SALE_ITEM_EDIT);
+    define("DISPLAY", DISPLAY_PRODUCT_SALE_ITEM_EDIT);
 
 // Show line item + transaction + edit
 } else if ($productSaleID && ($status == "allocate" || ($status == "admin" && $productSale->have_perm(PERM_APPROVE_PRODUCT_TRANSACTIONS)))) {
-  define("DISPLAY",DISPLAY_PRODUCT_SALE_ITEM_TRANSACTION_EDIT);
+    define("DISPLAY", DISPLAY_PRODUCT_SALE_ITEM_TRANSACTION_EDIT);
 
 // Show line item + transaction + view
 } else if ($productSaleID && ($status == "finished" || !$productSale->have_perm(PERM_APPROVE_PRODUCT_TRANSACTIONS))) {
-  define("DISPLAY",DISPLAY_PRODUCT_SALE_ITEM_TRANSACTION_VIEW);
-
+    define("DISPLAY", DISPLAY_PRODUCT_SALE_ITEM_TRANSACTION_VIEW);
 } else {
-  define("DISPLAY",0);
+    define("DISPLAY", 0);
 }
 
 if (!$productSale->get_id()) {
-  $TPL["message_help"][] = "To create a new Sale, optionally select a Client and/or Project and click the Create Sale button.";
+    $TPL["message_help"][] = "To create a new Sale, optionally select a Client and/or Project and click the Create Sale button.";
 } else if ($productSale->get_value("status") == "edit") {
-  $TPL["message_help"][] = "Add as many Sale Items as you like by clicking the 'New' link multiple times, and then clicking the
+    $TPL["message_help"][] = "Add as many Sale Items as you like by clicking the 'New' link multiple times, and then clicking the
                             Save Items button.<br><br>When you are done adding Sale Items click the 'Allocate -->' button
                             to setup the resulting transactions from this Sale.";
-
 } else if ($productSale->get_value("status") == "allocate") {
-  $TPL["message_help"][] = "If necessary, adjust the transactions below. When you're done, submit this Sale
+    $TPL["message_help"][] = "If necessary, adjust the transactions below. When you're done, submit this Sale
                             to the Adminstrator, you will no longer be able to edit this Sale.
 
                             <br><br>Generally, the transactions for the Sale Items will add up correctly if the
                             <b>Sell Price</b> is equal to <b>Transactions Incoming</b>, and the <b>Margin</b> is
                             equal to <b>Transactions Other</b>.";
-
-
 } else if ($productSale->get_value("status") == "admin" && $productSale->have_perm(PERM_APPROVE_PRODUCT_TRANSACTIONS)) {
-  $TPL["message_help"][] = "Please review the Sale Transactions carefully. If accurate <b>approve</b> and save the transactions,
+    $TPL["message_help"][] = "Please review the Sale Transactions carefully. If accurate <b>approve</b> and save the transactions,
                             then move this Sale to status 'Completed'.";
 } else if ($productSale->get_value("status") == "admin") {
-  $TPL["message_help"][] = "This Sale is awaiting approval from the Administrator.";
+    $TPL["message_help"][] = "This Sale is awaiting approval from the Administrator.";
 }
 
 
 if ($productSale->get_value("projectID")) {
-  $project = new project();
-  $project->set_id($productSale->get_value("projectID"));
-  $project->select();
-  $ptf = $project->get_value("cost_centre_tfID");
-  $ptf and $TPL["project_tfID"] = " (TF: ".tf::get_name($ptf).")";
-  $ptf or $TPL["project_tfID"] = " (No project TF)";
+    $project = new project();
+    $project->set_id($productSale->get_value("projectID"));
+    $project->select();
+    $ptf = $project->get_value("cost_centre_tfID");
+    $ptf and $TPL["project_tfID"] = " (TF: ".tf::get_name($ptf).")";
+    $ptf or $TPL["project_tfID"] = " (No project TF)";
 }
 
 $TPL["taxName"] = config::get_config_item("taxName");
@@ -453,5 +452,3 @@ $TPL["taxName"] = config::get_config_item("taxName");
 $TPL["main_alloc_title"] = "Sale - ".APPLICATION_NAME;
 $productSale->get_id() and $TPL["main_alloc_title"] = "Sale " . $productSale->get_id()." - ".APPLICATION_NAME;
 include_template("templates/productSaleM.tpl");
-
-?>

--- a/sale/productSaleList.php
+++ b/sale/productSaleList.php
@@ -3,32 +3,33 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function show_filter() {
-  global $TPL;
-  global $defaults;
-  $_FORM = productSale::load_form_data($defaults);
-  $arr = productSale::load_productSale_filter($_FORM);
-  is_array($arr) and $TPL = array_merge($TPL,$arr);
-  include_template("templates/productSaleListFilterS.tpl");
+function show_filter()
+{
+    global $TPL;
+    global $defaults;
+    $_FORM = productSale::load_form_data($defaults);
+    $arr = productSale::load_productSale_filter($_FORM);
+    is_array($arr) and $TPL = array_merge($TPL, $arr);
+    include_template("templates/productSaleListFilterS.tpl");
 }
 
 
@@ -41,7 +42,7 @@ $_FORM = productSale::load_form_data($defaults);
 $TPL["productSaleListRows"] = productSale::get_list($_FORM);
 
 if (!$current_user->prefs["productSaleList_filter"]) {
-  $TPL["message_help"][] = "
+    $TPL["message_help"][] = "
 
 allocPSA allows you to create Sales and Products and allocate the funds from
 Sales. This page allows you to view a list of Sales.
@@ -59,5 +60,3 @@ in the top-right hand corner of the box below.";
 
 $TPL["main_alloc_title"] = "Sales List - ".APPLICATION_NAME;
 include_template("templates/productSaleListM.tpl");
-
-?>

--- a/sale/updateCostPrice.php
+++ b/sale/updateCostPrice.php
@@ -3,24 +3,24 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 $db = new db_alloc();
@@ -35,10 +35,8 @@ $p->set_tpl_values();
 
 // Probably not valid XML, but jQuery will parse it.
 echo "<data>\n";
-echo "<price>".page::money($TPL["sellPriceCurrencyTypeID"],$TPL["sellPrice"]*$quantity,"%m")."</price>\n";
+echo "<price>".page::money($TPL["sellPriceCurrencyTypeID"], $TPL["sellPrice"]*$quantity, "%m")."</price>\n";
 echo "<priceCurrency>".$TPL["sellPriceCurrencyTypeID"]."</priceCurrency>\n";
 echo "<priceTax>".($TPL["sellPriceIncTax"] ? "1" : "")."</priceTax>\n";
 echo "<description>".$TPL["description"]."</description>\n";
 echo "</data>\n";
-
-?>

--- a/search/lib/init.php
+++ b/search/lib/init.php
@@ -3,25 +3,25 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class search_module extends module {
-  var $module = "search";
+class search_module extends module
+{
+    var $module = "search";
 }
-?>

--- a/search/lib/search.inc.php
+++ b/search/lib/search.inc.php
@@ -3,97 +3,93 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 define("PERM_PROJECT_READ_TASK_DETAIL", 256);
 
-class search {
+class search
+{
 
-  function by_file($file, $needle) {
-    if (file_exists($file) && is_readable($file) && !is_dir($file)) {
-      $rtn = array();
-      $fp = fopen($file, 'r');
-      if ($fp) {
-        while (!feof($fp)) {
-          $line = stream_get_line($fp,65535,"\n"); // faster than fgets
-          strpos(strtolower($line), strtolower($needle)) !== false and $rtn[] = $line;
+    function by_file($file, $needle)
+    {
+        if (file_exists($file) && is_readable($file) && !is_dir($file)) {
+            $rtn = array();
+            $fp = fopen($file, 'r');
+            if ($fp) {
+                while (!feof($fp)) {
+                    $line = stream_get_line($fp, 65535, "\n"); // faster than fgets
+                    strpos(strtolower($line), strtolower($needle)) !== false and $rtn[] = $line;
+                }
+                fclose($fp);
+            }
         }
-        fclose($fp);
-      }
+        return $rtn;
     }
-    return $rtn;
-  }
 
-  function get_trimmed_description($haystack, $needle, $category) {
+    function get_trimmed_description($haystack, $needle, $category)
+    {
 
-    $position = strpos(strtolower($haystack),strtolower($needle));
-    if ($position !== false) {
-      $prefix = "...";
-      $suffix = "...";
+        $position = strpos(strtolower($haystack), strtolower($needle));
+        if ($position !== false) {
+            $prefix = "...";
+            $suffix = "...";
 
-      // Nuke trailing ellipses if the string ends in the match
-      if (strlen(substr($haystack,$position)) == strlen($needle)) {
-        $suffix = "";
-      } 
+          // Nuke trailing ellipses if the string ends in the match
+            if (strlen(substr($haystack, $position)) == strlen($needle)) {
+                $suffix = "";
+            }
 
-      $buffer = 30;
-      $position = $position - $buffer;
+            $buffer = 30;
+            $position = $position - $buffer;
 
-      // Reset position to zero cause negative number will make it wrap around, 
-      // and nuke ellipses prefix because the string begins with the match
-      if ($position < 0) {
-        $position = 0;
-        $prefix = "";
-      } 
+          // Reset position to zero cause negative number will make it wrap around,
+          // and nuke ellipses prefix because the string begins with the match
+            if ($position < 0) {
+                $position = 0;
+                $prefix = "";
+            }
 
-      $str = substr($haystack,$position,strlen($needle)+100);
-      $str = str_replace($needle,"[[[".$needle."]]]",$str);
-      $str = $prefix.$str.$suffix;
-      return $str;
-    } 
-
-    if ($category == "Clients") {
-      return substr($haystack,0,100);
-    } 
-    
-  }
-
-  function get_recursive_dir_list($dir) {
-    $rtn = array();
-    $dir = realpath($dir).DIRECTORY_SEPARATOR;
-    $dont_search_these_dirs = array(".","..","CVS",".hg",".bzr","_darcs",".git");
-    $files = scandir($dir);
-    foreach ($files as $file) {
-      if(!in_array($file, $dont_search_these_dirs)) {
-        if (is_file($dir.$file) && !is_dir($dir.$file)) {
-          $rtn[] = $dir.$file;
-
-        } else if (is_dir($dir.$file)) {
-          $rtn = array_merge((array)$rtn, (array)search::get_recursive_dir_list($dir.$file));
+            $str = substr($haystack, $position, strlen($needle)+100);
+            $str = str_replace($needle, "[[[".$needle."]]]", $str);
+            $str = $prefix.$str.$suffix;
+            return $str;
         }
-      }
+
+        if ($category == "Clients") {
+            return substr($haystack, 0, 100);
+        }
     }
-    return $rtn;
-  }
 
-
-
+    function get_recursive_dir_list($dir)
+    {
+        $rtn = array();
+        $dir = realpath($dir).DIRECTORY_SEPARATOR;
+        $dont_search_these_dirs = array(".","..","CVS",".hg",".bzr","_darcs",".git");
+        $files = scandir($dir);
+        foreach ($files as $file) {
+            if (!in_array($file, $dont_search_these_dirs)) {
+                if (is_file($dir.$file) && !is_dir($dir.$file)) {
+                    $rtn[] = $dir.$file;
+                } else if (is_dir($dir.$file)) {
+                    $rtn = array_merge((array)$rtn, (array)search::get_recursive_dir_list($dir.$file));
+                }
+            }
+        }
+        return $rtn;
+    }
 }
-
-
-?>

--- a/search/search.php
+++ b/search/search.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,21 +23,22 @@
 require_once("../alloc.php");
 
 
-function format_display_fields($str="") {
-  if ($str) {
-    $lines = explode("|+|=|",$str); // arbitrary line delimiter, can't use newlines as data will contain newlines.
-    $t = "<table class='list'>";
-    foreach ($lines as $line) {
-      $t.= "<tr>";
-      $cells = explode("|",$line);
-      foreach ($cells as $cell) {
-        $t.= "<td>".str_replace(array("\n","\r","<br>","<br />")," ",substr($cell,0,200))."</td>";
-      }
-      $t.= "</tr>";
+function format_display_fields($str = "")
+{
+    if ($str) {
+        $lines = explode("|+|=|", $str); // arbitrary line delimiter, can't use newlines as data will contain newlines.
+        $t = "<table class='list'>";
+        foreach ($lines as $line) {
+            $t.= "<tr>";
+            $cells = explode("|", $line);
+            foreach ($cells as $cell) {
+                $t.= "<td>".str_replace(array("\n","\r","<br>","<br />"), " ", substr($cell, 0, 200))."</td>";
+            }
+            $t.= "</tr>";
+        }
+        $t.= "</table>";
+        return "<div>".$t."</div>";
     }
-    $t.= "</table>";
-    return "<div>".$t."</div>";
-  }
 }
 
 
@@ -53,303 +54,312 @@ $db = new db_alloc();
 
 // Project Search
 if ($search && $needle && $category == "search_projects") {
+    $TPL["search_title"] = "Project Search";
 
-  $TPL["search_title"] = "Project Search";
+    if (!$noRedirect && is_numeric($needle)) {
+        $query = prepare("SELECT projectID FROM project WHERE projectID = %d", $needle);
+        $db->query($query);
+        if ($db->next_record()) {
+            alloc_redirect($TPL["url_alloc_project"]."projectID=".$db->f("projectID"));
+        }
+    } else {
+        $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/project');
+        $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);
+        $hits = $index->find($needle);
+        $TPL["index_count"] = $index->count();
+        $TPL["hits_count"] = count($hits);
 
-  if (!$noRedirect && is_numeric($needle)) {
-    $query = prepare("SELECT projectID FROM project WHERE projectID = %d",$needle);
-    $db->query($query);
-    if ($db->next_record()) {
-      alloc_redirect($TPL["url_alloc_project"]."projectID=".$db->f("projectID"));
-    } 
-
-  } else {
-
-    $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/project');
-    $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);  
-    $hits = $index->find($needle);
-    $TPL["index_count"] = $index->count();
-    $TPL["hits_count"] = count($hits);
-
-    foreach ($hits as $hit) {
-      $d = $hit->getDocument();
-      $row = array();
-      $row["idx"] = $hit->id;
-      $row["score"] = sprintf('%d%%', $hit->score*100);
-      $row["title"] = $d->getFieldValue('id')." ".sprintf("<a href='%sprojectID=%d'>%s</a>"
-                      ,$TPL["url_alloc_project"], $d->getFieldValue('id'), page::htmlentities($d->getFieldValue('name')));
-      $row["related"] = sprintf("<a href='%sclientID=%d'>%s</a>"
-                      ,$TPL["url_alloc_client"], $d->getFieldValue('cid'), page::htmlentities($d->getFieldValue('client')));
-      $row["desc"] = page::htmlentities($d->getFieldValue('desc'));
-      $TPL["search_results"][] = $row;
+        foreach ($hits as $hit) {
+            $d = $hit->getDocument();
+            $row = array();
+            $row["idx"] = $hit->id;
+            $row["score"] = sprintf('%d%%', $hit->score*100);
+            $row["title"] = $d->getFieldValue('id')." ".sprintf(
+                "<a href='%sprojectID=%d'>%s</a>",
+                $TPL["url_alloc_project"],
+                $d->getFieldValue('id'),
+                page::htmlentities($d->getFieldValue('name'))
+            );
+            $row["related"] = sprintf(
+                "<a href='%sclientID=%d'>%s</a>",
+                $TPL["url_alloc_client"],
+                $d->getFieldValue('cid'),
+                page::htmlentities($d->getFieldValue('client'))
+            );
+            $row["desc"] = page::htmlentities($d->getFieldValue('desc'));
+            $TPL["search_results"][] = $row;
+        }
     }
-  }
 
 // Clients Search
 } else if ($search && $needle && $category == "search_clients") {
+    $TPL["search_title"] = "Client Search";
 
-  $TPL["search_title"] = "Client Search";
+    if (!$noRedirect && is_numeric($needle)) {
+        $query = prepare("SELECT clientID FROM client WHERE clientID = %d", $needle);
+        $db->query($query);
+        if ($db->next_record()) {
+            alloc_redirect($TPL["url_alloc_client"]."clientID=".$db->f("clientID"));
+        }
+    } else {
+        $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/client');
+        $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);
+        $hits = $index->find($needle);
+        $TPL["index_count"] = $index->count();
+        $TPL["hits_count"] = count($hits);
 
-  if (!$noRedirect && is_numeric($needle)) {
-    $query = prepare("SELECT clientID FROM client WHERE clientID = %d",$needle);
-    $db->query($query);
-    if ($db->next_record()) {
-      alloc_redirect($TPL["url_alloc_client"]."clientID=".$db->f("clientID"));
-    } 
-    
-  } else {
+        foreach ($hits as $hit) {
+            $d = $hit->getDocument();
+            $row = array();
+            $row["idx"] = $hit->id;
+            $row["score"] = sprintf('%d%%', $hit->score*100);
+            $row["title"] = $d->getFieldValue('id')." ".sprintf(
+                "<a href='%sclientID=%d'>%s</a>",
+                $TPL["url_alloc_client"],
+                $d->getFieldValue('id'),
+                page::htmlentities($d->getFieldValue('name'))
+            );
+          //$row["related"] = sprintf("<a href='%sprojectID=%d'>%s</a>"
+          //                ,$TPL["url_alloc_project"], $d->getFieldValue('pid'), $d->getFieldValue('project'));
 
-    $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/client');
-    $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);  
-    $hits = $index->find($needle);
-    $TPL["index_count"] = $index->count();
-    $TPL["hits_count"] = count($hits);
+            unset($num_contact);
+            if ($d->getFieldValue('contact')) {
+                  $num_contact = count((array)explode("|+|=|", $d->getFieldValue('contact')));
+                  unset($s);
+                $num_contact > 1 and $s = "s";
+                  $num_contact and $num_contact = "\n\n".$num_contact." contact".$s.".\n";
+            }
 
-    foreach ($hits as $hit) {
-      $d = $hit->getDocument();
-      $row = array();
-      $row["idx"] = $hit->id;
-      $row["score"] = sprintf('%d%%', $hit->score*100);
-      $row["title"] = $d->getFieldValue('id')." ".sprintf("<a href='%sclientID=%d'>%s</a>"
-                      ,$TPL["url_alloc_client"], $d->getFieldValue('id'), page::htmlentities($d->getFieldValue('name')));
-      //$row["related"] = sprintf("<a href='%sprojectID=%d'>%s</a>"
-      //                ,$TPL["url_alloc_project"], $d->getFieldValue('pid'), $d->getFieldValue('project'));
+            $desc = page::htmlentities($d->getFieldValue('desc'));
 
-      unset($num_contact);
-      if ($d->getFieldValue('contact')) {
-        $num_contact = count((array)explode("|+|=|",$d->getFieldValue('contact')));
-        unset($s); $num_contact > 1 and $s = "s";
-        $num_contact and $num_contact = "\n\n".$num_contact." contact".$s.".\n";
-      }
+            $row["desc"] = $desc.$num_contact;
+            $row["desc2"] = page::htmlentities($d->getFieldValue('contact'));
 
-      $desc = page::htmlentities($d->getFieldValue('desc'));
-
-      $row["desc"] = $desc.$num_contact;
-      $row["desc2"] = page::htmlentities($d->getFieldValue('contact'));
-
-      $TPL["search_results"][] = $row;
+            $TPL["search_results"][] = $row;
+        }
     }
-
-
-  }
 
 // Tasks Search
 } else if ($search && $needle && $category == "search_tasks") {
+    $TPL["search_title"] = "Task Search";
 
-  $TPL["search_title"] = "Task Search";
+    if (!$noRedirect && is_numeric($needle)) {
+        $query = prepare("SELECT taskID FROM task WHERE taskID = %d", $needle);
+        $db->query($query);
+        if ($db->next_record()) {
+            alloc_redirect($TPL["url_alloc_task"]."taskID=".$db->f("taskID"));
+        }
+    } else {
+        $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/task');
+        $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);
+        $hits = $index->find($needle);
+        $TPL["index_count"] = $index->count();
+        $TPL["hits_count"] = count($hits);
 
-  if (!$noRedirect && is_numeric($needle)) {
-    $query = prepare("SELECT taskID FROM task WHERE taskID = %d",$needle);
-    $db->query($query);
-    if ($db->next_record()) {
-      alloc_redirect($TPL["url_alloc_task"]."taskID=".$db->f("taskID"));
-    } 
-
-  } else {
-
-    $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/task');
-    $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);  
-    $hits = $index->find($needle);
-    $TPL["index_count"] = $index->count();
-    $TPL["hits_count"] = count($hits);
-
-    foreach ($hits as $hit) {
-      $d = $hit->getDocument();
-      $row = array();
-      $row["idx"] = $hit->id;
-      $row["score"] = sprintf('%d%%', $hit->score*100);
-      $row["title"] = $d->getFieldValue('id')." ".sprintf("<a href='%staskID=%d'>%s</a>"
-                      ,$TPL["url_alloc_task"], $d->getFieldValue('id'), page::htmlentities($d->getFieldValue('name')));
-      $row["related"] = sprintf("<a href='%sprojectID=%d'>%s</a>"
-                      ,$TPL["url_alloc_project"], $d->getFieldValue('pid'), page::htmlentities($d->getFieldValue('project')));
-      $row["desc"] = page::htmlentities($d->getFieldValue('desc'));
-      $TPL["search_results"][] = $row;
+        foreach ($hits as $hit) {
+            $d = $hit->getDocument();
+            $row = array();
+            $row["idx"] = $hit->id;
+            $row["score"] = sprintf('%d%%', $hit->score*100);
+            $row["title"] = $d->getFieldValue('id')." ".sprintf(
+                "<a href='%staskID=%d'>%s</a>",
+                $TPL["url_alloc_task"],
+                $d->getFieldValue('id'),
+                page::htmlentities($d->getFieldValue('name'))
+            );
+            $row["related"] = sprintf(
+                "<a href='%sprojectID=%d'>%s</a>",
+                $TPL["url_alloc_project"],
+                $d->getFieldValue('pid'),
+                page::htmlentities($d->getFieldValue('project'))
+            );
+            $row["desc"] = page::htmlentities($d->getFieldValue('desc'));
+            $TPL["search_results"][] = $row;
+        }
     }
-  }
 
 
 // Item Search
 } else if ($search && $needle && $category == "search_items") {
+    $TPL["search_title"] = "Item Search";
+    $today = date("Y")."-".date("m")."-".date("d");
 
-  $TPL["search_title"] = "Item Search";
-  $today = date("Y")."-".date("m")."-".date("d");
-
-  if (!$noRedirect && is_numeric($needle)) {
-    $query = prepare("SELECT itemID FROM item WHERE itemID = %d",$needle);
-    $db->query($query);
-    if ($db->next_record()) {
-      alloc_redirect($TPL["url_alloc_item"]."itemID=".$db->f("itemID"));
-    }
-
-  } else {
-
-    //open the index
-    $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/item');
-    $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);  
-    $hits = $index->find($needle);
-    $TPL["index_count"] = $index->count();
-    $TPL["hits_count"] = count($hits);
-
-    $p =& get_cached_table("person");
-
-    foreach ($hits as $hit) {
-      $d = $hit->getDocument();
-      $item = new item();
-      $item->set_id($d->getFieldValue('id'));
-      $item->select();
-      $row = array();
-      $row["idx"] = $hit->id;
-      $author = $item->get_value("itemAuthor");
-      $author and $author = " by ".$author;
-      $row["title"] = $item->get_id()." ".$item->get_link().$author;
-      $row["score"] = sprintf('%d%%', $hit->score*100);
-      $row["desc"] = page::htmlentities($d->getFieldValue('desc'));
-
-      // get availability of loan
-      $db2 = new db_alloc();
-      $query = prepare("SELECT * FROM loan WHERE itemID = %d AND dateReturned='0000-00-00'",$item->get_id());
-      $db2->query($query);
-      if ($db2->next_record()) {
-        $loan = new loan();
-        $loan->read_db_record($db2);
-
-        if ($loan->have_perm(PERM_READ_WRITE)) {
-          // if item is overdue
-          if ($loan->get_value("dateToBeReturned") < $today) {
-            $status = "Overdue";
-          } else {
-            $status = "Due on ".$loan->get_value("dateToBeReturned");
-          }
-          $row["related"] = $status." <a href=\"".$TPL["url_alloc_item"]."itemID=".$item->get_id()."&return=true\">Return</a>";
-
-        // Else you dont have permission to loan or return so just show status
-        } else {
-          
-          $name = page::htmlentities($p[$loan->get_value("personID")]["name"]);
-
-          if ($loan->get_value("dateToBeReturned") < $today) {
-            $row["related"] = "Overdue from ".$name;
-          } else {
-            $row["related"] = "Due from ".$name." on ".$loan->get_value("dateToBeReturned");
-          }
+    if (!$noRedirect && is_numeric($needle)) {
+        $query = prepare("SELECT itemID FROM item WHERE itemID = %d", $needle);
+        $db->query($query);
+        if ($db->next_record()) {
+            alloc_redirect($TPL["url_alloc_item"]."itemID=".$db->f("itemID"));
         }
+    } else {
+      //open the index
+        $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/item');
+        $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);
+        $hits = $index->find($needle);
+        $TPL["index_count"] = $index->count();
+        $TPL["hits_count"] = count($hits);
 
-      } else {
-        $row["related"] = "Available <a href=\"".$TPL["url_alloc_item"]."itemID=".$item->get_id()."&borrow=true\">Borrow</a>";
-      }
+        $p =& get_cached_table("person");
+
+        foreach ($hits as $hit) {
+            $d = $hit->getDocument();
+            $item = new item();
+            $item->set_id($d->getFieldValue('id'));
+            $item->select();
+            $row = array();
+            $row["idx"] = $hit->id;
+            $author = $item->get_value("itemAuthor");
+            $author and $author = " by ".$author;
+            $row["title"] = $item->get_id()." ".$item->get_link().$author;
+            $row["score"] = sprintf('%d%%', $hit->score*100);
+            $row["desc"] = page::htmlentities($d->getFieldValue('desc'));
+
+          // get availability of loan
+            $db2 = new db_alloc();
+            $query = prepare("SELECT * FROM loan WHERE itemID = %d AND dateReturned='0000-00-00'", $item->get_id());
+            $db2->query($query);
+            if ($db2->next_record()) {
+                $loan = new loan();
+                $loan->read_db_record($db2);
+
+                if ($loan->have_perm(PERM_READ_WRITE)) {
+                  // if item is overdue
+                    if ($loan->get_value("dateToBeReturned") < $today) {
+                        $status = "Overdue";
+                    } else {
+                        $status = "Due on ".$loan->get_value("dateToBeReturned");
+                    }
+                    $row["related"] = $status." <a href=\"".$TPL["url_alloc_item"]."itemID=".$item->get_id()."&return=true\">Return</a>";
+
+                // Else you dont have permission to loan or return so just show status
+                } else {
+                    $name = page::htmlentities($p[$loan->get_value("personID")]["name"]);
+
+                    if ($loan->get_value("dateToBeReturned") < $today) {
+                        $row["related"] = "Overdue from ".$name;
+                    } else {
+                        $row["related"] = "Due from ".$name." on ".$loan->get_value("dateToBeReturned");
+                    }
+                }
+            } else {
+                $row["related"] = "Available <a href=\"".$TPL["url_alloc_item"]."itemID=".$item->get_id()."&borrow=true\">Borrow</a>";
+            }
   
-      $TPL["search_results"][] = $row;
+            $TPL["search_results"][] = $row;
+        }
     }
-  }
  
 // Expense Form ID search
 } else if ($search && $needle && $category == "search_expenseForm") {
-
-  if (!$noRedirect && is_numeric($needle)) {
-    $query = prepare("SELECT expenseFormID FROM expenseForm WHERE expenseFormID = %d",$needle);
-    $db->query($query);
-    if ($db->next_record()) {
-      alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$db->f("expenseFormID"));
+    if (!$noRedirect && is_numeric($needle)) {
+        $query = prepare("SELECT expenseFormID FROM expenseForm WHERE expenseFormID = %d", $needle);
+        $db->query($query);
+        if ($db->next_record()) {
+            alloc_redirect($TPL["url_alloc_expenseForm"]."expenseFormID=".$db->f("expenseFormID"));
+        }
     }
-  }
 
 // Time Sheet Search
 } else if ($search && $needle && $category == "search_time") {
+    $TPL["search_title"] = "Time Sheet Search";
 
-  $TPL["search_title"] = "Time Sheet Search";
+    if (!$noRedirect && is_numeric($needle)) {
+        $query = prepare("SELECT timeSheetID FROM timeSheet WHERE timeSheetID = %d", $needle);
+        $db->query($query);
+        if ($db->next_record()) {
+            alloc_redirect($TPL["url_alloc_timeSheet"]."timeSheetID=".$db->f("timeSheetID"));
+        }
+    } else {
+        $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/timeSheet');
+        $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);
+        $hits = $index->find($needle);
+        $TPL["index_count"] = $index->count();
+        $TPL["hits_count"] = count($hits);
 
-  if (!$noRedirect && is_numeric($needle)) {
-    $query = prepare("SELECT timeSheetID FROM timeSheet WHERE timeSheetID = %d",$needle);
-    $db->query($query);
-    if ($db->next_record()) {
-      alloc_redirect($TPL["url_alloc_timeSheet"]."timeSheetID=".$db->f("timeSheetID"));
-    } 
-    
-  } else {
+        foreach ($hits as $hit) {
+            $d = $hit->getDocument();
+            $row = array();
+            $row["idx"] = $hit->id;
+            $row["score"] = sprintf('%d%%', $hit->score*100);
+            $c = (array)explode(" ", $d->getFieldValue('creator'));
+            $creator = implode(" ", (array)array_slice($c, 2));
+          //$creator = implode(" ",array_shift(array_shift(explode(" ",$d->getFieldValue('creator')))));
+            $row["title"] = $d->getFieldValue('id')." ".sprintf(
+                "<a href='%stimeSheetID=%d'>%s</a>",
+                $TPL["url_alloc_timeSheet"],
+                $d->getFieldValue('id'),
+                "Time Sheet for ".page::htmlentities($d->getFieldValue('project'))." by ".page::htmlentities($creator)
+            );
+            $row["related"] = sprintf(
+                "<a href='%sprojectID=%d'>%s</a>",
+                $TPL["url_alloc_project"],
+                $d->getFieldValue('pid'),
+                page::htmlentities($d->getFieldValue('project'))
+            );
 
-    $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/timeSheet');
-    $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);  
-    $hits = $index->find($needle);
-    $TPL["index_count"] = $index->count();
-    $TPL["hits_count"] = count($hits);
-
-    foreach ($hits as $hit) {
-      $d = $hit->getDocument();
-      $row = array();
-      $row["idx"] = $hit->id;
-      $row["score"] = sprintf('%d%%', $hit->score*100);
-      $c = (array)explode(" ",$d->getFieldValue('creator'));
-      $creator = implode(" ",(array)array_slice($c,2));
-      //$creator = implode(" ",array_shift(array_shift(explode(" ",$d->getFieldValue('creator')))));
-      $row["title"] = $d->getFieldValue('id')." ".sprintf("<a href='%stimeSheetID=%d'>%s</a>"
-                      ,$TPL["url_alloc_timeSheet"], $d->getFieldValue('id')
-                      ,"Time Sheet for ".page::htmlentities($d->getFieldValue('project'))." by ".page::htmlentities($creator));
-      $row["related"] = sprintf("<a href='%sprojectID=%d'>%s</a>"
-                      ,$TPL["url_alloc_project"], $d->getFieldValue('pid'), page::htmlentities($d->getFieldValue('project')));
-
-      $row["desc"] = page::htmlentities($d->getFieldValue('desc'));
-      $TPL["search_results"][] = $row;
+            $row["desc"] = page::htmlentities($d->getFieldValue('desc'));
+            $TPL["search_results"][] = $row;
+        }
     }
-
-  }
 
 // Comment Search
 } else if ($search && $needle && $category == "search_comment") {
+    $TPL["search_title"] = "Comment Search";
 
-  $TPL["search_title"] = "Comment Search";
+    if (!$noRedirect && is_numeric($needle)) {
+        $query = prepare("SELECT commentID FROM comment WHERE commentID = %d", $needle);
+        $db->query($query);
+        if ($db->next_record()) {
+            alloc_redirect($TPL["url_alloc_comment"]."commentID=".$db->f("commentID"));
+        }
+    } else {
+        $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/comment');
+        $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);
+        $hits = $index->find($needle);
+        $TPL["index_count"] = $index->count();
+        $TPL["hits_count"] = count($hits);
 
-  if (!$noRedirect && is_numeric($needle)) {
-    $query = prepare("SELECT commentID FROM comment WHERE commentID = %d",$needle);
-    $db->query($query);
-    if ($db->next_record()) {
-      alloc_redirect($TPL["url_alloc_comment"]."commentID=".$db->f("commentID"));
-    } 
-    
-  } else {
+        foreach ($hits as $hit) {
+            $d = $hit->getDocument();
+            $row = array();
+            $row["idx"] = $hit->id;
+            $row["score"] = sprintf('%d%%', $hit->score*100);
+            $row["title"] = page::htmlentities($d->getFieldValue('name'));
+            $row["related"] = sprintf(
+                "<a href='%s%sID=%d'>%s</a>",
+                $TPL["url_alloc_".$d->getFieldValue('type')],
+                $d->getFieldValue('type'),
+                $d->getFieldValue('typeid'),
+                page::htmlentities($d->getFieldValue('typename'))
+            );
+            $row["desc"] = page::htmlentities($d->getFieldValue('desc'));
+            $TPL["search_results"][] = $row;
+        }
+    }
 
-    $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/comment');
-    $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);  
+// Wiki Search
+} else if ($search && $needle && $category == "search_wiki") {
+    $TPL["search_title"] = "Wiki Search";
+
+    $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/wiki');
+    $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);
     $hits = $index->find($needle);
     $TPL["index_count"] = $index->count();
     $TPL["hits_count"] = count($hits);
 
     foreach ($hits as $hit) {
-      $d = $hit->getDocument();
-      $row = array();
-      $row["idx"] = $hit->id;
-      $row["score"] = sprintf('%d%%', $hit->score*100);
-      $row["title"] = page::htmlentities($d->getFieldValue('name'));
-      $row["related"] = sprintf("<a href='%s%sID=%d'>%s</a>"
-                      ,$TPL["url_alloc_".$d->getFieldValue('type')], $d->getFieldValue('type')
-                      ,$d->getFieldValue('typeid'), page::htmlentities($d->getFieldValue('typename')));
-      $row["desc"] = page::htmlentities($d->getFieldValue('desc'));
-      $TPL["search_results"][] = $row;
+        $d = $hit->getDocument();
+        $row = array();
+        $row["idx"] = $hit->id;
+        $row["score"] = sprintf('%d%%', $hit->score*100);
+        $row["title"] = sprintf(
+            "<a href='%starget=%s'>%s</a>",
+            $TPL["url_alloc_wiki"],
+            urlencode($d->getFieldValue('name')),
+            page::htmlentities($d->getFieldValue('name'))
+        );
+        $row["desc"] = page::htmlentities($d->getFieldValue('desc'));
+        $TPL["search_results"][] = $row;
     }
-  }
-
-// Wiki Search
-} else if ($search && $needle && $category == "search_wiki") {
-
-  $TPL["search_title"] = "Wiki Search";
-
-  $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/wiki');
-  $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);  
-  $hits = $index->find($needle);
-  $TPL["index_count"] = $index->count();
-  $TPL["hits_count"] = count($hits);
-
-  foreach ($hits as $hit) {
-    $d = $hit->getDocument();
-    $row = array();
-    $row["idx"] = $hit->id;
-    $row["score"] = sprintf('%d%%', $hit->score*100);
-    $row["title"] = sprintf("<a href='%starget=%s'>%s</a>"
-                    ,$TPL["url_alloc_wiki"], urlencode($d->getFieldValue('name'))
-                    ,page::htmlentities($d->getFieldValue('name')));
-    $row["desc"] = page::htmlentities($d->getFieldValue('desc'));
-    $TPL["search_results"][] = $row;
-  }
-
 }
 
 
@@ -358,10 +368,8 @@ $TPL["search_category_options"] = page::get_category_options($category);
 $TPL["needle"] = $needle;
 $TPL["needle2"] = $needle;
 if (!$needle || $noRedirect) {
-  $TPL["redir"] = "checked=\"1\"";
+    $TPL["redir"] = "checked=\"1\"";
 }
 
 $TPL["main_alloc_title"] = "Search - ".APPLICATION_NAME;
 include_template("templates/searchM.tpl");
-
-?>

--- a/search/updateIndex.php
+++ b/search/updateIndex.php
@@ -3,43 +3,44 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_AUTH",true);
-define("IS_GOD",true);
+define("NO_AUTH", true);
+define("IS_GOD", true);
 require_once("../alloc.php");
 
-ini_set('max_execution_time',180000); 
-ini_set('memory_limit',"512M");
+ini_set('max_execution_time', 180000);
+ini_set('memory_limit', "512M");
 
 
-function echoo($str) {
-  $nl = "<br>";
-  $nl = "\n";
-  echo $nl.$str;
+function echoo($str)
+{
+    $nl = "<br>";
+    $nl = "\n";
+    echo $nl.$str;
 }
 
 
 foreach (array("client","comment","item","project","task","timeSheet","wiki") as $i) {
-  if (!is_dir(ATTACHMENTS_DIR.'search/'.$i)) {
-    $index = Zend_Search_Lucene::create(ATTACHMENTS_DIR.'search/'.$i);
-    $index->commit();
-  }
+    if (!is_dir(ATTACHMENTS_DIR.'search/'.$i)) {
+        $index = Zend_Search_Lucene::create(ATTACHMENTS_DIR.'search/'.$i);
+        $index->commit();
+    }
 }
 
 
@@ -51,49 +52,42 @@ $q1 = $db->query($q);
 echoo("Beginning ...");
 
 while ($row = $db->row($q1)) {
-
-  $z++;
-  if ($z % 1000 == 0 && is_object($index)) {
-    echoo($z." Committing index: ".$current_index);
-    $index->commit();
-    flush();
-  }
-
-  if (!$current_index || $current_index != $row["entity"]) {
-
-    // commit previous index
-    if (is_object($index)) { 
-      echoo("Committing index: ".$current_index);
-      $index->commit();
+    $z++;
+    if ($z % 1000 == 0 && is_object($index)) {
+        echoo($z." Committing index: ".$current_index);
+        $index->commit();
+        flush();
     }
 
-    // start a new index
-    echoo("New \$index: ".$row["entity"]);
-    $index = Zend_Search_Lucene::open(ATTACHMENTS_DIR.'search/'.$row["entity"]);
-  }
+    if (!$current_index || $current_index != $row["entity"]) {
+      // commit previous index
+        if (is_object($index)) {
+            echoo("Committing index: ".$current_index);
+            $index->commit();
+        }
 
-  $current_index = $row["entity"];
+      // start a new index
+        echoo("New \$index: ".$row["entity"]);
+        $index = Zend_Search_Lucene::open(ATTACHMENTS_DIR.'search/'.$row["entity"]);
+    }
 
-  echoo("  Updating index ".$row["entity"]." #".$row["entityID"]);
+    $current_index = $row["entity"];
 
-  $e = new $row["entity"];
-  $e->set_id($row["entityID"]);
-  $e->select();
-  $e->delete_search_index_doc($index);
-  $e->update_search_index_doc($index);
+    echoo("  Updating index ".$row["entity"]." #".$row["entityID"]);
+
+    $e = new $row["entity"];
+    $e->set_id($row["entityID"]);
+    $e->select();
+    $e->delete_search_index_doc($index);
+    $e->update_search_index_doc($index);
 
 
   // Nuke item from queue
-  $db->query("DELETE FROM indexQueue WHERE indexQueueID = %d",$row["indexQueueID"]);
+    $db->query("DELETE FROM indexQueue WHERE indexQueueID = %d", $row["indexQueueID"]);
 }
 
 // commit index
-if (is_object($index)) { 
-  echoo("Committing index(2): ".$current_index);
-  $index->commit();
+if (is_object($index)) {
+    echoo("Committing index(2): ".$current_index);
+    $index->commit();
 }
-
-
-
-
-?>

--- a/security/lib/init.php
+++ b/security/lib/init.php
@@ -3,26 +3,26 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class security_module extends module {
-  var $module = "security";
-  var $db_entities = array("permission","role");
+class security_module extends module
+{
+    var $module = "security";
+    var $db_entities = array("permission","role");
 }
-?>

--- a/security/lib/permission.inc.php
+++ b/security/lib/permission.inc.php
@@ -3,28 +3,29 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class permission extends db_entity {
-  public $data_table = "permission";
-  public $display_field_name = "tableName";
-  public $key_field = "permissionID";
-  public $data_fields = array("tableName"
+class permission extends db_entity
+{
+    public $data_table = "permission";
+    public $display_field_name = "tableName";
+    public $key_field = "permissionID";
+    public $data_fields = array("tableName"
                              ,"entityID"
                              ,"roleName"=>array("empty_to_null"=>false)
                              ,"actions"
@@ -32,42 +33,39 @@ class permission extends db_entity {
                              ,"comment"
                              );
 
-  function describe_actions() {
-    $actions = $this->get_value("actions");
-    $description = "";
+    function describe_actions()
+    {
+        $actions = $this->get_value("actions");
+        $description = "";
 
-    $entity_class = $this->get_value("tableName");
+        $entity_class = $this->get_value("tableName");
 
-    if (meta::$tables[$entity_class]) {
-      $entity = new meta($entity_class);
-      $permissions = $entity->permissions;
-    } else if (class_exists($entity_class)) {
-      $entity = new $entity_class();
-      $permissions = $entity->permissions;
-    }
-
-    foreach ((array)$permissions as $a=>$d) {
-      if ((($actions & $a) == $a) && $d != "") {
-        if ($description) {
-          $description.= ",";
+        if (meta::$tables[$entity_class]) {
+            $entity = new meta($entity_class);
+            $permissions = $entity->permissions;
+        } else if (class_exists($entity_class)) {
+            $entity = new $entity_class();
+            $permissions = $entity->permissions;
         }
-        $description.= $d;
-      }
+
+        foreach ((array)$permissions as $a => $d) {
+            if ((($actions & $a) == $a) && $d != "") {
+                if ($description) {
+                    $description.= ",";
+                }
+                $description.= $d;
+            }
+        }
+
+        return $description;
     }
 
-    return $description;
-  }
-
-  function get_roles() {
-    return array("god"=>"Super User"
+    function get_roles()
+    {
+        return array("god"=>"Super User"
                 ,"admin"=>"Finance Admin"
                 ,"manage"=>"Project Manager"
                 ,"employee"=>"Employee"
                 ,"client"=>"Client");
-  }
-
+    }
 }
-
-
-
-?>

--- a/security/lib/role.inc.php
+++ b/security/lib/role.inc.php
@@ -3,47 +3,42 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class role extends db_entity {
-  public $data_table = "role";
-  public $key_field = "roleID";
-  public $data_fields = array("roleHandle"
+class role extends db_entity
+{
+    public $data_table = "role";
+    public $key_field = "roleID";
+    public $data_fields = array("roleHandle"
                              ,"roleName"
                              ,"roleLevel"
                              ,"roleSequence"
                              );
 
-  function get_roles_array($level="person") {
-    $rows = array();
-    $db = new db_alloc();
-    $q = prepare("SELECT * FROM role WHERE roleLevel = '%s' ORDER BY roleSequence",$level);
-    $db->query($q);
-    while ($row = $db->row()) {
-      $rows[$row["roleHandle"]] = $row["roleName"];
+    function get_roles_array($level = "person")
+    {
+        $rows = array();
+        $db = new db_alloc();
+        $q = prepare("SELECT * FROM role WHERE roleLevel = '%s' ORDER BY roleSequence", $level);
+        $db->query($q);
+        while ($row = $db->row()) {
+            $rows[$row["roleHandle"]] = $row["roleName"];
+        }
+        return $rows;
     }
-    return $rows;
-  }
-  
-
-
 }
-
-
-
-?>

--- a/security/permission.php
+++ b/security/permission.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -27,16 +27,16 @@ $permission = new permission();
 $permissionID = $_POST["permissionID"] or $permissionID = $_GET["permissionID"];
 
 if ($permissionID) {
-  $permission->set_id($permissionID);
-  $permission->select();
+    $permission->set_id($permissionID);
+    $permission->select();
 }
 
 $actions_array = $_POST["actions_array"];
 if (is_array($actions_array)) {
-  $actions = 0;
-  foreach($actions_array as $k => $a) {
-    $actions = $actions | $a;
-  }
+    $actions = 0;
+    foreach ($actions_array as $k => $a) {
+        $actions = $actions | $a;
+    }
 }
 
 $permission->read_globals();
@@ -44,39 +44,39 @@ $permission->set_values();
 
 
 if (!$permission->get_value("tableName")) {
-  global $modules;
-  $entities = array();
-  reset($modules);
-  while (list($module_name, $module) = each($modules)) {
-    $mod_entities = $module->db_entities;
-    $entities = array_merge($entities, $mod_entities);
-  }
+    global $modules;
+    $entities = array();
+    reset($modules);
+    while (list($module_name, $module) = each($modules)) {
+        $mod_entities = $module->db_entities;
+        $entities = array_merge($entities, $mod_entities);
+    }
 
-  $table_names = array();
-  reset($entities);
-  while (list(, $entity_name) = each($entities)) {
-    $entity = new $entity_name;
-    $table_names[] = $entity->data_table;
-  }
+    $table_names = array();
+    reset($entities);
+    while (list(, $entity_name) = each($entities)) {
+        $entity = new $entity_name;
+        $table_names[] = $entity->data_table;
+    }
 
-  $ops = $table_names;
-  asort($ops);
-  foreach ($ops as $v) {
-    $table_name_options[$v] = $v;
-  }
-  $TPL["tableNameOptions"] = page::select_options($table_name_options, $permission->get_value("tableName"));
-  include_template("templates/permissionTableM.tpl");
-  exit();
+    $ops = $table_names;
+    asort($ops);
+    foreach ($ops as $v) {
+        $table_name_options[$v] = $v;
+    }
+    $TPL["tableNameOptions"] = page::select_options($table_name_options, $permission->get_value("tableName"));
+    include_template("templates/permissionTableM.tpl");
+    exit();
 }
 
 if ($_POST["save"]) {
-  $permission->set_value("actions",$actions);
-  $permission->set_value("comment",rtrim($permission->get_value("comment")));
-  $permission->save();
-  alloc_redirect($TPL["url_alloc_permissionList"]);
+    $permission->set_value("actions", $actions);
+    $permission->set_value("comment", rtrim($permission->get_value("comment")));
+    $permission->save();
+    alloc_redirect($TPL["url_alloc_permissionList"]);
 } else if ($_POST["delete"]) {
-  $permission->delete();
-  alloc_redirect($TPL["url_alloc_permissionList"]);
+    $permission->delete();
+    alloc_redirect($TPL["url_alloc_permissionList"]);
 }
 
 // necessary
@@ -88,9 +88,9 @@ $table_name = $_POST["tableName"] or $table_name = $permission->get_value("table
 $entity = new $table_name;
 
 foreach ($entity->permissions as $value => $label) {
-  if (($permission->get_value("actions") & $value) == $value) {
-    $sel[] = $value;
-  }
+    if (($permission->get_value("actions") & $value) == $value) {
+        $sel[] = $value;
+    }
 }
 
 $TPL["actionOptions"] = page::select_options($entity->permissions, $sel);
@@ -98,5 +98,3 @@ $TPL["actionOptions"] = page::select_options($entity->permissions, $sel);
 $TPL["main_alloc_title"] = "Edit Permission - ".APPLICATION_NAME;
 
 include_template("templates/permissionM.tpl");
-
-?>

--- a/security/permissionList.php
+++ b/security/permissionList.php
@@ -3,48 +3,47 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function show_permission_list($template_name) {
-  global $TPL;
+function show_permission_list($template_name)
+{
+    global $TPL;
 
-  $roles = permission::get_roles();
+    $roles = permission::get_roles();
 
-  if ($_REQUEST["submit"] || $_REQUEST["filter"] != "") {
-    $where = " where tableName like '%".db_esc($_REQUEST["filter"])."%' ";   // TODO: Add filtering to permission list
-  }
-  $db = new db_alloc();
-  $db->query("SELECT * FROM permission $where ORDER BY tableName, sortKey");
-  while ($db->next_record()) {
-    $permission = new permission();
-    $permission->read_db_record($db);
-    $permission->set_values();
-    $TPL["actions"] = $permission->describe_actions();
-    $TPL["odd_even"] = $TPL["odd_even"] == "odd" ? "even" : "odd";
-    $TPL["roleName"] = $roles[$TPL["roleName"]];
-    include_template($template_name);
-  }
+    if ($_REQUEST["submit"] || $_REQUEST["filter"] != "") {
+        $where = " where tableName like '%".db_esc($_REQUEST["filter"])."%' ";   // TODO: Add filtering to permission list
+    }
+    $db = new db_alloc();
+    $db->query("SELECT * FROM permission $where ORDER BY tableName, sortKey");
+    while ($db->next_record()) {
+        $permission = new permission();
+        $permission->read_db_record($db);
+        $permission->set_values();
+        $TPL["actions"] = $permission->describe_actions();
+        $TPL["odd_even"] = $TPL["odd_even"] == "odd" ? "even" : "odd";
+        $TPL["roleName"] = $roles[$TPL["roleName"]];
+        include_template($template_name);
+    }
 }
 
 $TPL["main_alloc_title"] = "Permissions List - ".APPLICATION_NAME;
 
 include_template("templates/permissionListM.tpl");
-
-?>

--- a/services/json.php
+++ b/services/json.php
@@ -1,81 +1,78 @@
 <?php
 
-define("NO_AUTH",1); 
+define("NO_AUTH", 1);
 require_once("../alloc.php");
-singleton("errors_fatal",true);
-singleton("errors_format","text");
-singleton("errors_logged",false);
-singleton("errors_thrown",false);
-singleton("errors_haltdb",true);
+singleton("errors_fatal", true);
+singleton("errors_format", "text");
+singleton("errors_logged", false);
+singleton("errors_thrown", false);
+singleton("errors_haltdb", true);
 
 
-function g($var) {
-  $rtn = $_GET[$var] or $rtn = $_POST[$var] or $rtn = $_REQUEST[$var];
-  $var == "options"    and $rtn = alloc_json_decode($_POST[$var]); 
-  return $rtn;
+function g($var)
+{
+    $rtn = $_GET[$var] or $rtn = $_POST[$var] or $rtn = $_REQUEST[$var];
+    $var == "options"    and $rtn = alloc_json_decode($_POST[$var]);
+    return $rtn;
 }
 
 if (g("get_server_version")) {
-  die(alloc_json_encode(array("version"=>get_alloc_version())));
+    die(alloc_json_encode(array("version"=>get_alloc_version())));
 }
 
-if (!version_compare(g("client_version"),get_alloc_version(),">=")) {
-  die("Your alloc client needs to be upgraded.");
+if (!version_compare(g("client_version"), get_alloc_version(), ">=")) {
+    die("Your alloc client needs to be upgraded.");
 }
 
 $sessID = g("sessID");
 
 if (g("authenticate") && g("username") && g("password")) {
-  $sessID = services::authenticate(g("username"), g("password"));
-  die(alloc_json_encode(array("sessID"=>$sessID)));
+    $sessID = services::authenticate(g("username"), g("password"));
+    die(alloc_json_encode(array("sessID"=>$sessID)));
 }
 
 
 $services = new services($sessID);
 $current_user = &singleton("current_user");
 if (!$current_user || !is_object($current_user) || !$current_user->get_id()) {
-  die(alloc_json_encode(array("reauthenticate"=>"true")));
+    die(alloc_json_encode(array("reauthenticate"=>"true")));
 }
 
 
 if ($sessID) {
-  if (method_exists($services,g("method"))) {
+    if (method_exists($services, g("method"))) {
+        $modelReflector = new ReflectionClass('services');
+        $method = $modelReflector->getMethod(g("method"));
+        $parameters = $method->getParameters();
 
-    $modelReflector = new ReflectionClass('services');
-    $method = $modelReflector->getMethod(g("method"));
-    $parameters = $method->getParameters();
+        foreach ((array)$parameters as $v) {
+            $a[] = g((string)$v->name);
+        }
 
-    foreach ((array)$parameters as $v) {
-      $a[] = g((string)$v->name);
+        $method = g("method");
+
+      // Ouch
+        $n = count($parameters);
+        if ($n == 9) {
+            echo alloc_json_encode($services->$method($a[0], $a[1], $a[2], $a[3], $a[4], $a[5], $a[6], $a[7], $a[8]));
+        } else if ($n == 8) {
+            echo alloc_json_encode($services->$method($a[0], $a[1], $a[2], $a[3], $a[4], $a[5], $a[6], $a[7]));
+        } else if ($n == 7) {
+            echo alloc_json_encode($services->$method($a[0], $a[1], $a[2], $a[3], $a[4], $a[5], $a[6]));
+        } else if ($n == 6) {
+            echo alloc_json_encode($services->$method($a[0], $a[1], $a[2], $a[3], $a[4], $a[5]));
+        } else if ($n == 5) {
+            echo alloc_json_encode($services->$method($a[0], $a[1], $a[2], $a[3], $a[4]));
+        } else if ($n == 4) {
+            echo alloc_json_encode($services->$method($a[0], $a[1], $a[2], $a[3]));
+        } else if ($n == 3) {
+            echo alloc_json_encode($services->$method($a[0], $a[1], $a[2]));
+        } else if ($n == 2) {
+            echo alloc_json_encode($services->$method($a[0], $a[1]));
+        } else if ($n == 1) {
+            echo alloc_json_encode($services->$method($a[0]));
+        } else if ($n == 0) {
+            echo alloc_json_encode($services->$method());
+        }
     }
-
-    $method = g("method");
-
-    // Ouch
-    $n = count($parameters);
-    if ($n == 9) {
-      echo alloc_json_encode($services->$method($a[0],$a[1],$a[2],$a[3],$a[4],$a[5],$a[6],$a[7],$a[8]));
-    } else if ($n == 8) {
-      echo alloc_json_encode($services->$method($a[0],$a[1],$a[2],$a[3],$a[4],$a[5],$a[6],$a[7]));
-    } else if ($n == 7) {
-      echo alloc_json_encode($services->$method($a[0],$a[1],$a[2],$a[3],$a[4],$a[5],$a[6]));
-    } else if ($n == 6) {
-      echo alloc_json_encode($services->$method($a[0],$a[1],$a[2],$a[3],$a[4],$a[5]));
-    } else if ($n == 5) {
-      echo alloc_json_encode($services->$method($a[0],$a[1],$a[2],$a[3],$a[4]));
-    } else if ($n == 4) {
-      echo alloc_json_encode($services->$method($a[0],$a[1],$a[2],$a[3]));
-    } else if ($n == 3) {
-      echo alloc_json_encode($services->$method($a[0],$a[1],$a[2]));
-    } else if ($n == 2) {
-      echo alloc_json_encode($services->$method($a[0],$a[1]));
-    } else if ($n == 1) {
-      echo alloc_json_encode($services->$method($a[0]));
-    } else if ($n == 0) {
-      echo alloc_json_encode($services->$method());
-    }
-  }
 }
-
-
-?>

--- a/services/lib/init.php
+++ b/services/lib/init.php
@@ -3,25 +3,25 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class services_module extends module {
-  var $module = "services";
+class services_module extends module
+{
+    var $module = "services";
 }
-?>

--- a/services/lib/services.inc.php
+++ b/services/lib/services.inc.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -27,12 +27,14 @@
 * @author Alex Lance
 * @version 1.0
 */
-class services {
+class services
+{
 
-  public function __construct($sessID="") {
-    $current_user = $this->get_current_user($sessID);
-    singleton("current_user",$current_user);
-  }
+    public function __construct($sessID = "")
+    {
+        $current_user = $this->get_current_user($sessID);
+        singleton("current_user", $current_user);
+    }
 
   /**
   * Perform an authentication check, start a new session
@@ -40,44 +42,47 @@ class services {
   * @param string $password
   * @return string the session key
   */
-  public function authenticate($username,$password) {
-    $person = new person();
-    $sess = new session();
-    $row = $person->get_valid_login_row($username,$password); 
-    if ($row) {
-      $sess->Start($row,false);
-      $sess->UseGet();
-      $sess->Save();
-      return $sess->GetKey();
-    } else {
-      die("Authentication Failed(1)."); 
+    public function authenticate($username, $password)
+    {
+        $person = new person();
+        $sess = new session();
+        $row = $person->get_valid_login_row($username, $password);
+        if ($row) {
+            $sess->Start($row, false);
+            $sess->UseGet();
+            $sess->Save();
+            return $sess->GetKey();
+        } else {
+            die("Authentication Failed(1).");
+        }
     }
-  }  
 
-  private function get_current_user($sessID) {
-    $sess = new session($sessID);
-    if ($sess->Started()) {
-      $person = new person();
-      $person->load_current_user($sess->Get("personID"));
-      // update session_started, which affects session lifetime
-      $sess->Save();
-      return $person;
+    private function get_current_user($sessID)
+    {
+        $sess = new session($sessID);
+        if ($sess->Started()) {
+            $person = new person();
+            $person->load_current_user($sess->Get("personID"));
+          // update session_started, which affects session lifetime
+            $sess->Save();
+            return $person;
+        }
     }
-  }
 
   /**
   * Get all the commments on a task
   * @param string $taskID
   * @return array an array of comments
   */
-  public function get_task_comments($taskID) {
-    if ($taskID) {
-      $task = new task();
-      $task->set_id($taskID);
-      $task->select();
-      return $task->get_task_comments_array();
+    public function get_task_comments($taskID)
+    {
+        if ($taskID) {
+            $task = new task();
+            $task->set_id($taskID);
+            $task->select();
+            return $task->get_task_comments_array();
+        }
     }
-  }
 
   /**
   * Convert a comma separated string of names, into an array with email addresses
@@ -86,167 +91,169 @@ class services {
   * @param integer $entityID the id of the related entity
   * @return array an array of people, indexed by their email address
   */
-  public function get_people($options=array(), $entity="", $entityID="") {
-    $person_table =& get_cached_table("person");
-    $people = $options;
+    public function get_people($options = array(), $entity = "", $entityID = "")
+    {
+        $person_table =& get_cached_table("person");
+        $people = $options;
 
-    if ($entity && $entityID) {
-      $e = new $entity;
-      $e->set_id($entityID);
-      $e->select();
-      in_array("default",$people)  and $default_recipients  = $e->get_all_parties();
-      in_array("internal",$people) and $internal_recipients = $e->get_all_parties();
-    }
-
-    // remove default and internal from the array
-    $clean_people = array_diff($people, array("default", "internal"));
-
-    if (is_object($e)) {
-      $projectID = $e->get_project_id();
-      $p = new project();
-      $p->set_id($projectID);
-      $p->select();
-      $client = $p->get_foreign_object("client");
-      $clientID = $client->get_id();
-    }
-
-    foreach ((array)$default_recipients as $email => $info) {
-      if ($info["selected"]) {
-        $rtn[$email] = $this->reduce_person_info($info);
-      }
-    }
-
-    foreach ((array)$internal_recipients as $email => $info) {
-      if ($info["selected"] && !$info["external"]) {
-        $rtn[$email] = $this->reduce_person_info($info);
-      }
-    }
-
-    foreach ((array)$clean_people as $person) {
-      $bad_person = true;
-      $person = trim($person);
-
-      // personID
-      if (is_numeric($person)) {
-        if ($person_table[$person]["personActive"]) {
-          $rtn[$person_table[$person]["emailAddress"]] = $person_table[$person];
-          $bad_person = false;
-          continue;
+        if ($entity && $entityID) {
+            $e = new $entity;
+            $e->set_id($entityID);
+            $e->select();
+            in_array("default", $people)  and $default_recipients  = $e->get_all_parties();
+            in_array("internal", $people) and $internal_recipients = $e->get_all_parties();
         }
 
-      // email addresses
-      } else if (in_str("@",$person)) {
-        foreach ($person_table as $pid => $data) {
-          if (same_email_address($person,$data["emailAddress"]) && $data["personActive"]) {
-            $rtn[$data["emailAddress"]] = $data;
-            $bad_person = false;
-            continue 2;
-          }
+      // remove default and internal from the array
+        $clean_people = array_diff($people, array("default", "internal"));
+
+        if (is_object($e)) {
+            $projectID = $e->get_project_id();
+            $p = new project();
+            $p->set_id($projectID);
+            $p->select();
+            $client = $p->get_foreign_object("client");
+            $clientID = $client->get_id();
         }
+
+        foreach ((array)$default_recipients as $email => $info) {
+            if ($info["selected"]) {
+                $rtn[$email] = $this->reduce_person_info($info);
+            }
+        }
+
+        foreach ((array)$internal_recipients as $email => $info) {
+            if ($info["selected"] && !$info["external"]) {
+                $rtn[$email] = $this->reduce_person_info($info);
+            }
+        }
+
+        foreach ((array)$clean_people as $person) {
+            $bad_person = true;
+            $person = trim($person);
+
+          // personID
+            if (is_numeric($person)) {
+                if ($person_table[$person]["personActive"]) {
+                    $rtn[$person_table[$person]["emailAddress"]] = $person_table[$person];
+                    $bad_person = false;
+                    continue;
+                }
+
+              // email addresses
+            } else if (in_str("@", $person)) {
+                foreach ($person_table as $pid => $data) {
+                    if (same_email_address($person, $data["emailAddress"]) && $data["personActive"]) {
+                        $rtn[$data["emailAddress"]] = $data;
+                        $bad_person = false;
+                        continue 2;
+                    }
+                }
         
-        if ($ccID = clientContact::find_by_email($person)) {
-          $cc = new clientContact();
-          $cc->set_id($ccID);
-          $cc->select();
-          $rtn[$cc->get_value("clientContactEmail")] = $cc->row();
-          $bad_person = false;
-          continue;
+                if ($ccID = clientContact::find_by_email($person)) {
+                    $cc = new clientContact();
+                    $cc->set_id($ccID);
+                    $cc->select();
+                    $rtn[$cc->get_value("clientContactEmail")] = $cc->row();
+                    $bad_person = false;
+                    continue;
+                }
+
+                // If we get here, then return the email address entered
+                list($e, $n) = parse_email_address($person);
+                $rtn[$e] = array("emailAddress"=>$e, "name"=>$n);
+                $bad_person = false;
+                continue;
+
+              // usernames, partial and full names
+            } else {
+                foreach ($person_table as $pid => $data) {
+                  // If matches username
+                    if (strtolower($person) == strtolower($data["username"]) && $data["personActive"]) {
+                        $rtn[$data["emailAddress"]] = $data;
+                        $bad_person = false;
+                        continue 2;
+                    }
+                }
+                foreach ($person_table as $pid => $data) {
+                  // If matches name
+                    if (strtolower($person) == strtolower($data["firstName"]." ".$data["surname"]) && $data["personActive"]) {
+                        $rtn[$data["emailAddress"]] = $data;
+                        $bad_person = false;
+                        continue 2;
+                    }
+                }
+                foreach ($person_table as $pid => $data) {
+                  // If matches a section of name, eg: a search for "Ale" will match the full name "Alex Lance"
+                    if (strtolower($person) == strtolower(substr(strtolower($data["firstName"]." ".$data["surname"]), 0, strlen($person))) && $data["personActive"]) {
+                        $rtn[$data["emailAddress"]] = $data;
+                        $bad_person = false;
+                        continue 2;
+                    }
+                }
+
+                if ($ccID = clientContact::find_by_nick($person, $clientID)) {
+                    $cc = new clientContact();
+                    $cc->set_id($ccID);
+                    $cc->select();
+                    $rtn[$cc->get_value("clientContactEmail")] = $cc->row();
+                    $bad_person = false;
+                    continue;
+                }
+
+                if ($ccID = clientContact::find_by_name($person, $projectID)) {
+                    $cc = new clientContact();
+                    $cc->set_id($ccID);
+                    $cc->select();
+                    $rtn[$cc->get_value("clientContactEmail")] = $cc->row();
+                    $bad_person = false;
+                    continue;
+                }
+                if ($ccID = clientContact::find_by_partial_name($person, $projectID)) {
+                    $cc = new clientContact();
+                    $cc->set_id($ccID);
+                    $cc->select();
+                    $rtn[$cc->get_value("clientContactEmail")] = $cc->row();
+                    $bad_person = false;
+                    continue;
+                }
+            }
+
+            if ($bad_person) {
+                die("Unable to find person: ".$person);
+            }
         }
 
-        // If we get here, then return the email address entered
-        list($e, $n) = parse_email_address($person);
-        $rtn[$e] = array("emailAddress"=>$e, "name"=>$n);
-        $bad_person = false;
-        continue;
-
-      // usernames, partial and full names
-      } else {
-
-        foreach ($person_table as $pid => $data) {
-          // If matches username
-          if (strtolower($person) == strtolower($data["username"]) && $data["personActive"]) {
-            $rtn[$data["emailAddress"]] = $data;
-            $bad_person = false;
-            continue 2;
-          }
+        foreach ((array)$rtn as $id => $p) {
+            $rtn[$id] = $this->reduce_person_info($p);
         }
-        foreach ($person_table as $pid => $data) {
-          // If matches name
-          if (strtolower($person) == strtolower($data["firstName"]." ".$data["surname"]) && $data["personActive"]) {
-            $rtn[$data["emailAddress"]] = $data;
-            $bad_person = false;
-            continue 2;
-          }
-        }
-        foreach ($person_table as $pid => $data) {
-          // If matches a section of name, eg: a search for "Ale" will match the full name "Alex Lance"
-          if (strtolower($person) == strtolower(substr(strtolower($data["firstName"]." ".$data["surname"]),0,strlen($person))) && $data["personActive"]) {
-            $rtn[$data["emailAddress"]] = $data;
-            $bad_person = false;
-            continue 2;
-          }
-        }
-
-        if ($ccID = clientContact::find_by_nick($person,$clientID)) {
-          $cc = new clientContact();
-          $cc->set_id($ccID);
-          $cc->select();
-          $rtn[$cc->get_value("clientContactEmail")] = $cc->row();
-          $bad_person = false;
-          continue;
-        }
-
-        if ($ccID = clientContact::find_by_name($person,$projectID)) {
-          $cc = new clientContact();
-          $cc->set_id($ccID);
-          $cc->select();
-          $rtn[$cc->get_value("clientContactEmail")] = $cc->row();
-          $bad_person = false;
-          continue;
-        }
-        if ($ccID = clientContact::find_by_partial_name($person,$projectID)) {
-          $cc = new clientContact();
-          $cc->set_id($ccID);
-          $cc->select();
-          $rtn[$cc->get_value("clientContactEmail")] = $cc->row();
-          $bad_person = false;
-          continue;
-        }
-      }
-
-      if ($bad_person) {
-        die("Unable to find person: ".$person);
-      }
+        return (array)$rtn;
     }
 
-    foreach ((array)$rtn as $id => $p) {
-      $rtn[$id] = $this->reduce_person_info($p);
+    private function reduce_person_info($person)
+    {
+        $rtn["personID"] = $person["personID"];
+        $rtn["username"] = $person["username"];
+        $rtn["name"]     = $person["name"]             or $rtn["name"] = $person["clientContactName"];
+        $rtn["emailAddress"] = $person["emailAddress"] or $rtn["emailAddress"] = $person["clientContactEmail"] or $rtn["emailAddress"] = $person["email"];
+        $rtn["clientContactID"] = $person["clientContactID"];
+        return $rtn;
     }
-    return (array)$rtn;
-  }
-
-  private function reduce_person_info($person) {
-    $rtn["personID"] = $person["personID"];
-    $rtn["username"] = $person["username"];
-    $rtn["name"]     = $person["name"]             or $rtn["name"] = $person["clientContactName"];
-    $rtn["emailAddress"] = $person["emailAddress"] or $rtn["emailAddress"] = $person["clientContactEmail"] or $rtn["emailAddress"] = $person["email"];
-    $rtn["clientContactID"] = $person["clientContactID"];
-    return $rtn;
-  }
 
   /**
   * Add a timesheet item
   * @param array $options
   * @return string a success message
   */
-  public function add_timeSheetItem($options) {
-    $rtn = timeSheet::add_timeSheetItem($options);
-    if ($rtn["status"] == "yay") {
-      return $rtn["message"];
-    } else {
-      die(print_r($rtn,1));
+    public function add_timeSheetItem($options)
+    {
+        $rtn = timeSheet::add_timeSheetItem($options);
+        if ($rtn["status"] == "yay") {
+            return $rtn["message"];
+        } else {
+            die(print_r($rtn, 1));
+        }
     }
-  }
 
   /**
   * Move a time sheet to a different status
@@ -254,23 +261,25 @@ class services {
   * @param string $direction the direction to move the timesheet eg "forwards" or "backwards"
   * @return string a success message
   */
-  public function change_timeSheet_status($timeSheetID,$direction) {
-    $timeSheet = new timeSheet();
-    $timeSheet->set_id($timeSheetID);
-    $timeSheet->select();
-    $rtn = $timeSheet->change_status($direction);
-    $timeSheet->save();
-    return $rtn;
-  }
+    public function change_timeSheet_status($timeSheetID, $direction)
+    {
+        $timeSheet = new timeSheet();
+        $timeSheet->set_id($timeSheetID);
+        $timeSheet->select();
+        $rtn = $timeSheet->change_status($direction);
+        $timeSheet->save();
+        return $rtn;
+    }
 
   /**
   * Convert a tf from its name to its tf ID
   * @param mixed $name a tf name
   * @return integer the tf's ID
   */
-  public function get_tfID($options) {
-    return tf::get_tfID($options);
-  } 
+    public function get_tfID($options)
+    {
+        return tf::get_tfID($options);
+    }
 
   /**
   * Get a list of entities, eg one of: tasks, comments, timeSheets, projects et al. See also this::get_list_help()
@@ -278,46 +287,48 @@ class services {
   * @param array $options the various filter options to apply see: ${entity}/lib/${entity}.inc.php -> get_list_filter().
   * @return array the list of entities
   */
-  public function get_list($entity, $options=array()) {
-    $current_user = &singleton("current_user");
-    if (class_exists($entity)) {
-      $options = obj2array($options);
-      $e = new $entity;
-      if (method_exists($e, "get_list")) {
-        ob_start();
-        $rtn = $entity::get_list($options);
-        $echoed = ob_get_contents();
-        if (!$rtn && $echoed) {
-          return array("error"=>$echoed);
+    public function get_list($entity, $options = array())
+    {
+        $current_user = &singleton("current_user");
+        if (class_exists($entity)) {
+            $options = obj2array($options);
+            $e = new $entity;
+            if (method_exists($e, "get_list")) {
+                ob_start();
+                $rtn = $entity::get_list($options);
+                $echoed = ob_get_contents();
+                if (!$rtn && $echoed) {
+                    return array("error"=>$echoed);
+                } else {
+                    if (isset($rtn["rows"])) {
+                        return $rtn["rows"];
+                    } else {
+                        return $rtn;
+                    }
+                }
+            } else {
+                die("Entity method '".$entity."::get_list()' does not exist.");
+            }
         } else {
-          if (isset($rtn["rows"])) {
-            return $rtn["rows"];
-          } else {
-            return $rtn;
-          }
+            die("Entity '".$entity."' does not exist.");
         }
-      } else {
-        die("Entity method '".$entity."::get_list()' does not exist.");
-      }
-    } else {
-      die("Entity '".$entity."' does not exist."); 
     }
-  }
 
   /**
   * Run a search across all emails, using PHP's IMAP search syntax http://php.net/imap_search and RFC2060 6.4.4
   * @param string $str the search string
   * @return string of mbox format emails
   */
-  public function search_emails($str) {
-    if ($str) {
-      $uids = $this->get_comment_email_uids_search($str);
-      foreach ((array)$uids as $uid) {
-        $emails.= $this->get_email($uid);
-      }
+    public function search_emails($str)
+    {
+        if ($str) {
+            $uids = $this->get_comment_email_uids_search($str);
+            foreach ((array)$uids as $uid) {
+                $emails.= $this->get_email($uid);
+            }
+        }
+        return $emails;
     }
-    return $emails;
-  }
 
   /**
   * Grab all emails from a task mail box
@@ -325,189 +336,201 @@ class services {
   * @param string $entity the particular entity: task, client, project, etc
   * @return string of mbox format emails
   */
-  public function get_task_emails($taskID, $entity="task") {
-    $current_user = &singleton("current_user");
-    $entity or $entity = "task";
-    if ($taskID) {
-      $folder = config::get_config_item("allocEmailFolder")."/".$entity.$taskID;
-      $info = $this->init_email_info();
-      $mail = new email_receive($info);
-      $mail->open_mailbox($folder,OP_READONLY);
-      $uids = $mail->get_all_email_msg_uids();
-      foreach ((array)$uids as $uid) {
-        list($header,$body) = $mail->get_raw_email_by_msg_uid($uid);
-        if ($header && $body) {
-          $m = new email_send();
-          $m->set_headers($header);
-          $timestamp = $m->get_header('Date');
-          $str = "\r\nFrom allocPSA ".date('D M  j G:i:s Y',strtotime($timestamp))."\r\n".$header.$body;
-          $emails.= utf8_encode(str_replace("\r\n","\n",$str));
+    public function get_task_emails($taskID, $entity = "task")
+    {
+        $current_user = &singleton("current_user");
+        $entity or $entity = "task";
+        if ($taskID) {
+            $folder = config::get_config_item("allocEmailFolder")."/".$entity.$taskID;
+            $info = $this->init_email_info();
+            $mail = new email_receive($info);
+            $mail->open_mailbox($folder, OP_READONLY);
+            $uids = $mail->get_all_email_msg_uids();
+            foreach ((array)$uids as $uid) {
+                list($header,$body) = $mail->get_raw_email_by_msg_uid($uid);
+                if ($header && $body) {
+                    $m = new email_send();
+                    $m->set_headers($header);
+                    $timestamp = $m->get_header('Date');
+                    $str = "\r\nFrom allocPSA ".date('D M  j G:i:s Y', strtotime($timestamp))."\r\n".$header.$body;
+                    $emails.= utf8_encode(str_replace("\r\n", "\n", $str));
+                }
+            }
+            $mail->close();
         }
-      }
-      $mail->close();
+        return $emails;
     }
-    return $emails;
-  }
 
   /**
   * Get all time sheet item comments in a faked mbox format
   * @param integer $taskID which task the time sheet item comments relate to
   * @return string of mbox format emails
   */
-  public function get_timeSheetItem_comments($taskID) {
-    $people =& get_cached_table("person");
-    has("time") and $rows = timeSheetItem::get_timeSheetItemComments($taskID);
-    foreach ((array)$rows as $row) {
-      $d = $row["timeSheetItemCreatedTime"] or $d = $row["date"];
-      $timestamp = format_date("U",$d);
-      $name = $people[$row["personID"]]["name"];
-      $str.= $br."From allocPSA ".date('D M  j G:i:s Y',$timestamp);
-      $str.= "\nFrom: ".$name;
-      $str.= "\nDate: ".date("D, d M Y H:i:s O",$timestamp);
-      $str.= "\n\n".$name." ".$row["duration"]." ".$row["comment"];
-      $br = "\n\n";
-    } 
-    return $str;
-  }
-
-  private function init_email_info() {
-    $current_user = &singleton("current_user");
-    $info["host"] = config::get_config_item("allocEmailHost");
-    $info["port"] = config::get_config_item("allocEmailPort");
-    $info["username"] = config::get_config_item("allocEmailUsername");
-    $info["password"] = config::get_config_item("allocEmailPassword");
-    $info["protocol"] = config::get_config_item("allocEmailProtocol");
-    if (!$info["host"]) {
-      die("Email mailbox host not defined, assuming email fetch function is inactive.");
+    public function get_timeSheetItem_comments($taskID)
+    {
+        $people =& get_cached_table("person");
+        has("time") and $rows = timeSheetItem::get_timeSheetItemComments($taskID);
+        foreach ((array)$rows as $row) {
+            $d = $row["timeSheetItemCreatedTime"] or $d = $row["date"];
+            $timestamp = format_date("U", $d);
+            $name = $people[$row["personID"]]["name"];
+            $str.= $br."From allocPSA ".date('D M  j G:i:s Y', $timestamp);
+            $str.= "\nFrom: ".$name;
+            $str.= "\nDate: ".date("D, d M Y H:i:s O", $timestamp);
+            $str.= "\n\n".$name." ".$row["duration"]." ".$row["comment"];
+            $br = "\n\n";
+        }
+        return $str;
     }
-    return $info;
-  }
+
+    private function init_email_info()
+    {
+        $current_user = &singleton("current_user");
+        $info["host"] = config::get_config_item("allocEmailHost");
+        $info["port"] = config::get_config_item("allocEmailPort");
+        $info["username"] = config::get_config_item("allocEmailUsername");
+        $info["password"] = config::get_config_item("allocEmailPassword");
+        $info["protocol"] = config::get_config_item("allocEmailProtocol");
+        if (!$info["host"]) {
+            die("Email mailbox host not defined, assuming email fetch function is inactive.");
+        }
+        return $info;
+    }
 
   /**
   * Get a single email, add an mbox date header line
   * @param integer $emailUID the IMAP UID of an email
   * @return string a single email in mbox format
   */
-  public function get_email($emailUID) {
-    $current_user = &singleton("current_user");
-    //$lockfile = ATTACHMENTS_DIR."mail.lock.person_".$current_user->get_id();
-    if ($emailUID) {
-      $info = $this->init_email_info();
-      $mail = new email_receive($info);
-      $mail->open_mailbox(config::get_config_item("allocEmailFolder"),OP_READONLY);
-      list($header,$body) = $mail->get_raw_email_by_msg_uid($emailUID);
-      $mail->close();
-      $m = new email_send();
-      $m->set_headers($header);
-      $timestamp = $m->get_header('Date');
-      $str = "From allocPSA ".date('D M  j G:i:s Y',strtotime($timestamp))."\r\n".$header.$body;
-      return utf8_encode(str_replace("\r\n","\n",$str));
+    public function get_email($emailUID)
+    {
+        $current_user = &singleton("current_user");
+      //$lockfile = ATTACHMENTS_DIR."mail.lock.person_".$current_user->get_id();
+        if ($emailUID) {
+            $info = $this->init_email_info();
+            $mail = new email_receive($info);
+            $mail->open_mailbox(config::get_config_item("allocEmailFolder"), OP_READONLY);
+            list($header,$body) = $mail->get_raw_email_by_msg_uid($emailUID);
+            $mail->close();
+            $m = new email_send();
+            $m->set_headers($header);
+            $timestamp = $m->get_header('Date');
+            $str = "From allocPSA ".date('D M  j G:i:s Y', strtotime($timestamp))."\r\n".$header.$body;
+            return utf8_encode(str_replace("\r\n", "\n", $str));
+        }
     }
-  }
 
   /**
   * Get a list of IMAP email UIDs, based on a string search
   * @param string $str the search string
   * @return array an array of email UIDs
   */
-  public function get_comment_email_uids_search($str) {
-    if ($str) { 
-      $current_user = &singleton("current_user");
-      $info = $this->init_email_info();
-      $mail = new email_receive($info);
-      $mail->open_mailbox(config::get_config_item("allocEmailFolder"),OP_READONLY);
-      $rtn = $mail->get_emails_UIDs_search($str);
-      $mail->close();
+    public function get_comment_email_uids_search($str)
+    {
+        if ($str) {
+            $current_user = &singleton("current_user");
+            $info = $this->init_email_info();
+            $mail = new email_receive($info);
+            $mail->open_mailbox(config::get_config_item("allocEmailFolder"), OP_READONLY);
+            $rtn = $mail->get_emails_UIDs_search($str);
+            $mail->close();
+        }
+        return (array)$rtn;
     }
-    return (array)$rtn;
-  }
 
   /**
   * A now defunct method to obtain help about this class
   * @param string $topic the name of the class method, eg "get_list"
   * @return string the help information
   */
-  public function get_help($topic="") {
-    $this_methods = get_class_methods($this);
+    public function get_help($topic = "")
+    {
+        $this_methods = get_class_methods($this);
 
-    if (!$topic) {
-      foreach ($this_methods as $method) {
-        $m = $method."_help";
-        if (method_exists($this,$m)) {
-          $available_topics.= $commar.$method;
-          $commar = ", ";
+        if (!$topic) {
+            foreach ($this_methods as $method) {
+                $m = $method."_help";
+                if (method_exists($this, $m)) {
+                    $available_topics.= $commar.$method;
+                    $commar = ", ";
+                }
+            }
+            die("Help is available for the following methods: ".$available_topics);
+        } else {
+            $m = $topic."_help";
+            if (method_exists($this, $m)) {
+                return $this->$m();
+            } else {
+                die("No help exists for this method: ".$topic);
+            }
         }
-      }
-      die("Help is available for the following methods: ".$available_topics);
-
-    } else {
-      $m = $topic."_help";
-      if (method_exists($this,$m)) {
-        return $this->$m();
-      } else {
-        die("No help exists for this method: ".$topic); 
-      }
     }
-  }
 
   /**
   * Add an interested party
   * @param array $options see shared/lib/interestedParty.inc.php [add|delete]_interested_party()
   */
-  public function save_interestedParty($options) {
-    // Python will submit None instead of ''
-    foreach ($options as $k=>$v) { strtolower($v) != 'none' and $data[$k] = $v; }
+    public function save_interestedParty($options)
+    {
+      // Python will submit None instead of ''
+        foreach ($options as $k => $v) {
+            strtolower($v) != 'none' and $data[$k] = $v;
+        }
 
-    // Check we have the minimum of fields
-    if ($data["entity"] && $data["entityID"] && $data["emailAddress"]) {
-      interestedParty::delete_interested_party($data["entity"],$data["entityID"],$data["emailAddress"]);
-      interestedParty::add_interested_party($data);
+      // Check we have the minimum of fields
+        if ($data["entity"] && $data["entityID"] && $data["emailAddress"]) {
+            interestedParty::delete_interested_party($data["entity"], $data["entityID"], $data["emailAddress"]);
+            interestedParty::add_interested_party($data);
+        }
     }
-  }
 
   /**
   * Deactivate (not delete) an interested party
   * @param array $options see shared/lib/interestedParty.inc.php [add|delete]_interested_party()
   */
-  public function delete_interestedParty($options) {
-    // Python will submit None instead of ''
-    foreach ($options as $k=>$v) { strtolower($v) != 'none' and $data[$k] = $v; }
+    public function delete_interestedParty($options)
+    {
+      // Python will submit None instead of ''
+        foreach ($options as $k => $v) {
+            strtolower($v) != 'none' and $data[$k] = $v;
+        }
 
-    // Delete existing entries
-    if ($data["entity"] && $data["entityID"] && $data["emailAddress"]) {
-      interestedParty::delete_interested_party($data["entity"],$data["entityID"],$data["emailAddress"]);
+      // Delete existing entries
+        if ($data["entity"] && $data["entityID"] && $data["emailAddress"]) {
+            interestedParty::delete_interested_party($data["entity"], $data["entityID"], $data["emailAddress"]);
+        }
     }
-  }
 
   /**
   * An introspective method to display all the various get_list options across all the different entities
   * @return string the help text
   */
-  private function get_list_help() {
-    global $modules;
-    foreach ($modules as $name => $object) {  
-      if (is_object($object) && is_array($object->db_entities)) {
-        foreach ($object->db_entities as $entity) {
-          unset($commar2);
-          if (class_exists($entity)) {
-            $e = new $entity;
-            if (method_exists($e, "get_list")) {
-              $rtn.= "\n\nEntity: ".$entity."\nOptions:\n";
-              if (method_exists($e, "get_list_vars")) {
-                $options = $entity::get_list_vars();
-                foreach ($options as $option=>$help) {
-                  $padding = 30 - strlen($option);
-                  $rtn.= $commar2."    ".$option.str_repeat(" ",$padding).$help;
-                  $commar2 = "\n";
+    private function get_list_help()
+    {
+        global $modules;
+        foreach ($modules as $name => $object) {
+            if (is_object($object) && is_array($object->db_entities)) {
+                foreach ($object->db_entities as $entity) {
+                    unset($commar2);
+                    if (class_exists($entity)) {
+                        $e = new $entity;
+                        if (method_exists($e, "get_list")) {
+                            $rtn.= "\n\nEntity: ".$entity."\nOptions:\n";
+                            if (method_exists($e, "get_list_vars")) {
+                                  $options = $entity::get_list_vars();
+                                foreach ($options as $option => $help) {
+                                    $padding = 30 - strlen($option);
+                                    $rtn.= $commar2."    ".$option.str_repeat(" ", $padding).$help;
+                                    $commar2 = "\n";
+                                }
+                            }
+                        }
+                    }
                 }
-              }
             }
-          }
         }
-      }
+        die("Usage: get_list(entity, options). The following entities are available: ".$rtn);
     }
-    die("Usage: get_list(entity, options). The following entities are available: ".$rtn);
-  }
 
   /**
   * A generic method to edit entities
@@ -516,16 +539,14 @@ class services {
   * @param array $options the edit options see email/lib/command.inc.php for the various options
   * @return array success or failure object
   */
-  public function edit_entity($entity,$id,$options=false) {
-    $options[$entity] = $id;
-    if (strtolower($options[$entity]) == "help") {
-      return array("status"=>"msg","message"=>command::get_help($entity));
-    } else if ($options) {
-      $command = new command();
-      return $command->run_commands($options);
+    public function edit_entity($entity, $id, $options = false)
+    {
+        $options[$entity] = $id;
+        if (strtolower($options[$entity]) == "help") {
+            return array("status"=>"msg","message"=>command::get_help($entity));
+        } else if ($options) {
+            $command = new command();
+            return $command->run_commands($options);
+        }
     }
-  }
-
-} 
-
-?>
+}

--- a/shared/del_attachment.php
+++ b/shared/del_attachment.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -28,31 +28,28 @@ $id = $_GET["id"] or $id = $_POST["id"];
 $file = $_GET["file"] or $file = $_POST["file"];
 $entity = $_GET["entity"] or $entity = $_POST["entity"];
 
-$id = sprintf("%d",$id);
+$id = sprintf("%d", $id);
 
 
 
-if ($id && $file 
-&& !preg_match("/\.\./",$file) && !preg_match("/\//",$file)
-&& !preg_match("/\.\./",$entity) && !preg_match("/\//",$entity)) {
+if ($id && $file
+&& !preg_match("/\.\./", $file) && !preg_match("/\//", $file)
+&& !preg_match("/\.\./", $entity) && !preg_match("/\//", $entity)) {
+    $e = new $entity;
+    $e->set_id($id);
+    $e->select();
 
-  $e = new $entity;
-  $e->set_id($id);
-  $e->select();
+    $dir = ATTACHMENTS_DIR.$entity.DIRECTORY_SEPARATOR.$id.DIRECTORY_SEPARATOR;
+    $file = $dir.$file;
 
-  $dir = ATTACHMENTS_DIR.$entity.DIRECTORY_SEPARATOR.$id.DIRECTORY_SEPARATOR;
-  $file = $dir.$file;
-
-  if ($e->has_attachment_permission_delete($current_user) && file_exists($file)) {
-    if (dirname($file) == dirname($dir.".")) { // last check
-      unlink($file);
-      alloc_redirect($TPL["url_alloc_".$entity].$entity."ID=".$id."&sbs_link=attachments");
-      exit();
+    if ($e->has_attachment_permission_delete($current_user) && file_exists($file)) {
+        if (dirname($file) == dirname($dir.".")) { // last check
+            unlink($file);
+            alloc_redirect($TPL["url_alloc_".$entity].$entity."ID=".$id."&sbs_link=attachments");
+            exit();
+        }
     }
-  }
 }
 
 // return by default
 alloc_redirect($TPL["url_alloc_".$entity].$entity."ID=".$id."&sbs_link=attachments");
-
-?>

--- a/shared/get_attachment.php
+++ b/shared/get_attachment.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -27,39 +27,34 @@ require_once("../alloc.php");
 $file = $_GET["file"];
 
 if (isset($_GET["id"]) && $file && !bad_filename($file)) {
+    $entity = new $_GET["entity"];
+    $entity->set_id(sprintf("%d", $_GET["id"]));
+    $entity->select();
 
-  $entity = new $_GET["entity"];
-  $entity->set_id(sprintf("%d",$_GET["id"]));
-  $entity->select();
+    $file = ATTACHMENTS_DIR.$_GET["entity"]."/".$_GET["id"]."/".$file;
 
-  $file = ATTACHMENTS_DIR.$_GET["entity"]."/".$_GET["id"]."/".$file;
+    if ($entity->has_attachment_permission($current_user)) {
+        if (file_exists($file)) {
+            $fp = fopen($file, "rb");
+            $mimetype = get_mimetype($file);
 
-  if ($entity->has_attachment_permission($current_user)) {
-    if (file_exists($file)) {
-      $fp = fopen($file, "rb");
-      $mimetype = get_mimetype($file);
+          // Forge html for the whatsnew files
+            if (basename(dirname(dirname($file))) == "whatsnew") {
+                $forged_suffix = ".html";
+                $mimetype="text/html";
+            }
 
-      // Forge html for the whatsnew files
-      if (basename(dirname(dirname($file))) == "whatsnew") {
-        $forged_suffix = ".html";
-        $mimetype="text/html";
-      }
-
-      header('Content-Type: '.$mimetype);
-      header("Content-Length: ".filesize($file));
-      header('Content-Disposition: inline; filename="'.basename($file).$forged_suffix.'"');
-      fpassthru($fp);
-      exit;
+            header('Content-Type: '.$mimetype);
+            header("Content-Length: ".filesize($file));
+            header('Content-Disposition: inline; filename="'.basename($file).$forged_suffix.'"');
+            fpassthru($fp);
+            exit;
+        } else {
+            echo "File not found.";
+            exit;
+        }
     } else {
-      echo "File not found.";
-      exit;
+        echo "Permission denied.";
+        exit;
     }
-  } else {
-    echo "Permission denied.";
-    exit;
-  }
 }
-
-
-
-?>

--- a/shared/get_export.php
+++ b/shared/get_export.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -26,19 +26,19 @@
 require_once("../alloc.php");
 
 if (isset($_GET["id"]) && isset($_GET["entity"])) {
-  switch($_GET["entity"]) {
-    case "project":
-    switch($_GET["format"]) {
-      case "planner":
-        header('Content-Type: application/xml');
-        header('Content-Disposition: attachment; filename="allocProject.planner"');
-        echo export_gnome_planner(intval($_GET["id"]));
-      break;
-      case "csv":
-        header('Content-Type: text/plain');
-        header('Content-Disposition: attachment; filename="allocProject.csv"');
-        echo export_csv(intval($_GET["id"]));
+    switch ($_GET["entity"]) {
+        case "project":
+            switch ($_GET["format"]) {
+                case "planner":
+                    header('Content-Type: application/xml');
+                    header('Content-Disposition: attachment; filename="allocProject.planner"');
+                    echo export_gnome_planner(intval($_GET["id"]));
+                    break;
+                case "csv":
+                    header('Content-Type: text/plain');
+                    header('Content-Disposition: attachment; filename="allocProject.csv"');
+                    echo export_csv(intval($_GET["id"]));
+            }
+            break;
     }
-    break;
-  }
 }

--- a/shared/get_mime_part.php
+++ b/shared/get_mime_part.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -25,33 +25,29 @@
 require_once("../alloc.php");
 
 if (isset($_GET["id"]) && $_GET["part"]) {
-  $comment = new comment();
-  $comment->set_id($_GET["id"]);
-  $comment->select() or die("Bad _GET[id]");
-  list($mail,$text,$mimebits) = $comment->find_email(false,true);
-  if (!$mail) {
-    list($mail,$text,$mimebits) = $comment->find_email(false,true,true);
-  }
-
-  if ($comment->has_attachment_permission($current_user)) {
-    foreach((array)$mimebits as $bit) {
-      if ($bit["part"] == $_GET["part"]) {
-        $thing = $bit["blob"];
-        $filename = $bit["name"];
-        break;
-      }   
+    $comment = new comment();
+    $comment->set_id($_GET["id"]);
+    $comment->select() or die("Bad _GET[id]");
+    list($mail,$text,$mimebits) = $comment->find_email(false, true);
+    if (!$mail) {
+        list($mail,$text,$mimebits) = $comment->find_email(false, true, true);
     }
-    header('Content-Type: '.$mimetype);
-    header("Content-Length: ".strlen($thing));
-    header('Content-Disposition: inline; filename="'.basename($filename).'"');
-    echo $thing;
-    exit;
-  } else {
-    echo "Permission denied.";
-    exit;
-  }
+
+    if ($comment->has_attachment_permission($current_user)) {
+        foreach ((array)$mimebits as $bit) {
+            if ($bit["part"] == $_GET["part"]) {
+                $thing = $bit["blob"];
+                $filename = $bit["name"];
+                break;
+            }
+        }
+        header('Content-Type: '.$mimetype);
+        header("Content-Length: ".strlen($thing));
+        header('Content-Disposition: inline; filename="'.basename($filename).'"');
+        echo $thing;
+        exit;
+    } else {
+        echo "Permission denied.";
+        exit;
+    }
 }
-
-
-
-?>

--- a/shared/global_tpl_values.inc.php
+++ b/shared/global_tpl_values.inc.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,8 +23,9 @@
 
 
 // This file basically provides static template values that are used throughout the application and is included by alloc.php
-function get_alloc_urls($TPL,$sess=false) {
-$alloc_urls = array(
+function get_alloc_urls($TPL, $sess = false)
+{
+    $alloc_urls = array(
              "url_alloc_logout"                         => "login/logout.php"
             ,"url_alloc_home"                           => "home/home.php"
             ,"url_alloc_history"                        => "home/history.php"
@@ -71,7 +72,7 @@ $alloc_urls = array(
             ,"url_alloc_updatePersonList"               => "task/updatePersonList.php"
             ,"url_alloc_updateManagerPersonList"        => "task/updateManagerPersonList.php"
             ,"url_alloc_updateEstimatorPersonList"      => "task/updateEstimatorPersonList.php"
- 	          ,"url_alloc_updateTaskDupes"                => "task/updateTaskDupes.php"
+              ,"url_alloc_updateTaskDupes"                => "task/updateTaskDupes.php"
 
             ,"url_alloc_comment"                        => "comment/comment.php"
             ,"url_alloc_commentSummary"                 => "comment/summary.php"
@@ -79,7 +80,7 @@ $alloc_urls = array(
             ,"url_alloc_downloadComments"               => "email/downloadComments.php"
             ,"url_alloc_client"                         => "client/client.php"
             ,"url_alloc_clientList"                     => "client/clientList.php"
- 	          ,"url_alloc_updateClientDupes"              => "client/updateClientDupes.php"
+              ,"url_alloc_updateClientDupes"              => "client/updateClientDupes.php"
             ,"url_alloc_personList"                     => "person/personList.php"
             ,"url_alloc_personSkillAdd"                 => "person/personSkillAdd.php"
             ,"url_alloc_person"                         => "person/person.php"
@@ -158,16 +159,14 @@ $alloc_urls = array(
             ,"url_alloc_fileDownload"                   => "wiki/fileDownload.php"
             ,"url_alloc_directory"                      => "wiki/directory.php"
 
-);
+    );
 
-  foreach ($alloc_urls as $k=>$v) {
-    if (is_object($sess)) {
-      $TPL[$k] = $sess->url(SCRIPT_PATH.$v);
-    } else {
-      $TPL[$k] = SCRIPT_PATH.$v;
+    foreach ($alloc_urls as $k => $v) {
+        if (is_object($sess)) {
+            $TPL[$k] = $sess->url(SCRIPT_PATH.$v);
+        } else {
+            $TPL[$k] = SCRIPT_PATH.$v;
+        }
     }
-  }
-  return $TPL;
+    return $TPL;
 }
-
-?>

--- a/shared/lib/db.inc.php
+++ b/shared/lib/db.inc.php
@@ -3,381 +3,415 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 // DB abstraction
-class db {
+class db
+{
 
-  var $username;
-  var $password;
-  var $hostname;
-  var $database;
-  var $pdo;
-  var $pdo_statement;
-  var $row = array();
-  var $error;
-  public static $started_transaction = false;
-  public static $stop_doing_queries = false;
+    var $username;
+    var $password;
+    var $hostname;
+    var $database;
+    var $pdo;
+    var $pdo_statement;
+    var $row = array();
+    var $error;
+    public static $started_transaction = false;
+    public static $stop_doing_queries = false;
 
-  function __construct($username="",$password="",$hostname="",$database="") { // Constructor
-    $this->username = $username;
-    $this->password = $password;
-    $this->hostname = $hostname;
-    $this->database = $database;
-  }
-
-  function connect($force=false) {
-    if ($force || !isset($this->pdo)) { 
-      $this->hostname and $h = "host=".$this->hostname.";";
-      $this->database and $d = "dbname=".$this->database.";";
-      try {
-        $this->pdo = new PDO(sprintf('mysql:%s%scharset=UTF8',$h,$d), $this->username, $this->password);
-        $this->pdo->exec("SET CHARACTER SET utf8");
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        return true;
-      } catch (PDOException $e) {
-        $this->error("Unable to connect to database: ".$e->getMessage());
-      }
+    function __construct($username = "", $password = "", $hostname = "", $database = "")
+    {
+ // Constructor
+        $this->username = $username;
+        $this->password = $password;
+        $this->hostname = $hostname;
+        $this->database = $database;
     }
-  } 
 
-  function start_transaction() {
-    $this->connect();
-    $this->pdo->beginTransaction();
-    self::$started_transaction = true;
-  }
-
-  function commit() {
-    if (self::$started_transaction && is_object($this->pdo)) {
-      $rtn = $this->pdo->commit();
-      if (!$rtn) {
-        $this->error("Couldn't commit db transaction.");
-      }
+    function connect($force = false)
+    {
+        if ($force || !isset($this->pdo)) {
+            $this->hostname and $h = "host=".$this->hostname.";";
+            $this->database and $d = "dbname=".$this->database.";";
+            try {
+                $this->pdo = new PDO(sprintf('mysql:%s%scharset=UTF8', $h, $d), $this->username, $this->password);
+                $this->pdo->exec("SET CHARACTER SET utf8");
+                $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+                return true;
+            } catch (PDOException $e) {
+                $this->error("Unable to connect to database: ".$e->getMessage());
+            }
+        }
     }
-  }
 
-  function rollback() {
-    if (self::$started_transaction) {
-      self::$started_transaction = false;
-      try {
-        $this->pdo->rollBack();
-      } catch (Exception $e) {
-        return false;
-      }
+    function start_transaction()
+    {
+        $this->connect();
+        $this->pdo->beginTransaction();
+        self::$started_transaction = true;
     }
-  }
 
-  function error($msg=false,$errno=false) {
-    if ($errno == 1451 || $errno == 1217) { 
-      $m = "Error: ".$errno." There are other records in the database that depend on the item you just tried to delete. 
+    function commit()
+    {
+        if (self::$started_transaction && is_object($this->pdo)) {
+            $rtn = $this->pdo->commit();
+            if (!$rtn) {
+                $this->error("Couldn't commit db transaction.");
+            }
+        }
+    }
+
+    function rollback()
+    {
+        if (self::$started_transaction) {
+            self::$started_transaction = false;
+            try {
+                $this->pdo->rollBack();
+            } catch (Exception $e) {
+                return false;
+            }
+        }
+    }
+
+    function error($msg = false, $errno = false)
+    {
+        if ($errno == 1451 || $errno == 1217) {
+            $m = "Error: ".$errno." There are other records in the database that depend on the item you just tried to delete. 
             Remove those other records first and then try to delete this item again. 
             <br><br>".$msg;
-
-    } else if ($errno == 1216) {
-      $m = "Error: ".$errno." The parent record of the item you just tried to create does not exist in the database. 
+        } else if ($errno == 1216) {
+            $m = "Error: ".$errno." The parent record of the item you just tried to create does not exist in the database. 
             Create that other record first and then try to create this item again. 
             <br><br>".$msg;
-
-    } else if (preg_match("/(ALLOC ERROR:([^']*)')/m",$msg,$matches)) {
-      $m = "Error: ".$matches[2];
-
-    } else if ($msg) {
-      $m = "Error: ".$msg;
-    }
-
-    if ($m) {
-      alloc_error($m);
-    }
-
-    $this->error = $msg;
-  }
-
-  function get_error() {
-    return trim($this->error);
-  }
-
-  function get_insert_id() {
-    return $this->pdo->lastInsertId();
-  }
-  
-  function esc($str) {
-    if (is_numeric($str)) {
-      return $str;
-    }
-    if (!isset($this->pdo)) {
-      $this->connect();
-    }
-    $v = $this->pdo->quote($str);
-    substr($v,-1) == "'" and $v = substr($v,0,-1);
-    substr($v,0,1) == "'" and $v = substr($v,1);
-    return $v;
-  }
-
-  function select_db($db="") { 
-    // Select a database
-    $this->database = $db;
-    return $this->connect(true);
-  } 
-
-  function qr() {
-    // Quick Row run it like this:
-    // $row = $db->qr("SELECT * FROM hey WHERE heyID = %d",$heyID);
-    // arguments will be automatically escaped
-    $args = func_get_args();
-    $query = $this->get_escaped_query_str($args);
-    $id = $this->query($query);
-    return $this->row($id);
-  }
-
-  private function _query($query) {
-    if (!self::$stop_doing_queries || $query == "ROLLBACK") {
-      try {
-        return $this->pdo->query($query);
-      } catch (PDOException $e) {
-        $this->error("Error executing query: ".$e->getMessage());
-      }
-    }
-  }
-
-  function query() {
-    global $TPL;
-    $current_user = &singleton("current_user");
-    $start = microtime();
-    $this->connect();
-    $args = func_get_args();
-    $query = $this->get_escaped_query_str($args);
-
-    if ($query && !self::$stop_doing_queries) {
-
-      if (is_object($current_user) && method_exists($current_user,"get_id") && $current_user->get_id()) {
-        $this->_query(prepare("SET @personID = %d",$current_user->get_id()));
-      } else {
-        $this->_query("SET @personID = NULL");
-      }
-
-      $rtn = $this->_query($query);
-
-      if (!$rtn) {
-        $info = $this->pdo->errorInfo();
-        $this->error("Query failed: ".$info[0]." ".$info[1]."\n".$query, $info[2]);
-        $this->rollback();
-        unset($this->pdo_statement);
-
-      } else {
-        $this->pdo_statement = $rtn;
-        $this->error();
-      }
-    }
-
-    $result = timetook($start,false);
-    if ($result > $TPL["slowest_query_time"]) {
-      $TPL["slowest_query"] = $query;
-      $TPL["slowest_query_time"] = $result;
-    }
-    $TPL["all_page_queries"][] = array("time"=>$result, "query"=>$query);
-    return $rtn;
-  } 
-
-  function num($pdo_statement="") {
-    $pdo_statement or $pdo_statement = $this->pdo_statement;
-    return $pdo_statement->rowCount();
-  } 
-
-  function num_rows($pdo_statement="") {
-    return $this->num($pdo_statement);
-  } 
-
-  function row($pdo_statement="",$method=PDO::FETCH_ASSOC) { 
-    if (!self::$stop_doing_queries) {
-      $pdo_statement or $pdo_statement = $this->pdo_statement;
-      if ($pdo_statement) {
-        unset($this->row);
-        if (isset($this->pos)) {
-          $this->row = $pdo_statement->fetch($method,PDO::FETCH_ORI_ABS,$this->pos);
-          unset($this->pos);
-        } else {
-          $this->row = $pdo_statement->fetch($method,PDO::FETCH_ORI_NEXT);
+        } else if (preg_match("/(ALLOC ERROR:([^']*)')/m", $msg, $matches)) {
+            $m = "Error: ".$matches[2];
+        } else if ($msg) {
+            $m = "Error: ".$msg;
         }
-        return $this->row;
-      }
+
+        if ($m) {
+            alloc_error($m);
+        }
+
+        $this->error = $msg;
     }
-  } 
+
+    function get_error()
+    {
+        return trim($this->error);
+    }
+
+    function get_insert_id()
+    {
+        return $this->pdo->lastInsertId();
+    }
+  
+    function esc($str)
+    {
+        if (is_numeric($str)) {
+            return $str;
+        }
+        if (!isset($this->pdo)) {
+            $this->connect();
+        }
+        $v = $this->pdo->quote($str);
+        substr($v, -1) == "'" and $v = substr($v, 0, -1);
+        substr($v, 0, 1) == "'" and $v = substr($v, 1);
+        return $v;
+    }
+
+    function select_db($db = "")
+    {
+      // Select a database
+        $this->database = $db;
+        return $this->connect(true);
+    }
+
+    function qr()
+    {
+      // Quick Row run it like this:
+      // $row = $db->qr("SELECT * FROM hey WHERE heyID = %d",$heyID);
+      // arguments will be automatically escaped
+        $args = func_get_args();
+        $query = $this->get_escaped_query_str($args);
+        $id = $this->query($query);
+        return $this->row($id);
+    }
+
+    private function _query($query)
+    {
+        if (!self::$stop_doing_queries || $query == "ROLLBACK") {
+            try {
+                return $this->pdo->query($query);
+            } catch (PDOException $e) {
+                $this->error("Error executing query: ".$e->getMessage());
+            }
+        }
+    }
+
+    function query()
+    {
+        global $TPL;
+        $current_user = &singleton("current_user");
+        $start = microtime();
+        $this->connect();
+        $args = func_get_args();
+        $query = $this->get_escaped_query_str($args);
+
+        if ($query && !self::$stop_doing_queries) {
+            if (is_object($current_user) && method_exists($current_user, "get_id") && $current_user->get_id()) {
+                $this->_query(prepare("SET @personID = %d", $current_user->get_id()));
+            } else {
+                $this->_query("SET @personID = NULL");
+            }
+
+            $rtn = $this->_query($query);
+
+            if (!$rtn) {
+                $info = $this->pdo->errorInfo();
+                $this->error("Query failed: ".$info[0]." ".$info[1]."\n".$query, $info[2]);
+                $this->rollback();
+                unset($this->pdo_statement);
+            } else {
+                $this->pdo_statement = $rtn;
+                $this->error();
+            }
+        }
+
+        $result = timetook($start, false);
+        if ($result > $TPL["slowest_query_time"]) {
+            $TPL["slowest_query"] = $query;
+            $TPL["slowest_query_time"] = $result;
+        }
+        $TPL["all_page_queries"][] = array("time"=>$result, "query"=>$query);
+        return $rtn;
+    }
+
+    function num($pdo_statement = "")
+    {
+        $pdo_statement or $pdo_statement = $this->pdo_statement;
+        return $pdo_statement->rowCount();
+    }
+
+    function num_rows($pdo_statement = "")
+    {
+        return $this->num($pdo_statement);
+    }
+
+    function row($pdo_statement = "", $method = PDO::FETCH_ASSOC)
+    {
+        if (!self::$stop_doing_queries) {
+            $pdo_statement or $pdo_statement = $this->pdo_statement;
+            if ($pdo_statement) {
+                unset($this->row);
+                if (isset($this->pos)) {
+                    $this->row = $pdo_statement->fetch($method, PDO::FETCH_ORI_ABS, $this->pos);
+                    unset($this->pos);
+                } else {
+                    $this->row = $pdo_statement->fetch($method, PDO::FETCH_ORI_NEXT);
+                }
+                return $this->row;
+            }
+        }
+    }
 
   // DEPRECATED
-  function next_record() {
-    return $this->row();
-  }
+    function next_record()
+    {
+        return $this->row();
+    }
 
-  function f($name) {
-    return $this->row[$name];
-  }
+    function f($name)
+    {
+        return $this->row[$name];
+    }
 
   // Return true if a particular table exists
-  function table_exists($table,$db="") {
-    $db or $db = $this->database;
-    $prev_db = $this->database;
-    $this->select_db($db);
-    $query = prepare('SHOW TABLES LIKE "%s"',$table);
-    $this->query($query);
-    while ($row = $this->row($this->pdo_statement,PDO::FETCH_NUM)) {
-      if ($row[0] == $table) $yep = true;
+    function table_exists($table, $db = "")
+    {
+        $db or $db = $this->database;
+        $prev_db = $this->database;
+        $this->select_db($db);
+        $query = prepare('SHOW TABLES LIKE "%s"', $table);
+        $this->query($query);
+        while ($row = $this->row($this->pdo_statement, PDO::FETCH_NUM)) {
+            if ($row[0] == $table) {
+                $yep = true;
+            }
+        }
+        $this->select_db($prev_db);
+        return $yep;
     }
-    $this->select_db($prev_db);
-    return $yep;
-  }
 
-  function get_table_fields($table) {
-    static $fields;
+    function get_table_fields($table)
+    {
+        static $fields;
 
-    if ($fields[$table]) {
-      return $fields[$table];
+        if ($fields[$table]) {
+            return $fields[$table];
+        }
+        $database = $this->database;
+        if (strstr($table, ".")) {
+            list($database,$table) = explode(".", $table);
+        }
+        $this->query("SHOW COLUMNS FROM ".$table);
+        while ($row = $this->row()) {
+            $fields[$table][] = $row["Field"];
+        }
+        $fields[$table] or $fields[$table] = array();
+        return $fields[$table];
     }
-    $database = $this->database;
-    if (strstr($table,".")) {
-      list($database,$table) = explode(".",$table);
-    }
-    $this->query("SHOW COLUMNS FROM ".$table);
-    while ($row = $this->row()) {
-      $fields[$table][] = $row["Field"];
-    }
-    $fields[$table] or $fields[$table] = array();
-    return $fields[$table];
-  }
 
-  function get_table_keys($table) {
-    static $keys;
-    if ($keys[$table]) {
-      return $keys[$table];
-    }
+    function get_table_keys($table)
+    {
+        static $keys;
+        if ($keys[$table]) {
+            return $keys[$table];
+        }
     
-    $this->query("SHOW KEYS FROM %s",$table);
-    while ($row = $this->row()) {
-      if (!$row["Non_unique"]) {
-        $keys[$table][] = $row["Column_name"]; 
-      }
+        $this->query("SHOW KEYS FROM %s", $table);
+        while ($row = $this->row()) {
+            if (!$row["Non_unique"]) {
+                $keys[$table][] = $row["Column_name"];
+            }
+        }
+        return $keys[$table];
     }
-    return $keys[$table];
-  }
 
-  function save($table, $row=array(), $debug=0) {
-    $table_keys = $this->get_table_keys($table) or $table_keys = array();
-    foreach ($table_keys as $k) {
-      $row[$k] and $do_update = true;
-      $keys[$k] = $row[$k]; 
+    function save($table, $row = array(), $debug = 0)
+    {
+        $table_keys = $this->get_table_keys($table) or $table_keys = array();
+        foreach ($table_keys as $k) {
+            $row[$k] and $do_update = true;
+            $keys[$k] = $row[$k];
+        }
+        $row = $this->unset_invalid_field_names($table, $row, $keys);
+
+        if ($do_update) {
+            $q = sprintf(
+                "UPDATE %s SET %s WHERE %s",
+                $table,
+                $this->get_update_str($row),
+                $this->get_update_str($keys, " AND ")
+            );
+            $debug &&  sizeof($row) and print ("<br>SAVE -> UPDATE -> Would have executed this query: <br>".$q);
+            $debug && !sizeof($row) and print ("<br>SAVE -> UPDATE -> Would NOT have executed this query: <br>".$q);
+            !$debug && sizeof($row) and $this->query($q);
+            reset($keys);
+            return current($keys);
+        } else {
+            $q = sprintf(
+                "INSERT INTO %s (%s) VALUES (%s)",
+                $table,
+                $this->get_insert_str_fields($row),
+                $this->get_insert_str_values($row)
+            );
+            $debug &&  sizeof($row) and print ("<br>SAVE -> INSERT -> Would have executed this query: <br>".$q);
+            $debug && !sizeof($row) and print ("<br>SAVE -> INSERT -> Would NOT have executed this query: <br>".$q);
+            !$debug && sizeof($row) and $this->query($q);
+            return $this->get_insert_id();
+        }
     }
-    $row = $this->unset_invalid_field_names($table, $row, $keys);
 
-    if ($do_update) {
-      $q = sprintf("UPDATE %s SET %s WHERE %s"
-                  , $table, $this->get_update_str($row), $this->get_update_str($keys, " AND "));
-      $debug &&  sizeof($row) and print ("<br>SAVE -> UPDATE -> Would have executed this query: <br>".$q);
-      $debug && !sizeof($row) and print ("<br>SAVE -> UPDATE -> Would NOT have executed this query: <br>".$q);
-      !$debug && sizeof($row) and $this->query($q);
-      reset($keys);
-      return current($keys);
-
-    } else {
-      $q = sprintf("INSERT INTO %s (%s) VALUES (%s)"
-                  , $table, $this->get_insert_str_fields($row), $this->get_insert_str_values($row));
-      $debug &&  sizeof($row) and print ("<br>SAVE -> INSERT -> Would have executed this query: <br>".$q);
-      $debug && !sizeof($row) and print ("<br>SAVE -> INSERT -> Would NOT have executed this query: <br>".$q);
-      !$debug && sizeof($row) and $this->query($q);
-      return $this->get_insert_id();
+    function delete($table, $row = array(), $debug = 0)
+    {
+        $row = $this->unset_invalid_field_names($table, $row);
+        $q = sprintf(
+            "DELETE FROM %s WHERE %s",
+            $table,
+            $this->get_update_str($row, " AND ")
+        );
+        $debug &&  sizeof($row) and print ("<br>DELETE -> WILL execute this query: <br>".$q);
+        $debug && !sizeof($row) and print ("<br>DELETE -> WONT execute this query: <br>".$q);
+        if (sizeof($row)) {
+            $pdo_statement = $this->query($q);
+            return $pdo_statement->rowCount();
+        }
     }
-  }
 
-  function delete($table, $row=array(), $debug=0) {
-    $row = $this->unset_invalid_field_names($table, $row);
-    $q = sprintf("DELETE FROM %s WHERE %s"
-                 , $table, $this->get_update_str($row, " AND "));
-    $debug &&  sizeof($row) and print ("<br>DELETE -> WILL execute this query: <br>".$q);
-    $debug && !sizeof($row) and print ("<br>DELETE -> WONT execute this query: <br>".$q);
-    if (sizeof($row)) {
-      $pdo_statement = $this->query($q);
-      return $pdo_statement->rowCount();
+    function get_insert_str_fields($row)
+    {
+        foreach ($row as $fieldname => $value) {
+            $rtn .= $commar.$fieldname;
+            $commar = ", ";
+        }
+        return $rtn;
     }
-  }
 
-  function get_insert_str_fields($row) {
-    foreach ($row as $fieldname => $value) {
-      $rtn .= $commar.$fieldname;
-      $commar = ", ";
+    function get_insert_str_values($row)
+    {
+        foreach ($row as $fieldname => $value) {
+            $rtn .= $commar.$this->esc($value);
+            $commar = ", ";
+        }
+        return $rtn;
     }
-    return $rtn;
-  }
 
-  function get_insert_str_values($row) {
-    foreach ($row as $fieldname => $value) {
-      $rtn .= $commar.$this->esc($value);
-      $commar = ", ";
+    function get_update_str($row, $glue = ", ")
+    {
+        foreach ($row as $fieldname => $value) {
+            $rtn .= $commar." ".$fieldname." = ".$this->esc($value);
+            $commar = $glue;
+        }
+        return $rtn;
     }
-    return $rtn;
-  }
 
-  function get_update_str($row, $glue=", ") {
-    foreach ($row as $fieldname => $value) {
-      $rtn .= $commar." ".$fieldname." = ".$this->esc($value);
-      $commar = $glue;
-    }
-    return $rtn;
-  }
-
-  function unset_invalid_field_names($table, $row, $keys=array()) {
-    $valid_field_names = $this->get_table_fields($table);
-    $keys = array_keys($keys);
+    function unset_invalid_field_names($table, $row, $keys = array())
+    {
+        $valid_field_names = $this->get_table_fields($table);
+        $keys = array_keys($keys);
     
-    foreach ($row as $field_name => $v) {
-      if (!in_array($field_name, $valid_field_names) || in_array($field_name, $keys)) {
-        unset($row[$field_name]);
-      }
+        foreach ($row as $field_name => $v) {
+            if (!in_array($field_name, $valid_field_names) || in_array($field_name, $keys)) {
+                unset($row[$field_name]);
+            }
+        }
+        $row or $row = array();
+        return $row;
     }
-    $row or $row = array();
-    return $row;
-  }
 
-  function get_escaped_query_str($args) {
-    return call_user_func_array("prepare",$args);
-  }
-
-  function seek($pos = 0) {
-    $this->pos = $pos;
-  }
-
-  function get_encoding() {
-    $this->query("SHOW VARIABLES LIKE 'character_set_client'");
-    $row = $this->row();
-    return $row["Value"];
-  }
-
-  function dump_db($filename) {
-    if ($this->password) {
-      $pw = " -p" . $this->password;
+    function get_escaped_query_str($args)
+    {
+        return call_user_func_array("prepare", $args);
     }
-    $command = sprintf("mysqldump -B -c --add-drop-table -h %s -u %s %s %s", $this->hostname, $this->username, $pw, $this->database);
 
-    $command .= " >" . $filename;
+    function seek($pos = 0)
+    {
+        $this->pos = $pos;
+    }
 
-    system($command);
-  }
+    function get_encoding()
+    {
+        $this->query("SHOW VARIABLES LIKE 'character_set_client'");
+        $row = $this->row();
+        return $row["Value"];
+    }
 
+    function dump_db($filename)
+    {
+        if ($this->password) {
+            $pw = " -p" . $this->password;
+        }
+        $command = sprintf("mysqldump -B -c --add-drop-table -h %s -u %s %s %s", $this->hostname, $this->username, $pw, $this->database);
+
+        $command .= " >" . $filename;
+
+        system($command);
+    }
 }
-
-
-
-
-?>

--- a/shared/lib/db_alloc.inc.php
+++ b/shared/lib/db_alloc.inc.php
@@ -1,9 +1,9 @@
 <?php
 
-class db_alloc extends db {
-  function __construct() {
-    parent::__construct(ALLOC_DB_USER,ALLOC_DB_PASS,ALLOC_DB_HOST,ALLOC_DB_NAME);
-  }
+class db_alloc extends db
+{
+    function __construct()
+    {
+        parent::__construct(ALLOC_DB_USER, ALLOC_DB_PASS, ALLOC_DB_HOST, ALLOC_DB_NAME);
+    }
 }
-
-?>

--- a/shared/lib/db_entity.inc.php
+++ b/shared/lib/db_entity.inc.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -26,692 +26,757 @@ define("PERM_DELETE", 4);
 define("PERM_CREATE", 8);
 define("PERM_READ_WRITE", PERM_READ + PERM_UPDATE + PERM_DELETE + PERM_CREATE);
 
-class db_entity {
-  public $classname = "db_entity";   // Support phplib session variables
-  public $data_table = "";           // Set this to the name of the data base table
-  public $key_field = "";            // Set this to the table's primary key
-  public $data_fields = array();     // Set this to the data fields using array("field_name1","field_name2");
-  public $all_row_fields = array();  // This gets set to all fields from the row of the query result used to load this entity
-  public $db_class = "db_alloc";
-  public $db;
-  public $debug = false;
-  public $display_field_name;        // Set this to the field to be used by the get_display_value function
-  public $cache;                     // Cache associative array stored by primary key index
-  private $fields_loaded = false;    // This internal flag just specifies whether a row from the db was loaded
+class db_entity
+{
+    public $classname = "db_entity";   // Support phplib session variables
+    public $data_table = "";           // Set this to the name of the data base table
+    public $key_field = "";            // Set this to the table's primary key
+    public $data_fields = array();     // Set this to the data fields using array("field_name1","field_name2");
+    public $all_row_fields = array();  // This gets set to all fields from the row of the query result used to load this entity
+    public $db_class = "db_alloc";
+    public $db;
+    public $debug = false;
+    public $display_field_name;        // Set this to the field to be used by the get_display_value function
+    public $cache;                     // Cache associative array stored by primary key index
+    private $fields_loaded = false;    // This internal flag just specifies whether a row from the db was loaded
 
 
-  function __construct($id = false) {
+    function __construct($id = false)
+    {
 
-    $this->data_table or $this->data_table = get_class($this);
-    $this->classname  or $this->classname  = get_class($this);
+        $this->data_table or $this->data_table = get_class($this);
+        $this->classname  or $this->classname  = get_class($this);
   
-    $this->permissions[PERM_READ]   = "Read";
-    $this->permissions[PERM_UPDATE] = "Update";
-    $this->permissions[PERM_DELETE] = "Delete";
-    $this->permissions[PERM_CREATE] = "Create";
+        $this->permissions[PERM_READ]   = "Read";
+        $this->permissions[PERM_UPDATE] = "Update";
+        $this->permissions[PERM_DELETE] = "Delete";
+        $this->permissions[PERM_CREATE] = "Create";
 
-    // convert key_field into a field object
-    $this->key_field = new db_field($this->key_field); 
+      // convert key_field into a field object
+        $this->key_field = new db_field($this->key_field);
 
-    // we're going to reload the data_fields as $name => $object
-    $fields = $this->data_fields;
-    unset($this->data_fields); 
+      // we're going to reload the data_fields as $name => $object
+        $fields = $this->data_fields;
+        unset($this->data_fields);
 
-    // convert data_fields into field objects
-    foreach ($fields as $k=>$v) {
+      // convert data_fields into field objects
+        foreach ($fields as $k => $v) {
+          // This caters for per-field options.
+            if (is_array($v)) {
+                $this->data_fields[$k] = new db_field($k, $v);
+            } else {
+                $this->data_fields[$v] = new db_field($v);
+            }
+        }
 
-      // This caters for per-field options.
-      if (is_array($v)) {
-        $this->data_fields[$k] = new db_field($k, $v);
-      } else {
-        $this->data_fields[$v] = new db_field($v);
-      }
+      // If we're passed an id load this object up
+        if ($id) {
+            $this->set_id($id);
+            $this->select();
+        }
     }
 
-    // If we're passed an id load this object up
-    if ($id) {
-      $this->set_id($id);
-      $this->select();
-    }
-  }
+    function have_perm($action = 0, $person = "", $assume_owner = false)
+    {
+        $current_user = &singleton("current_user");
+        global $permission_cache;
+        if (defined("IS_GOD")) {
+            return true;
+        }
 
-  function have_perm($action = 0, $person = "", $assume_owner = false) {
-    $current_user = &singleton("current_user");
-    global $permission_cache;
-    if (defined("IS_GOD")) {
-      return true;
-    }
+        if (!$person) {
+            if ($current_user && is_object($current_user) && method_exists($current_user, "get_id") && $current_user->get_id()) {
+                $person = $current_user;
+            }
+        }
 
-    if (!$person) {
-      if ($current_user && is_object($current_user) && method_exists($current_user,"get_id") && $current_user->get_id()) {
-        $person = $current_user;
-      }
-    }
-
-    $entity_id = 0;
+        $entity_id = 0;
     
-    if (is_object($person) && method_exists($person,"get_id") && $person->get_id()) {
-      $person_id = $person->get_id();
-      $person_type = $person->classname;
-      $person_id and $person_flag = $person_type."_".$person_id;
-    }
+        if (is_object($person) && method_exists($person, "get_id") && $person->get_id()) {
+            $person_id = $person->get_id();
+            $person_type = $person->classname;
+            $person_id and $person_flag = $person_type."_".$person_id;
+        }
 
-    $record_cache_key = $this->data_table.":".$entity_id.":".$action.":".$person_flag.":".$assume_owner;
-    $table_cache_key = $this->data_table.":T:".$action.":".$person_flag.":".$assume_owner;
+        $record_cache_key = $this->data_table.":".$entity_id.":".$action.":".$person_flag.":".$assume_owner;
+        $table_cache_key = $this->data_table.":T:".$action.":".$person_flag.":".$assume_owner;
 
-    if (isset($permission_cache[$table_cache_key])) {
-      return $permission_cache[$table_cache_key];
-    } else if (isset($permission_cache[$record_cache_key])) {
-      return $permission_cache[$record_cache_key];
-    }
+        if (isset($permission_cache[$table_cache_key])) {
+            return $permission_cache[$table_cache_key];
+        } else if (isset($permission_cache[$record_cache_key])) {
+            return $permission_cache[$record_cache_key];
+        }
 
-    $db = new db_alloc();
-    $query = prepare("SELECT * 
+        $db = new db_alloc();
+        $query = prepare(
+            "SELECT * 
                         FROM permission 
                         WHERE (tableName = '%s')
                          AND (actions & %d = %d)
-                    ORDER BY entityID DESC"
-                    ,$this->data_table,$action,$action);
-    $db->query($query);
+                    ORDER BY entityID DESC",
+            $this->data_table,
+            $action,
+            $action
+        );
+        $db->query($query);
     
-    while ($db->next_record()) {
+        while ($db->next_record()) {
+            // Ignore this record if it specifies a role the user doesn't have
+            if ($db->f("roleName") && is_object($person) && !$person->have_role($db->f("roleName"))) {
+                continue;
+            }
 
-      // Ignore this record if it specifies a role the user doesn't have
-      if ($db->f("roleName") && is_object($person) && !$person->have_role($db->f("roleName"))) {
-        continue;
-      }
+            // Ignore this record if it specifies that the user must be the record's owner and they are not
+            if ($db->f("entityID") == -1 && !$assume_owner && !$this->is_owner($person)) {
+                continue;
+            }
 
-      // Ignore this record if it specifies that the user must be the record's owner and they are not
-      if ($db->f("entityID") == -1 && !$assume_owner && !$this->is_owner($person)) {
-        continue;
-      }
+            // Cache the result in variables to prevent duplicate database lookups
+            $permission_cache[$record_cache_key] = true;
+            if ($db->f("entityID") == 0) {
+                $permission_cache[$table_cache_key] = true;
+            }
 
-      // Cache the result in variables to prevent duplicate database lookups
-      $permission_cache[$record_cache_key] = true;
-      if ($db->f("entityID") == 0) {
-        $permission_cache[$table_cache_key] = true;
-      }
+            return true;
+        }
 
-      return true;
+      // No matching records - return false
+        $permission_cache[$record_cache_key] = false;
+        return false;
     }
 
-    // No matching records - return false
-    $permission_cache[$record_cache_key] = false;
-    return false;
-  }
-
-  function select() {
-    if (!$this->has_key_values()) {
-      return false;
+    function select()
+    {
+        if (!$this->has_key_values()) {
+            return false;
+        }
+        if ($this->data_table && $this->key_field) {
+            $query = "SELECT * FROM ".db_esc($this->data_table)." WHERE ".$this->get_name_equals_value(array($this->key_field), " AND ");
+            if ($this->debug) {
+                echo "db_entity->select query: $query<br>\n";
+            }
+            $db = $this->get_db();
+            $db->query($query);
+            if ($db->next_record()) {
+                $this->read_db_record($db);
+                return true;
+            }
+        }
     }
-    if ($this->data_table && $this->key_field) {
-      $query = "SELECT * FROM ".db_esc($this->data_table)." WHERE ".$this->get_name_equals_value(array($this->key_field), " AND ");
-      if ($this->debug)
-        echo "db_entity->select query: $query<br>\n";
-      $db = $this->get_db();
-      $db->query($query);
-      if ($db->next_record()) {
-        $this->read_db_record($db);
-        return true;
-      }
-    }
-  }
  
-  function perm_cleanup(&$row=array()) {
-    foreach ($row as $field_name => $object) {
-      if (!$this->can_read_field($field_name)) {
-        $str = "Permission denied to ".$this->permissions[$this->data_fields[$field_name]->read_perm_name]." of ".$this->data_table.".".$field_name;
-        $row[$field_name] = $str;
-      }
-    }
-    return $row;
-  }
-
-  function delete() {
-    if (!$this->have_perm(PERM_DELETE)) {
-      $current_user = &singleton("current_user");
-      alloc_error(sprintf("Person %d does not have permission %s for %s #%d"
-                         ,$current_user->get_id(), $this->permissions[PERM_DELETE], $this->data_table, $this->get_id()));
-      return false;
-    }
-    if (!$this->has_key_values()) {
-      return false;
-    }
-    $query = "DELETE FROM ".db_esc($this->data_table)." WHERE ".$this->get_name_equals_value(array($this->key_field), " AND ");
-    if ($this->debug)
-      echo "db_entity->delete query: $query<br>\n";
-    $db = $this->get_db();
-    $db->query($query);
-
-    return true;
-  }
-
-  function insert() {
-    $current_user = &singleton("current_user");
-    if (is_object($current_user) && method_exists($current_user,"get_id") && $current_user->get_id()) {
-      $current_user_id = $current_user->get_id();
-    } else {
-      $current_user_id = "0";
-    }
-    if (!$this->have_perm(PERM_CREATE)) {
-      $current_user = &singleton("current_user");
-      if (is_object($this) && method_exists($this,"get_id")) {
-        $this_id = $this->get_id();
-      }
-      alloc_error(sprintf("Person %d does not have permission %s for %s #%d"
-                         ,$current_user_id, $this->permissions[PERM_CREATE], $this->data_table, $this_id));
-      return false;
+    function perm_cleanup(&$row = array())
+    {
+        foreach ($row as $field_name => $object) {
+            if (!$this->can_read_field($field_name)) {
+                $str = "Permission denied to ".$this->permissions[$this->data_fields[$field_name]->read_perm_name]." of ".$this->data_table.".".$field_name;
+                $row[$field_name] = $str;
+            }
+        }
+        return $row;
     }
 
-    if (isset($this->data_fields[$this->data_table."CreatedUser"]) && $current_user_id) {
-      $this->set_value($this->data_table."CreatedUser", $current_user_id);
-    }
-    if (isset($this->data_fields[$this->data_table."CreatedTime"])) {
-      $this->set_value($this->data_table."CreatedTime", date("Y-m-d H:i:s"));
-    }
-    if (isset($this->data_fields[$this->data_table."ModifiedUser"])) {
-      #$this->set_value($this->data_table."ModifiedUser", $current_user_id);
-    }
-    if (isset($this->data_fields[$this->data_table."ModifiedTime"])) {
-      #$this->set_value($this->data_table."ModifiedTime", date("Y-m-d H:i:s"));
-    }
+    function delete()
+    {
+        if (!$this->have_perm(PERM_DELETE)) {
+            $current_user = &singleton("current_user");
+            alloc_error(sprintf(
+                "Person %d does not have permission %s for %s #%d",
+                $current_user->get_id(),
+                $this->permissions[PERM_DELETE],
+                $this->data_table,
+                $this->get_id()
+            ));
+            return false;
+        }
+        if (!$this->has_key_values()) {
+            return false;
+        }
+        $query = "DELETE FROM ".db_esc($this->data_table)." WHERE ".$this->get_name_equals_value(array($this->key_field), " AND ");
+        if ($this->debug) {
+            echo "db_entity->delete query: $query<br>\n";
+        }
+        $db = $this->get_db();
+        $db->query($query);
 
-    // Even if we're doing an insert, if a primary key is set, then insert the row with that PK.
-    if ($this->get_id()) {
-      $this->data_fields[] = $this->key_field;
-    }
-
-    $query = "INSERT INTO ".db_esc($this->data_table)." (";
-    $query.= $this->get_insert_fields($this->data_fields);
-    $query.= ") VALUES (";
-    $query.= $this->get_insert_values($this->data_fields);
-    $query.= ")";
-    $this->debug and print "<br>db_entity->insert() query: ".$query;
-    $db = $this->get_db();
-    $db->query($query);
-
-    $id = $db->get_insert_id();
-    if ($id === 0) {
-      $this->debug and print "<br>db_entity->insert(): The previous query does not generate an AUTO_INCREMENT value`";
-    } else if ($id === FALSE) {
-      $this->debug and print "<br>db_entity->insert(): No MySQL connection was established";
-    } else {
-      $this->debug and print "<br>db_entity->insert(): New ID: ".$id;
-    }
-    $this->key_field->set_value($id);
-
-    return true;
-  }
-
-  function update() {
-
-    if (!$this->have_perm(PERM_UPDATE)) {
-      $current_user = &singleton("current_user");
-      alloc_error(sprintf("Person %d does not have permission %s for %s #%d"
-                         ,$current_user->get_id(), $this->permissions[PERM_UPDATE], $this->data_table, $this->get_id()));
-      return false;
+        return true;
     }
 
-    // retrieve a copy of this object with the old values from the database
-    if (class_exists($this->data_table)) {
-      $old_this = new $this->data_table;
-      $old_this->set_id($this->get_id());
-      $old_this->select();
+    function insert()
+    {
+        $current_user = &singleton("current_user");
+        if (is_object($current_user) && method_exists($current_user, "get_id") && $current_user->get_id()) {
+            $current_user_id = $current_user->get_id();
+        } else {
+            $current_user_id = "0";
+        }
+        if (!$this->have_perm(PERM_CREATE)) {
+            $current_user = &singleton("current_user");
+            if (is_object($this) && method_exists($this, "get_id")) {
+                $this_id = $this->get_id();
+            }
+            alloc_error(sprintf(
+                "Person %d does not have permission %s for %s #%d",
+                $current_user_id,
+                $this->permissions[PERM_CREATE],
+                $this->data_table,
+                $this_id
+            ));
+            return false;
+        }
+
+        if (isset($this->data_fields[$this->data_table."CreatedUser"]) && $current_user_id) {
+            $this->set_value($this->data_table."CreatedUser", $current_user_id);
+        }
+        if (isset($this->data_fields[$this->data_table."CreatedTime"])) {
+            $this->set_value($this->data_table."CreatedTime", date("Y-m-d H:i:s"));
+        }
+        if (isset($this->data_fields[$this->data_table."ModifiedUser"])) {
+          #$this->set_value($this->data_table."ModifiedUser", $current_user_id);
+        }
+        if (isset($this->data_fields[$this->data_table."ModifiedTime"])) {
+          #$this->set_value($this->data_table."ModifiedTime", date("Y-m-d H:i:s"));
+        }
+
+      // Even if we're doing an insert, if a primary key is set, then insert the row with that PK.
+        if ($this->get_id()) {
+            $this->data_fields[] = $this->key_field;
+        }
+
+        $query = "INSERT INTO ".db_esc($this->data_table)." (";
+        $query.= $this->get_insert_fields($this->data_fields);
+        $query.= ") VALUES (";
+        $query.= $this->get_insert_values($this->data_fields);
+        $query.= ")";
+        $this->debug and print "<br>db_entity->insert() query: ".$query;
+        $db = $this->get_db();
+        $db->query($query);
+
+        $id = $db->get_insert_id();
+        if ($id === 0) {
+            $this->debug and print "<br>db_entity->insert(): The previous query does not generate an AUTO_INCREMENT value`";
+        } else if ($id === false) {
+            $this->debug and print "<br>db_entity->insert(): No MySQL connection was established";
+        } else {
+            $this->debug and print "<br>db_entity->insert(): New ID: ".$id;
+        }
+        $this->key_field->set_value($id);
+
+        return true;
     }
 
-    $current_user = &singleton("current_user");
-    if (is_object($current_user) && $current_user->get_id()) {
-      $current_user_id = $current_user->get_id();
-    } else {
-      $current_user_id = "0";
+    function update()
+    {
+
+        if (!$this->have_perm(PERM_UPDATE)) {
+            $current_user = &singleton("current_user");
+            alloc_error(sprintf(
+                "Person %d does not have permission %s for %s #%d",
+                $current_user->get_id(),
+                $this->permissions[PERM_UPDATE],
+                $this->data_table,
+                $this->get_id()
+            ));
+            return false;
+        }
+
+      // retrieve a copy of this object with the old values from the database
+        if (class_exists($this->data_table)) {
+            $old_this = new $this->data_table;
+            $old_this->set_id($this->get_id());
+            $old_this->select();
+        }
+
+        $current_user = &singleton("current_user");
+        if (is_object($current_user) && $current_user->get_id()) {
+            $current_user_id = $current_user->get_id();
+        } else {
+            $current_user_id = "0";
+        }
+
+        if (!$this->skip_modified_fields) {
+            if (isset($this->data_fields[$this->data_table."ModifiedUser"]) && $current_user_id) {
+                $this->set_value($this->data_table."ModifiedUser", $current_user_id);
+            }
+            if (isset($this->data_fields[$this->data_table."ModifiedTime"])) {
+                $this->set_value($this->data_table."ModifiedTime", date("Y-m-d H:i:s"));
+            }
+        }
+
+        $write_fields = array();
+
+        reset($this->data_fields);
+        while (list(, $field) = each($this->data_fields)) {
+            if ($this->can_write_field($field)) {
+                $write_fields[] = $field;
+            }
+        }
+
+        $query = "UPDATE ".db_esc($this->data_table)." SET ".$this->get_name_equals_value($write_fields)." WHERE ";
+        $query.= $this->get_name_equals_value(array($this->key_field));
+        $db = $this->get_db();
+        $this->debug and print "<br>db_entity->update() query: ".$query;
+        $db->query($query);
+        return true;
     }
 
-    if (!$this->skip_modified_fields) {
-      if (isset($this->data_fields[$this->data_table."ModifiedUser"]) && $current_user_id) {
-        $this->set_value($this->data_table."ModifiedUser", $current_user_id);
-      }
-      if (isset($this->data_fields[$this->data_table."ModifiedTime"])) {
-        $this->set_value($this->data_table."ModifiedTime", date("Y-m-d H:i:s"));
-      }
-    }
-
-    $write_fields = array();
-
-    reset($this->data_fields);
-    while (list(, $field) = each($this->data_fields)) {
-      if ($this->can_write_field($field)) {
-        $write_fields[] = $field;
-      }
-    }
-
-    $query = "UPDATE ".db_esc($this->data_table)." SET ".$this->get_name_equals_value($write_fields)." WHERE ";
-    $query.= $this->get_name_equals_value(array($this->key_field));
-    $db = $this->get_db();
-    $this->debug and print "<br>db_entity->update() query: ".$query;
-    $db->query($query);
-    return true;
-  }
-
-  function is_new() {
-    if (!$this->has_key_values()) {
-      return true;
-    } else if ($this->key_field->has_value() && $this->key_field->get_name() && $this->key_field->get_value()) {
-      $db = $this->get_db();
-      $row = $db->qr("SELECT ".db_esc($this->key_field->get_name())."
+    function is_new()
+    {
+        if (!$this->has_key_values()) {
+            return true;
+        } else if ($this->key_field->has_value() && $this->key_field->get_name() && $this->key_field->get_value()) {
+            $db = $this->get_db();
+            $row = $db->qr("SELECT ".db_esc($this->key_field->get_name())."
                         FROM ".db_esc($this->data_table)."
                        WHERE ".db_esc($this->key_field->get_name())." = '".db_esc($this->key_field->get_value())."'");
-      return !$row;
-    }
-  }
-
-  function save() {
-    global $TPL;
-    $this->doMoney = true;
-    $error = $this->validate();
-    if (is_array($error) && count($error)) {
-      alloc_error(implode(" ",$error));
-      return false;
-    } else if (strlen($error) && $error) {
-      alloc_error($error);
-      return false;
-    }
-
-    if ($this->is_new()) {
-      $rtn = $this->insert();
-    } else {
-      $rtn = $this->update();
-    }
-
-    // Update the search index for this entity, if any
-    if ($rtn && $this->get_id() && $this->classname && is_dir(ATTACHMENTS_DIR.'search/'.$this->classname)) {
-
-      // Update the index asynchronously (later from a job running search/updateIndex.php)
-      if ($this->updateSearchIndexLater) {
-        $db = $this->get_db();
-        $db->query("call update_search_index('%s',%d)",$this->classname,$this->get_id());
-
-      // Update the index right now
-      } else {
-        $index = Zend_Search_Lucene::open(ATTACHMENTS_DIR.'search/'.$this->classname);
-        $this->delete_search_index_doc($index);
-        $this->update_search_index_doc($index);
-        $index->commit();
-      }
-    }
-
-    return $rtn;
-  }
-
-  function validate($message=array()) {
-    $c = $this->currency;
-    if (isset($this->data_fields["currencyTypeID"]) && imp($this->data_fields["currencyTypeID"]->get_value())) {
-      $c = $this->data_fields["currencyTypeID"]->get_value();
-    }
-    $c and $this->currency = $c;
-    reset($this->data_fields);
-    while (list($field_index, $field) = each($this->data_fields)) {
-      $message[] = $field->validate($this);
-    }
-
-    $message = implode(" ",$message);
-    if ($message && preg_match("/[a-zA-Z0-9]+/",$message)) 
-    return $message;
-  }
-
-  function set_field_value(&$field, $value, $source = SRC_VARIABLE) {
-    $field->set_value($value, $source);
-  }
-
-  function clear_field_value(&$field) {
-    $field->clear_value();
-  }
-
-  function read_array(&$array, $source_prefix = "", $source = SRC_VARIABLE) {
-
-    // Data fields
-    foreach ($this->data_fields as $field_index=>$field) {
-      $source_index = $source_prefix.$field->get_name();
-      $this->set_field_value($this->data_fields[$field_index], $array[$source_index], $source);
-    }
-
-    // Key field
-    $source_index = $source_prefix.$this->key_field->get_name();
-    $this->key_field->set_value($array[$source_index], $source);
-    $this->debug and print "db_entity->read_array key_field->set_value(".$array[$source_index].", $source)<br>\n";
-    $this->fields_loaded = true;
-  }
-
-  function write_array(&$array, $dest = DST_VARIABLE, $array_index_prefix = "") {
-
-    // Data fields
-    reset($this->data_fields);
-    while (list($field_name) = each($this->data_fields)) {
-      $array_index = $array_index_prefix.$field_name;
-      $array[$array_index] = $this->get_value($field_name, $dest);
-    }
-
-    // Key field
-    $array_index = $array_index_prefix.$this->key_field->get_name();
-    $array[$array_index] = $this->key_field->get_value($dest);
-  }
-
-  function set_values($tpl_key_prefix="") {
-    $this->write_array($GLOBALS["TPL"], DST_VARIABLE, $tpl_key_prefix);
-  }
-
-  function set_tpl_values($tpl_key_prefix = "") {
-    $this->write_array($GLOBALS["TPL"], DST_HTML_DISPLAY, $tpl_key_prefix);
-  }
-
-  function read_globals($prefix = "", $source = SRC_VARIABLE) {
-    $this->read_array($_POST, $prefix, $source);
-  }
-
-  function set_global_variables($variable_name_prefix = "") {
-    $this->write_array($GLOBALS, DST_VARIABLE, $variable_name_prefix);
-  }
-
-  function has_key_values() {
-    return $this->key_field->has_value();
-  }
-
-  function read_db_record($db) {
-    $this->set_id($db->f($this->key_field->get_name()));
-    $this->read_array($db->row, "", SRC_DATABASE);
-    $this->all_row_fields = $db->row;
-    $have_perm = $this->have_perm(PERM_READ);
-    if (!$have_perm) {
-      $m = new meta();
-      $meta_tables = (array)$m->get_tables();
-      $meta_tables = array_keys($meta_tables);
-      if (in_array($this->data_table,(array)$meta_tables)) {
-        return true;
-      }
-      $this->clear();
-    }
-    return $have_perm;
-  } 
-
-  function read_row_record($row) {
-    $this->set_id($row[$this->key_field->get_name()]);
-    $this->read_array($row, "", SRC_DATABASE);
-    $this->all_row_fields = $row;
-    $have_perm = $this->have_perm(PERM_READ);
-    if (!$have_perm) {
-      $this->clear();
-    }
-    return $have_perm;
-  } 
-
-  function row() {
-    return $this->all_row_fields;
-  }
-
-  function set_value($field_name, $value, $source = SRC_VARIABLE) {
-    if (is_object($this->data_fields[$field_name])) {
-      $this->set_field_value($this->data_fields[$field_name], $value, $source);
-    } else {
-      alloc_error("Cannot set field value - field not found: ".$field_name);
-    }
-  }
-
-  function get_value($field_name, $dest = DST_VARIABLE) {
-    $field = $this->data_fields[$field_name];
-    if (!is_object($field)) {
-      $msg = "Field $field_name does not exist in ".$this->data_table;
-      alloc_error($msg);
-      return $msg;
-    }
-    if (!$this->can_read_field($field_name)) {
-      return "Permission denied to ".$this->permissions[$this->data_fields[$field_name]->read_perm_name]." of ".$this->data_table.".".$field_name;
-    }
-
-    $c = $this->currency;
-    if (isset($this->data_fields["currencyTypeID"]) && imp($this->data_fields["currencyTypeID"]->get_value())) {
-      $c = $this->data_fields["currencyTypeID"]->get_value();
-    }
-    $c and $this->currency = $c;
-    return $field->get_value($dest,$this);
-  }
-
-  function get_row_value($field_name) {
-    return $this->all_row_fields[$field_name];
-  }
-
-  function get_id($dest = DST_VARIABLE) {
-    return $this->key_field->get_value($dest);
-  }
-
-  function set_id($id) {
-    $this->key_field->set_value(db_esc($id));
-  }
-
-  function get_foreign_object($class_name, $key_name = "") {
-    if ($key_name == "") {
-      $key_name = $class_name."ID";
-    }
-    $object = new $class_name;
-    $object->set_id($this->get_value($key_name, DST_VARIABLE));
-    $object->select();
-    return $object;
-  }
-
-  function get_foreign_objects($class_name, $key_name = "") {
-    if ($key_name == "") {
-      $key_name = $this->key_field->get_name();
-    }
-    $foreign_objects = array();
-    $query = prepare("SELECT * FROM %s WHERE %s = %d",$class_name,$key_name,$this->get_id());
-    $db = new db_alloc();
-    $db->query($query);
-    while ($db->next_record()) {
-      $o = new $class_name;
-      $o->read_db_record($db);
-      $foreign_objects[$o->get_id()] = $o;
-    }
-    return $foreign_objects;
-  }
-
-  function get_filter_class() {
-    return $this->filter_class;
-  }
-
-  function get_display_value($dst=DST_HTML_DISPLAY) {
-    if ($this->display_field_name) {
-      if (!$this->fields_loaded) {
-        $found = $this->select();
-        if (!$found) {
-          return "";
+            return !$row;
         }
-      }
-      return $this->get_value($this->display_field_name, $dst);
-    } else {
-      return "#".$this->get_id();
-    }
-  }
-
-  function can_read_field($field_name) {
-    $field = $this->data_fields[$field_name];
-    if (is_object($field) && $field->read_perm_name) {
-      return $this->have_perm($field->read_perm_name);
-    } else {
-      return true;
-    }
-  }
-
-  function can_write_field($field) {
-    if (is_string($field)) {
-      $field = $this->data_fields[$field];
-    }
-    return $field->write_perm_name == 0 || $this->have_perm($field->write_perm_name);
-  }
-
-  function is_owner($person = "") {
-    $current_user = &singleton("current_user");
-    $person or $person = $current_user;
-    if (is_object($person) && $person->classname == "person") {
-      if (isset($this->data_fields["personID"])) {
-        return $this->get_value("personID") == $person->get_id();
-      } else if ($this->key_field->get_name() == "personID") {
-        return $this->get_id() == $person->get_id();
-      } else {
-        echo "Warning: could not determine owner for ".$this->data_table."<br>";
-      }
-    }
-  }
-
-  function clear() {
-
-    // Data fields
-    reset($this->data_fields);
-    while (list($field_index,) = each($this->data_fields)) {
-      $this->clear_field_value($this->data_fields[$field_index]);
     }
 
-    // Key field
-    $this->key_field->clear_value();
-    if ($this->debug)
-      echo "db_entity->read_array key_field->set_value(".$array[$source_index].", $source)<br>\n";
-    $this->fields_loaded = false;
-  }
+    function save()
+    {
+        global $TPL;
+        $this->doMoney = true;
+        $error = $this->validate();
+        if (is_array($error) && count($error)) {
+            alloc_error(implode(" ", $error));
+            return false;
+        } else if (strlen($error) && $error) {
+            alloc_error($error);
+            return false;
+        }
+
+        if ($this->is_new()) {
+            $rtn = $this->insert();
+        } else {
+            $rtn = $this->update();
+        }
+
+      // Update the search index for this entity, if any
+        if ($rtn && $this->get_id() && $this->classname && is_dir(ATTACHMENTS_DIR.'search/'.$this->classname)) {
+          // Update the index asynchronously (later from a job running search/updateIndex.php)
+            if ($this->updateSearchIndexLater) {
+                $db = $this->get_db();
+                $db->query("call update_search_index('%s',%d)", $this->classname, $this->get_id());
+
+              // Update the index right now
+            } else {
+                $index = Zend_Search_Lucene::open(ATTACHMENTS_DIR.'search/'.$this->classname);
+                $this->delete_search_index_doc($index);
+                $this->update_search_index_doc($index);
+                $index->commit();
+            }
+        }
+
+        return $rtn;
+    }
+
+    function validate($message = array())
+    {
+        $c = $this->currency;
+        if (isset($this->data_fields["currencyTypeID"]) && imp($this->data_fields["currencyTypeID"]->get_value())) {
+            $c = $this->data_fields["currencyTypeID"]->get_value();
+        }
+        $c and $this->currency = $c;
+        reset($this->data_fields);
+        while (list($field_index, $field) = each($this->data_fields)) {
+            $message[] = $field->validate($this);
+        }
+
+        $message = implode(" ", $message);
+        if ($message && preg_match("/[a-zA-Z0-9]+/", $message)) {
+            return $message;
+        }
+    }
+
+    function set_field_value(&$field, $value, $source = SRC_VARIABLE)
+    {
+        $field->set_value($value, $source);
+    }
+
+    function clear_field_value(&$field)
+    {
+        $field->clear_value();
+    }
+
+    function read_array(&$array, $source_prefix = "", $source = SRC_VARIABLE)
+    {
+
+      // Data fields
+        foreach ($this->data_fields as $field_index => $field) {
+            $source_index = $source_prefix.$field->get_name();
+            $this->set_field_value($this->data_fields[$field_index], $array[$source_index], $source);
+        }
+
+      // Key field
+        $source_index = $source_prefix.$this->key_field->get_name();
+        $this->key_field->set_value($array[$source_index], $source);
+        $this->debug and print "db_entity->read_array key_field->set_value(".$array[$source_index].", $source)<br>\n";
+        $this->fields_loaded = true;
+    }
+
+    function write_array(&$array, $dest = DST_VARIABLE, $array_index_prefix = "")
+    {
+
+      // Data fields
+        reset($this->data_fields);
+        while (list($field_name) = each($this->data_fields)) {
+            $array_index = $array_index_prefix.$field_name;
+            $array[$array_index] = $this->get_value($field_name, $dest);
+        }
+
+      // Key field
+        $array_index = $array_index_prefix.$this->key_field->get_name();
+        $array[$array_index] = $this->key_field->get_value($dest);
+    }
+
+    function set_values($tpl_key_prefix = "")
+    {
+        $this->write_array($GLOBALS["TPL"], DST_VARIABLE, $tpl_key_prefix);
+    }
+
+    function set_tpl_values($tpl_key_prefix = "")
+    {
+        $this->write_array($GLOBALS["TPL"], DST_HTML_DISPLAY, $tpl_key_prefix);
+    }
+
+    function read_globals($prefix = "", $source = SRC_VARIABLE)
+    {
+        $this->read_array($_POST, $prefix, $source);
+    }
+
+    function set_global_variables($variable_name_prefix = "")
+    {
+        $this->write_array($GLOBALS, DST_VARIABLE, $variable_name_prefix);
+    }
+
+    function has_key_values()
+    {
+        return $this->key_field->has_value();
+    }
+
+    function read_db_record($db)
+    {
+        $this->set_id($db->f($this->key_field->get_name()));
+        $this->read_array($db->row, "", SRC_DATABASE);
+        $this->all_row_fields = $db->row;
+        $have_perm = $this->have_perm(PERM_READ);
+        if (!$have_perm) {
+            $m = new meta();
+            $meta_tables = (array)$m->get_tables();
+            $meta_tables = array_keys($meta_tables);
+            if (in_array($this->data_table, (array)$meta_tables)) {
+                return true;
+            }
+            $this->clear();
+        }
+        return $have_perm;
+    }
+
+    function read_row_record($row)
+    {
+        $this->set_id($row[$this->key_field->get_name()]);
+        $this->read_array($row, "", SRC_DATABASE);
+        $this->all_row_fields = $row;
+        $have_perm = $this->have_perm(PERM_READ);
+        if (!$have_perm) {
+            $this->clear();
+        }
+        return $have_perm;
+    }
+
+    function row()
+    {
+        return $this->all_row_fields;
+    }
+
+    function set_value($field_name, $value, $source = SRC_VARIABLE)
+    {
+        if (is_object($this->data_fields[$field_name])) {
+            $this->set_field_value($this->data_fields[$field_name], $value, $source);
+        } else {
+            alloc_error("Cannot set field value - field not found: ".$field_name);
+        }
+    }
+
+    function get_value($field_name, $dest = DST_VARIABLE)
+    {
+        $field = $this->data_fields[$field_name];
+        if (!is_object($field)) {
+            $msg = "Field $field_name does not exist in ".$this->data_table;
+            alloc_error($msg);
+            return $msg;
+        }
+        if (!$this->can_read_field($field_name)) {
+            return "Permission denied to ".$this->permissions[$this->data_fields[$field_name]->read_perm_name]." of ".$this->data_table.".".$field_name;
+        }
+
+        $c = $this->currency;
+        if (isset($this->data_fields["currencyTypeID"]) && imp($this->data_fields["currencyTypeID"]->get_value())) {
+            $c = $this->data_fields["currencyTypeID"]->get_value();
+        }
+        $c and $this->currency = $c;
+        return $field->get_value($dest, $this);
+    }
+
+    function get_row_value($field_name)
+    {
+        return $this->all_row_fields[$field_name];
+    }
+
+    function get_id($dest = DST_VARIABLE)
+    {
+        return $this->key_field->get_value($dest);
+    }
+
+    function set_id($id)
+    {
+        $this->key_field->set_value(db_esc($id));
+    }
+
+    function get_foreign_object($class_name, $key_name = "")
+    {
+        if ($key_name == "") {
+            $key_name = $class_name."ID";
+        }
+        $object = new $class_name;
+        $object->set_id($this->get_value($key_name, DST_VARIABLE));
+        $object->select();
+        return $object;
+    }
+
+    function get_foreign_objects($class_name, $key_name = "")
+    {
+        if ($key_name == "") {
+            $key_name = $this->key_field->get_name();
+        }
+        $foreign_objects = array();
+        $query = prepare("SELECT * FROM %s WHERE %s = %d", $class_name, $key_name, $this->get_id());
+        $db = new db_alloc();
+        $db->query($query);
+        while ($db->next_record()) {
+            $o = new $class_name;
+            $o->read_db_record($db);
+            $foreign_objects[$o->get_id()] = $o;
+        }
+        return $foreign_objects;
+    }
+
+    function get_filter_class()
+    {
+        return $this->filter_class;
+    }
+
+    function get_display_value($dst = DST_HTML_DISPLAY)
+    {
+        if ($this->display_field_name) {
+            if (!$this->fields_loaded) {
+                $found = $this->select();
+                if (!$found) {
+                    return "";
+                }
+            }
+            return $this->get_value($this->display_field_name, $dst);
+        } else {
+            return "#".$this->get_id();
+        }
+    }
+
+    function can_read_field($field_name)
+    {
+        $field = $this->data_fields[$field_name];
+        if (is_object($field) && $field->read_perm_name) {
+            return $this->have_perm($field->read_perm_name);
+        } else {
+            return true;
+        }
+    }
+
+    function can_write_field($field)
+    {
+        if (is_string($field)) {
+            $field = $this->data_fields[$field];
+        }
+        return $field->write_perm_name == 0 || $this->have_perm($field->write_perm_name);
+    }
+
+    function is_owner($person = "")
+    {
+        $current_user = &singleton("current_user");
+        $person or $person = $current_user;
+        if (is_object($person) && $person->classname == "person") {
+            if (isset($this->data_fields["personID"])) {
+                return $this->get_value("personID") == $person->get_id();
+            } else if ($this->key_field->get_name() == "personID") {
+                return $this->get_id() == $person->get_id();
+            } else {
+                echo "Warning: could not determine owner for ".$this->data_table."<br>";
+            }
+        }
+    }
+
+    function clear()
+    {
+
+      // Data fields
+        reset($this->data_fields);
+        while (list($field_index,) = each($this->data_fields)) {
+            $this->clear_field_value($this->data_fields[$field_index]);
+        }
+
+      // Key field
+        $this->key_field->clear_value();
+        if ($this->debug) {
+            echo "db_entity->read_array key_field->set_value(".$array[$source_index].", $source)<br>\n";
+        }
+        $this->fields_loaded = false;
+    }
 
   /**************************************************************************
   'Private' utilitity functions These functions probably won't be useful to
   users of this class but are used by the other functions in the class
   ***************************************************************************/
-  function get_db() {
-    if (!is_object($this->db)) {
-      $db_class = $this->db_class;
-      $this->db = new $db_class;
-    }
-    return $this->db;
-  }
-  function get_insert_fields($fields) {
-    foreach((array)$fields as $k=>$field) {
-      if (strtolower($field->get_value(DST_DATABASE)) != "null") {
-        $rtn.= $comma.$field->get_name();
-        $comma = ",";
-      }
-    }
-    return $rtn;
-  }
-  function get_insert_values($fields) {
-    foreach((array)$fields as $k=>$field) {
-      if (strtolower($field->get_value(DST_DATABASE)) != "null") {
-        $rtn.= $comma.$field->get_value(DST_DATABASE);
-        $comma = ",";
-      }
-    }
-    return $rtn;
-  }
-  function get_name_equals_value($fields, $glue = ",") {
-    $query = "";
-    reset($fields);
-    while (list(, $field) = each($fields)) {
-      if ($query) {
-        $query.= $glue;
-      }
-      $query.= $field->get_name()." = ".$field->get_value(DST_DATABASE);
-    }
-    return $query;
-  }
-
-  function get_assoc_array($key=false,$value=false,$sel=false, $where=array()){
-    $key or $key = $this->key_field->get_name();
-    $value or $value = "*";
-    $value != "*" and $key_sql = $key.",";
-
-    $q = sprintf('SELECT %s %s FROM %s WHERE 1=1 '
-                ,db_esc($key_sql),db_esc($value),db_esc($this->data_table));
-
-    $pkey_sql = " OR ".$this->key_field->get_name()." = ";
-    if (is_array($sel) && count($sel)) {
-      foreach ($sel as $s) {
-        $extra.= $pkey_sql.sprintf("%d",$s);
-      }
-    } else if ($sel) {
-      $extra = $pkey_sql.db_esc($sel);
-    }
-
-    // If they haven't specifically asked for inactive or all
-    // records, we default to giving them only active records.
-    if (is_object($this->data_fields[$this->data_table."Active"]) && !isset($where[$this->data_table."Active"])) {
-      $where[$this->data_table."Active"] = 1;
-
-    // Else get all records
-    } else if ($where[$this->data_table."Active"] == "all") {
-      unset($where[$this->data_table."Active"]);
-    }
-
-    if (is_array($where) && count($where)) {
-      foreach ($where as $colname => $colvalue) {
-        $q.= " AND ".$colname." = '".db_esc($colvalue)."'";
-      }
-    }
-
-    $q.= $extra;
-
-    if (is_object($this->data_fields[$this->data_table."Sequence"])) {
-      $q.= " ORDER BY ".db_esc($this->data_table)."Sequence";
-    } else if (is_object($this->data_fields[$this->data_table."Seq"])) {
-      $q.= " ORDER BY ".db_esc($this->data_table)."Seq";
-    } else if ($value != "*") {
-      $q.= " ORDER BY ".db_esc($value);
-    }
-
-    $db = new db_alloc();
-    $db->query($q);
-    $rows = array();
-    while($row = $db->row()) {
-      if ($this->read_db_record($db)) {
-        if ($value && $value != "*") {
-          $v = $row[$value];
-        } else {
-          $v = $row;
+    function get_db()
+    {
+        if (!is_object($this->db)) {
+            $db_class = $this->db_class;
+            $this->db = new $db_class;
         }
-        $rows[$row[$key]] = $v;
-      }
+        return $this->db;
     }
-    return $rows;
-  }
-
-  function get_link($field=false) {
-    global $TPL;
-    if ($this->get_id()) {
-      $label = $this->get_display_value();
-
-      if ($field && $this->key_field->get_name() == $field) {
-        $label = $this->get_id();
-      } else if ($field) {
-        $label = $this->get_value($field,DST_HTML_DISPLAY);
-      }
-      return "<a href=\"".$TPL["url_alloc_".$this->classname].$this->key_field->get_name()."=".$this->get_id()."\">".$label."</a>";
+    function get_insert_fields($fields)
+    {
+        foreach ((array)$fields as $k => $field) {
+            if (strtolower($field->get_value(DST_DATABASE)) != "null") {
+                $rtn.= $comma.$field->get_name();
+                $comma = ",";
+            }
+        }
+        return $rtn;
     }
-  }
-
-  function get_name($dst=null) {
-    return $this->get_display_value($dst);
-  }
-
-  function delete_search_index_doc(&$index) {
-    if ($this->get_id()) {
-      $hits = $index->find('id:' . $this->get_id());
-      foreach ($hits as $hit) {
-        $index->delete($hit->id);
-      }
+    function get_insert_values($fields)
+    {
+        foreach ((array)$fields as $k => $field) {
+            if (strtolower($field->get_value(DST_DATABASE)) != "null") {
+                $rtn.= $comma.$field->get_value(DST_DATABASE);
+                $comma = ",";
+            }
+        }
+        return $rtn;
     }
-    return $index;
-  }
+    function get_name_equals_value($fields, $glue = ",")
+    {
+        $query = "";
+        reset($fields);
+        while (list(, $field) = each($fields)) {
+            if ($query) {
+                $query.= $glue;
+            }
+            $query.= $field->get_name()." = ".$field->get_value(DST_DATABASE);
+        }
+        return $query;
+    }
 
+    function get_assoc_array($key = false, $value = false, $sel = false, $where = array())
+    {
+        $key or $key = $this->key_field->get_name();
+        $value or $value = "*";
+        $value != "*" and $key_sql = $key.",";
+
+        $q = sprintf(
+            'SELECT %s %s FROM %s WHERE 1=1 ',
+            db_esc($key_sql),
+            db_esc($value),
+            db_esc($this->data_table)
+        );
+
+        $pkey_sql = " OR ".$this->key_field->get_name()." = ";
+        if (is_array($sel) && count($sel)) {
+            foreach ($sel as $s) {
+                $extra.= $pkey_sql.sprintf("%d", $s);
+            }
+        } else if ($sel) {
+            $extra = $pkey_sql.db_esc($sel);
+        }
+
+      // If they haven't specifically asked for inactive or all
+      // records, we default to giving them only active records.
+        if (is_object($this->data_fields[$this->data_table."Active"]) && !isset($where[$this->data_table."Active"])) {
+            $where[$this->data_table."Active"] = 1;
+
+        // Else get all records
+        } else if ($where[$this->data_table."Active"] == "all") {
+            unset($where[$this->data_table."Active"]);
+        }
+
+        if (is_array($where) && count($where)) {
+            foreach ($where as $colname => $colvalue) {
+                $q.= " AND ".$colname." = '".db_esc($colvalue)."'";
+            }
+        }
+
+        $q.= $extra;
+
+        if (is_object($this->data_fields[$this->data_table."Sequence"])) {
+            $q.= " ORDER BY ".db_esc($this->data_table)."Sequence";
+        } else if (is_object($this->data_fields[$this->data_table."Seq"])) {
+            $q.= " ORDER BY ".db_esc($this->data_table)."Seq";
+        } else if ($value != "*") {
+            $q.= " ORDER BY ".db_esc($value);
+        }
+
+        $db = new db_alloc();
+        $db->query($q);
+        $rows = array();
+        while ($row = $db->row()) {
+            if ($this->read_db_record($db)) {
+                if ($value && $value != "*") {
+                    $v = $row[$value];
+                } else {
+                    $v = $row;
+                }
+                $rows[$row[$key]] = $v;
+            }
+        }
+        return $rows;
+    }
+
+    function get_link($field = false)
+    {
+        global $TPL;
+        if ($this->get_id()) {
+            $label = $this->get_display_value();
+
+            if ($field && $this->key_field->get_name() == $field) {
+                $label = $this->get_id();
+            } else if ($field) {
+                $label = $this->get_value($field, DST_HTML_DISPLAY);
+            }
+            return "<a href=\"".$TPL["url_alloc_".$this->classname].$this->key_field->get_name()."=".$this->get_id()."\">".$label."</a>";
+        }
+    }
+
+    function get_name($dst = null)
+    {
+        return $this->get_display_value($dst);
+    }
+
+    function delete_search_index_doc(&$index)
+    {
+        if ($this->get_id()) {
+            $hits = $index->find('id:' . $this->get_id());
+            foreach ($hits as $hit) {
+                $index->delete($hit->id);
+            }
+        }
+        return $index;
+    }
 }
 
 
 // Statically callable version of $entity->have_perm();
-function have_entity_perm($class_name, $perm_name = "", $person = "", $assume_owner = false) {
-  $entity = new $class_name;
-  $entity->set_id(0);
-  return $entity->have_perm($perm_name, $person, $assume_owner);
+function have_entity_perm($class_name, $perm_name = "", $person = "", $assume_owner = false)
+{
+    $entity = new $class_name;
+    $entity->set_id(0);
+    return $entity->have_perm($perm_name, $person, $assume_owner);
 }
-
-
-?>

--- a/shared/lib/db_field.inc.php
+++ b/shared/lib/db_field.inc.php
@@ -3,116 +3,118 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class db_field {
-  var $classname = "db_field";
-  var $name;
-  var $value;
-  var $label;
-  var $empty_to_null = true;
+class db_field
+{
+    var $classname = "db_field";
+    var $name;
+    var $value;
+    var $label;
+    var $empty_to_null = true;
 
-  var $audit = false;
+    var $audit = false;
 
-  var $write_perm_name = 0;     // Name of a permission a user must have to write to this field, if any.  E.g. "admin"
-  var $read_perm_name = 0;      // Name of the permission a user must have to read this field, if any.  E.g. "read details"
+    var $write_perm_name = 0;     // Name of a permission a user must have to write to this field, if any.  E.g. "admin"
+    var $read_perm_name = 0;      // Name of the permission a user must have to read this field, if any.  E.g. "read details"
 
-  function __construct($name = "", $options = array()) {
-    $this->name = $name;
-    $this->label = $name;
+    function __construct($name = "", $options = array())
+    {
+        $this->name = $name;
+        $this->label = $name;
 
-    if (!is_array($options)) {
-      $options = array();
-      #echo "<br>".$this->name;
-    }
-    reset($options);
-    foreach ($options as $option_name => $option_value) {
-      $this->$option_name = $option_value;
-    }
-  }
-
-  function set_value($value, $source = SRC_VARIABLE) {
-    if (isset($value) || $this->empty_to_null == false) {
-      $this->value = $value;
-    }
-  }
-
-  function has_value() {
-    return isset($this->value) && imp($this->value);
-  }
-
-  function get_name() {
-    return $this->name;
-  }
-
-  function is_audited() {
-    return $this->audit;
-  }
-
-  function get_value($dest = DST_VARIABLE,$parent=null) {
-    if ($dest == DST_DATABASE) {
-      if ((isset($this->value) && imp($this->value)) || $this->empty_to_null == false) {
-        return "'".db_esc($this->value)."'";
-      } else {
-        return "NULL";
-      }
-    } else if ($dest == DST_HTML_DISPLAY) {
-      if ($this->type == "money" && imp($this->value)) {
-
-        $c = $parent->currency;
-        if ($this->currency && isset($parent->data_fields[$this->currency])) {
-          $c = $parent->get_value($this->currency);
+        if (!is_array($options)) {
+            $options = array();
+          #echo "<br>".$this->name;
         }
-
-        if (!$c) {
-          alloc_error("db_field::get_value(): No currency specified for ".$parent->classname.".".$this->name." (currency:".$c.")");
-        } else if ($this->value == $parent->all_row_fields[$this->name]) {
-          return page::money($c,$this->value,"%mo");
+        reset($options);
+        foreach ($options as $option_name => $option_value) {
+            $this->$option_name = $option_value;
         }
-      }
-      return page::htmlentities($this->value);
-    } else {
-      return $this->value;
     }
-  }
 
-  function clear_value() {
-    unset($this->value);
-  }
-
-  function validate($parent) {
-    global $TPL;
-    if ($parent->doMoney && $this->type == "money") {
-      $c = $parent->currency;
-      if ($this->currency && isset($parent->data_fields[$this->currency])) {
-        $c = $parent->get_value($this->currency);
-      }
-      if (!$c) {
-        return "db_field::validate(): No currency specified for ".$parent->classname.".".$this->name." (currency:".$c.")";
-      } else if ($this->value != $parent->all_row_fields[$this->name]) {
-        $this->set_value(page::money($c,$this->value,"%mi"));
-      }
+    function set_value($value, $source = SRC_VARIABLE)
+    {
+        if (isset($value) || $this->empty_to_null == false) {
+            $this->value = $value;
+        }
     }
-  }
+
+    function has_value()
+    {
+        return isset($this->value) && imp($this->value);
+    }
+
+    function get_name()
+    {
+        return $this->name;
+    }
+
+    function is_audited()
+    {
+        return $this->audit;
+    }
+
+    function get_value($dest = DST_VARIABLE, $parent = null)
+    {
+        if ($dest == DST_DATABASE) {
+            if ((isset($this->value) && imp($this->value)) || $this->empty_to_null == false) {
+                return "'".db_esc($this->value)."'";
+            } else {
+                return "NULL";
+            }
+        } else if ($dest == DST_HTML_DISPLAY) {
+            if ($this->type == "money" && imp($this->value)) {
+                $c = $parent->currency;
+                if ($this->currency && isset($parent->data_fields[$this->currency])) {
+                    $c = $parent->get_value($this->currency);
+                }
+
+                if (!$c) {
+                    alloc_error("db_field::get_value(): No currency specified for ".$parent->classname.".".$this->name." (currency:".$c.")");
+                } else if ($this->value == $parent->all_row_fields[$this->name]) {
+                    return page::money($c, $this->value, "%mo");
+                }
+            }
+            return page::htmlentities($this->value);
+        } else {
+            return $this->value;
+        }
+    }
+
+    function clear_value()
+    {
+        unset($this->value);
+    }
+
+    function validate($parent)
+    {
+        global $TPL;
+        if ($parent->doMoney && $this->type == "money") {
+            $c = $parent->currency;
+            if ($this->currency && isset($parent->data_fields[$this->currency])) {
+                $c = $parent->get_value($this->currency);
+            }
+            if (!$c) {
+                return "db_field::validate(): No currency specified for ".$parent->classname.".".$this->name." (currency:".$c.")";
+            } else if ($this->value != $parent->all_row_fields[$this->name]) {
+                $this->set_value(page::money($c, $this->value, "%mi"));
+            }
+        }
+    }
 }
-
-
-
-
-
-?>

--- a/shared/lib/history.inc.php
+++ b/shared/lib/history.inc.php
@@ -3,32 +3,33 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class history extends db_entity {
-  public $data_table = "history";
+class history extends db_entity
+{
+    public $data_table = "history";
 
   # Display the x most recent, but keep the 2x most recent
   # once we hit 3x, delete back down to 2x
-  public $max_to_display = 40;
+    public $max_to_display = 40;
 
-  public $key_field = historyID;
-  public $data_fields = array("the_time"
+    public $key_field = historyID;
+    public $data_fields = array("the_time"
                              ,"the_place"
                              ,"the_args"
                              ,"the_label"
@@ -36,181 +37,184 @@ class history extends db_entity {
                              );
 
 
-  function get_history_query($order="") {
-    $current_user = &singleton("current_user");
-    if (is_object($current_user)) {
-      $db = new db_alloc();
-      $query = prepare("SELECT *, historyID AS value, the_label AS label 
+    function get_history_query($order = "")
+    {
+        $current_user = &singleton("current_user");
+        if (is_object($current_user)) {
+            $db = new db_alloc();
+            $query = prepare(
+                "SELECT *, historyID AS value, the_label AS label 
                          FROM history 
                         WHERE personID = %d 
                      GROUP BY the_label 
                      ORDER BY the_time %s
-                        LIMIT %d"
-                      ,$current_user->get_id(),$order,$this->max_to_display);
-    } 
-    return $query;
-  }
-
-  // Returns an array of files which 
-  // will be used to determine whether 
-  // or not to save a history entry. 
-
-  function get_ignored_files() {
-    $ignored_files = array();
-    $query = $this->get_history_query("ASC");
-    if ($query) { 
-      $db = new db_alloc();
-      $db->query($query);
-      while ($db->next_record()) {
-        $ignored_files[] = end(explode("/", $db->f("the_place").$db->f("the_args")));
-      }
-    }
-    $ignored_files[] = "index.php";
-    $ignored_files[] = "home.php";
-    $ignored_files[] = "taskList.php";
-    $ignored_files[] = "projectList.php";
-    $ignored_files[] = "timeSheetList.php";
-    $ignored_files[] = "menu.php";
-    $ignored_files[] = "clientList.php";
-    $ignored_files[] = "itemLoan.php";
-    $ignored_files[] = "personList.php";
-    $ignored_files[] = "reminderList.php";
-    $ignored_files[] = "search.php";
-    $ignored_files[] = "person.php";
-
-    return $ignored_files;
-  }
-
-  function get_history_label($SCRIPT_NAME, $qs) {
-
-    // Save the history record LABEL with the most descriptive label
-    // possible, using the class variable->display_field_name
-
-    $db = new db_alloc();
-    $script_name_array = explode("/", $SCRIPT_NAME);
-
-    $file = end($script_name_array);
-    $CLASS_NAME = str_replace(".php", "", $file);                         // File name without .php extension
-    $dir = $script_name_array[sizeof($script_name_array) - 2];            // Directory that file is in
-    $qs = preg_replace("[^\?]", "", $qs);                                 // Nuke the leading question mark of the query string attached to end of url eg: ?tfID=23&anal=true
-
-    // We can only get a descriptive history entry if there is a xxxID 
-    // on the url, that way we can get the specific records label.
-    if ($qs) {
-      $qs_array = explode("&", $qs);
-
-      foreach($qs_array as $query_pair) {
-        // Break up url query string into key/value pairs.
-
-        if (preg_match("/$CLASS_NAME/", $query_pair)) {
-          // Look for a key like eg: transactionID so in that case it'd 
-          // use the class transaction.
-
-          $key_and_value = explode("=", $query_pair);
-          // Break key/value up into $KEY_FIELD and $ID
-          $ID = $key_and_value[1];
-          $KEY_FIELD = $key_and_value[0];
-
-          if (class_exists($CLASS_NAME) && $ID) {
-            $newClass = new $CLASS_NAME;
-            $display_field = $newClass->display_field_name;
-
-            if (is_object($newClass->key_field) && $newClass->key_field->get_name() == $KEY_FIELD) {
-              // The primary key for this db table is the same as 
-              // our KEY_FIELD var which was extracted from url.
-              $query = prepare("SELECT * FROM %s WHERE %s = %d", $CLASS_NAME, $KEY_FIELD, $ID);
-              $db->query($query);
-              $db->next_record();
-              // return that particular classes _default_ display field
-              // eg: for the table project, it would be projectName
-              $rtn = $db->f($display_field);
-
-              // But if our search for a descriptive text label failed 
-              // because the above search returned a number try again
-              // to get a description from the next table
-
-              // Get a new id and key field name and table name 
-              // Strip the trailing 'ID' from the , to get new class name 
-              $next_class_name = preg_replace("/ID$/", "", $display_field);
-
-
-              if (is_numeric($rtn) && class_exists($next_class_name)) {
-                $next_class = new $next_class_name;
-                if ($display_field == $next_class->key_field->get_name()) {
-                  // If the display field was eg: tfID and that equals the key field of this table
-                  $next_class->set_id($rtn);
-                  $next_class->select();
-                  $rtn = $next_class->get_value($next_class->display_field_name);
-                } else {
-                  $rtn = $ID;
-                }
-              }
-              $rtn = ": ".$rtn;
-              return ucwords($CLASS_NAME).$rtn;
-            }
-          }
+                        LIMIT %d",
+                $current_user->get_id(),
+                $order,
+                $this->max_to_display
+            );
         }
-      }
-    }
-    return false;
-  }
-
-  function save_history() {
-    $current_user = &singleton("current_user");
-    global $TPL;
-
-    // Delete old items if they have too many.
-    if (!is_object($current_user) || !$current_user->get_id()) {
-      return;
-    }
-    $db = new db_alloc();
-    $query = prepare("SELECT count(*) AS total FROM history WHERE personID = %d",$current_user->get_id());
-    $db->query($query);
-    $row = $db->row();
-    if ($row["total"] >= (3*$this->max_to_display)) {
-      $query  = prepare("DELETE FROM history WHERE personID = %d ORDER BY the_time LIMIT %d",$current_user->get_id(),$this->max_to_display, (2*$this->max_to_display));
-      $db->query($query);
+        return $query;
     }
 
-    $ignored_files = $this->get_ignored_files();
-    if ($_SERVER["QUERY_STRING"]) {
-      $qs = $this->strip_get_session($_SERVER["QUERY_STRING"]);
-      $qs = preg_replace("[&$]", "", $qs);
-      $qs = preg_replace("[^&]", "", $qs);
-      $qs = preg_replace("[^\?]", "", $qs);
+  // Returns an array of files which
+  // will be used to determine whether
+  // or not to save a history entry.
+
+    function get_ignored_files()
+    {
+        $ignored_files = array();
+        $query = $this->get_history_query("ASC");
+        if ($query) {
+            $db = new db_alloc();
+            $db->query($query);
+            while ($db->next_record()) {
+                $ignored_files[] = end(explode("/", $db->f("the_place").$db->f("the_args")));
+            }
+        }
+        $ignored_files[] = "index.php";
+        $ignored_files[] = "home.php";
+        $ignored_files[] = "taskList.php";
+        $ignored_files[] = "projectList.php";
+        $ignored_files[] = "timeSheetList.php";
+        $ignored_files[] = "menu.php";
+        $ignored_files[] = "clientList.php";
+        $ignored_files[] = "itemLoan.php";
+        $ignored_files[] = "personList.php";
+        $ignored_files[] = "reminderList.php";
+        $ignored_files[] = "search.php";
+        $ignored_files[] = "person.php";
+
+        return $ignored_files;
     }
 
-    $file = end(explode("/", $_SERVER["SCRIPT_NAME"]))."?".$qs;
+    function get_history_label($SCRIPT_NAME, $qs)
+    {
 
-    if (is_object($current_user) && !in_array($file, $ignored_files)
+      // Save the history record LABEL with the most descriptive label
+      // possible, using the class variable->display_field_name
+
+        $db = new db_alloc();
+        $script_name_array = explode("/", $SCRIPT_NAME);
+
+        $file = end($script_name_array);
+        $CLASS_NAME = str_replace(".php", "", $file);                         // File name without .php extension
+        $dir = $script_name_array[sizeof($script_name_array) - 2];            // Directory that file is in
+        $qs = preg_replace("[^\?]", "", $qs);                                 // Nuke the leading question mark of the query string attached to end of url eg: ?tfID=23&anal=true
+
+      // We can only get a descriptive history entry if there is a xxxID
+      // on the url, that way we can get the specific records label.
+        if ($qs) {
+            $qs_array = explode("&", $qs);
+
+            foreach ($qs_array as $query_pair) {
+                // Break up url query string into key/value pairs.
+
+                if (preg_match("/$CLASS_NAME/", $query_pair)) {
+                  // Look for a key like eg: transactionID so in that case it'd
+                  // use the class transaction.
+
+                    $key_and_value = explode("=", $query_pair);
+                  // Break key/value up into $KEY_FIELD and $ID
+                    $ID = $key_and_value[1];
+                    $KEY_FIELD = $key_and_value[0];
+
+                    if (class_exists($CLASS_NAME) && $ID) {
+                        $newClass = new $CLASS_NAME;
+                        $display_field = $newClass->display_field_name;
+
+                        if (is_object($newClass->key_field) && $newClass->key_field->get_name() == $KEY_FIELD) {
+                        // The primary key for this db table is the same as
+                        // our KEY_FIELD var which was extracted from url.
+                            $query = prepare("SELECT * FROM %s WHERE %s = %d", $CLASS_NAME, $KEY_FIELD, $ID);
+                            $db->query($query);
+                            $db->next_record();
+                        // return that particular classes _default_ display field
+                        // eg: for the table project, it would be projectName
+                            $rtn = $db->f($display_field);
+
+                        // But if our search for a descriptive text label failed
+                        // because the above search returned a number try again
+                        // to get a description from the next table
+
+                        // Get a new id and key field name and table name
+                        // Strip the trailing 'ID' from the , to get new class name
+                            $next_class_name = preg_replace("/ID$/", "", $display_field);
+
+
+                            if (is_numeric($rtn) && class_exists($next_class_name)) {
+                                  $next_class = new $next_class_name;
+                                if ($display_field == $next_class->key_field->get_name()) {
+                            // If the display field was eg: tfID and that equals the key field of this table
+                                    $next_class->set_id($rtn);
+                                    $next_class->select();
+                                    $rtn = $next_class->get_value($next_class->display_field_name);
+                                } else {
+                                    $rtn = $ID;
+                                }
+                            }
+                            $rtn = ": ".$rtn;
+                            return ucwords($CLASS_NAME).$rtn;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    function save_history()
+    {
+        $current_user = &singleton("current_user");
+        global $TPL;
+
+      // Delete old items if they have too many.
+        if (!is_object($current_user) || !$current_user->get_id()) {
+            return;
+        }
+        $db = new db_alloc();
+        $query = prepare("SELECT count(*) AS total FROM history WHERE personID = %d", $current_user->get_id());
+        $db->query($query);
+        $row = $db->row();
+        if ($row["total"] >= (3*$this->max_to_display)) {
+            $query  = prepare("DELETE FROM history WHERE personID = %d ORDER BY the_time LIMIT %d", $current_user->get_id(), $this->max_to_display, (2*$this->max_to_display));
+            $db->query($query);
+        }
+
+        $ignored_files = $this->get_ignored_files();
+        if ($_SERVER["QUERY_STRING"]) {
+            $qs = $this->strip_get_session($_SERVER["QUERY_STRING"]);
+            $qs = preg_replace("[&$]", "", $qs);
+            $qs = preg_replace("[^&]", "", $qs);
+            $qs = preg_replace("[^\?]", "", $qs);
+        }
+
+        $file = end(explode("/", $_SERVER["SCRIPT_NAME"]))."?".$qs;
+
+        if (is_object($current_user) && !in_array($file, $ignored_files)
         && !$_GET["historyID"] && !$_POST["historyID"] && $the_label = $this->get_history_label($_SERVER["SCRIPT_NAME"], $qs)) {
+            $the_place = basename($_SERVER["SCRIPT_NAME"]);
 
-      $the_place = basename($_SERVER["SCRIPT_NAME"]);
+            foreach ($TPL as $k => $v) {
+                $key = basename($this->strip_get_session($v));
+                $key = preg_replace("[&$]", "", $key);
+                $key = preg_replace("[\?$]", "", $key);
+                $arr[$key] = $k;
+            }
 
-      foreach($TPL as $k => $v) {
-        $key = basename($this->strip_get_session($v));
-        $key = preg_replace("[&$]", "", $key);
-        $key = preg_replace("[\?$]", "", $key);
-        $arr[$key] = $k;
-      }
-
-      if ($arr[$the_place]) {
-        $this->set_value("personID", $current_user->get_id());
-        $this->set_value("the_place", $arr[$the_place]);
-        $this->set_value("the_args", $qs);
-        $this->set_value("the_label", $the_label);
-        $this->set_value("the_time", date("Y-m-d H:i:s"));
-        $this->save();
-      }
+            if ($arr[$the_place]) {
+                $this->set_value("personID", $current_user->get_id());
+                $this->set_value("the_place", $arr[$the_place]);
+                $this->set_value("the_args", $qs);
+                $this->set_value("the_label", $the_label);
+                $this->set_value("the_time", date("Y-m-d H:i:s"));
+                $this->save();
+            }
+        }
     }
-  }
 
-  function strip_get_session($str="") {
-    return (string)preg_replace("/sess=[A-Za-z0-9]{32}/","",$str);
-  }
-
-
+    function strip_get_session($str = "")
+    {
+        return (string)preg_replace("/sess=[A-Za-z0-9]{32}/", "", $str);
+    }
 }
-
-
-?>

--- a/shared/lib/init.php
+++ b/shared/lib/init.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -24,8 +24,8 @@
 require_once(dirname(__FILE__)."/module.inc.php");
 require_once(dirname(__FILE__)."/template.inc.php");
 
-class shared_module extends module {
-  var $module = "shared";
-  var $db_entities = array("sentEmailLog","interestedParty");
+class shared_module extends module
+{
+    var $module = "shared";
+    var $db_entities = array("sentEmailLog","interestedParty");
 }
-?>

--- a/shared/lib/interestedParty.inc.php
+++ b/shared/lib/interestedParty.inc.php
@@ -20,10 +20,11 @@
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class interestedParty extends db_entity {
-  public $data_table = "interestedParty";
-  public $key_field = "interestedPartyID";
-  public $data_fields = array("entityID"
+class interestedParty extends db_entity
+{
+    public $data_table = "interestedParty";
+    public $key_field = "interestedPartyID";
+    public $data_fields = array("entityID"
                              ,"entity"
                              ,"fullName"
                              ,"emailAddress"
@@ -35,434 +36,447 @@ class interestedParty extends db_entity {
                              ,"interestedPartyActive"
                              );
 
-  function delete() {
-    $this->set_value("interestedPartyActive",0);
-    $this->save();
-  }
+    function delete()
+    {
+        $this->set_value("interestedPartyActive", 0);
+        $this->save();
+    }
 
-  function is_owner() {
-    $current_user = &singleton("current_user");
-    return same_email_address($this->get_value("emailAddress"),$current_user->get_value("emailAddress"));
-  }
+    function is_owner()
+    {
+        $current_user = &singleton("current_user");
+        return same_email_address($this->get_value("emailAddress"), $current_user->get_value("emailAddress"));
+    }
 
-  function save() {
-    $this->set_value("emailAddress", str_replace(array("<",">"),"",$this->get_value("emailAddress")));
-    return parent::save();
-  }
+    function save()
+    {
+        $this->set_value("emailAddress", str_replace(array("<",">"), "", $this->get_value("emailAddress")));
+        return parent::save();
+    }
 
-  function exists($entity, $entityID, $email) {
-    $email = str_replace(array("<",">"),"",$email);
-    $db = new db_alloc();
-    $db->query("SELECT *
+    function exists($entity, $entityID, $email)
+    {
+        $email = str_replace(array("<",">"), "", $email);
+        $db = new db_alloc();
+        $db->query("SELECT *
                   FROM interestedParty
                  WHERE entityID = %d
                    AND entity = '%s'
                    AND emailAddress = '%s'
-               ",$entityID,$entity,$email);
-    return $db->row();
-  }
+               ", $entityID, $entity, $email);
+        return $db->row();
+    }
 
-  function active($entity, $entityID, $email) {
-    list($email,$name) = parse_email_address($email);
-    $db = new db_alloc();
-    $db->query("SELECT *
+    function active($entity, $entityID, $email)
+    {
+        list($email,$name) = parse_email_address($email);
+        $db = new db_alloc();
+        $db->query("SELECT *
                   FROM interestedParty
                  WHERE entityID = %d
                    AND entity = '%s'
                    AND emailAddress = '%s'
                    AND interestedPartyActive = 1
-               ",$entityID,$entity,$email);
-    return $db->row();
-  }
-
-  function make_interested_parties($entity,$entityID,$encoded_parties=array()) {
-    // Nuke entries from interestedParty
-    $db = new db_alloc();
-    $db->start_transaction();
-
-    // Add entries to interestedParty
-    if (is_array($encoded_parties)) {
-      foreach ($encoded_parties as $encoded) {
-        $info = interestedParty::get_decoded_interested_party_identifier($encoded);
-        $info["entity"] = $entity;
-        $info["entityID"] = $entityID;
-        $info["emailAddress"] or $info["emailAddress"] = $info["email"];
-        $ipIDs[] = interestedParty::add_interested_party($info);
-      }
+               ", $entityID, $entity, $email);
+        return $db->row();
     }
 
-    $q = prepare("UPDATE interestedParty
+    function make_interested_parties($entity, $entityID, $encoded_parties = array())
+    {
+      // Nuke entries from interestedParty
+        $db = new db_alloc();
+        $db->start_transaction();
+
+      // Add entries to interestedParty
+        if (is_array($encoded_parties)) {
+            foreach ($encoded_parties as $encoded) {
+                $info = interestedParty::get_decoded_interested_party_identifier($encoded);
+                $info["entity"] = $entity;
+                $info["entityID"] = $entityID;
+                $info["emailAddress"] or $info["emailAddress"] = $info["email"];
+                $ipIDs[] = interestedParty::add_interested_party($info);
+            }
+        }
+
+        $q = prepare("UPDATE interestedParty
                      SET interestedPartyActive = 0
                    WHERE entity = '%s'
-                     AND entityID = %d",$entity,$entityID);
-    $ipIDs and $q.= " AND ".sprintf_implode(" AND ","interestedPartyID != %d",$ipIDs);
-    $db->query($q);
+                     AND entityID = %d", $entity, $entityID);
+        $ipIDs and $q.= " AND ".sprintf_implode(" AND ", "interestedPartyID != %d", $ipIDs);
+        $db->query($q);
 
-    $db->commit();
-  }
-
-  function abbreviate($str) {
-    $rtn = array();
-    $bits = explode(",",$str);
-    foreach((array)$bits as $bit) {
-      if ($bit) {
-        list($name,$address) = explode("<",$bit);
-        $rtn[] = page::htmlentities(trim($name))."<span class='hidden'> ".page::htmlentities("<".$address)."</span>";
-      }
+        $db->commit();
     }
-    if ($rtn) {
-      return "<span>".implode(", ",$rtn)."&nbsp;&nbsp;<a href='' onClick='$(this).parent().find(\"span\").slideToggle(\"fast\"); return false;'>Show</a></span>";
+
+    function abbreviate($str)
+    {
+        $rtn = array();
+        $bits = explode(",", $str);
+        foreach ((array)$bits as $bit) {
+            if ($bit) {
+                list($name,$address) = explode("<", $bit);
+                $rtn[] = page::htmlentities(trim($name))."<span class='hidden'> ".page::htmlentities("<".$address)."</span>";
+            }
+        }
+        if ($rtn) {
+            return "<span>".implode(", ", $rtn)."&nbsp;&nbsp;<a href='' onClick='$(this).parent().find(\"span\").slideToggle(\"fast\"); return false;'>Show</a></span>";
+        }
     }
-  }
 
-  function get_interested_parties_string($entity,$entityID) {
-    $q = prepare("SELECT get_interested_parties_string('%s',%d) as parties",$entity,$entityID);
-    $db = new db_alloc();
-    $row = $db->qr($q);
-    return $row["parties"];
-  }
+    function get_interested_parties_string($entity, $entityID)
+    {
+        $q = prepare("SELECT get_interested_parties_string('%s',%d) as parties", $entity, $entityID);
+        $db = new db_alloc();
+        $row = $db->qr($q);
+        return $row["parties"];
+    }
 
-  function sort_interested_parties($a, $b) {
-    return strtolower($a["name"]) > strtolower($b["name"]);
-  }
+    function sort_interested_parties($a, $b)
+    {
+        return strtolower($a["name"]) > strtolower($b["name"]);
+    }
 
-  public static function get_interested_parties($entity,$entityID=false,$ops=array(),$dont_select=false) {
-    $rtn = array();
+    public static function get_interested_parties($entity, $entityID = false, $ops = array(), $dont_select = false)
+    {
+        $rtn = array();
 
-    if ($entityID) {
-      $db = new db_alloc();
-      $q = prepare("SELECT *
+        if ($entityID) {
+            $db = new db_alloc();
+            $q = prepare("SELECT *
                       FROM interestedParty
                      WHERE entity='%s'
                        AND entityID = %d
-                  ",$entity,$entityID);
-      $db->query($q);
-      while ($db->row()) {
-        $ops[$db->f("emailAddress")]["name"] = $db->f("fullName");
-        $ops[$db->f("emailAddress")]["role"] = "interested";
-        $ops[$db->f("emailAddress")]["selected"] = $db->f("interestedPartyActive") && !$dont_select ? true : false;
-        $ops[$db->f("emailAddress")]["personID"] = $db->f("personID");
-        $ops[$db->f("emailAddress")]["clientContactID"] = $db->f("clientContactID");
-        $ops[$db->f("emailAddress")]["external"] = $db->f("external");
-      }
-    }
-
-    if (is_array($ops)) {
-      foreach ($ops as $email => $info) {
-        // if there is an @ symbol in email address
-        if (stristr($email,"@")) { 
-          $info["email"] = $email;
-          $info["identifier"] = interestedParty::get_encoded_interested_party_identifier($info);
-          $rtn[$email] = $info;
-        }
-      }
-
-      uasort($rtn,array("interestedParty","sort_interested_parties"));
-    }
-    return $rtn;
-  }
-
-  public static function get_encoded_interested_party_identifier($info=array()) {
-    return base64_encode(serialize($info));
-  }
-
-  function get_decoded_interested_party_identifier($blob) {
-    return unserialize(base64_decode($blob));
-  }
-
-  function get_interested_parties_html($parties=array()) {
-    $current_user = &singleton("current_user");
-    if (is_object($current_user) && $current_user->get_id()) {
-      $current_user_email = $current_user->get_value("emailAddress");
-    }
-    foreach ((array)$parties as $email => $info) {
-      $info["name"] or $info["name"] = $email;
-      if ($info["name"]) {
-        unset($sel,$c);
-        $counter++;
-
-        if ($current_user_email && same_email_address($current_user_email,$email)) {
-          $sel = " checked";
+                  ", $entity, $entityID);
+            $db->query($q);
+            while ($db->row()) {
+                  $ops[$db->f("emailAddress")]["name"] = $db->f("fullName");
+                  $ops[$db->f("emailAddress")]["role"] = "interested";
+                  $ops[$db->f("emailAddress")]["selected"] = $db->f("interestedPartyActive") && !$dont_select ? true : false;
+                  $ops[$db->f("emailAddress")]["personID"] = $db->f("personID");
+                  $ops[$db->f("emailAddress")]["clientContactID"] = $db->f("clientContactID");
+                  $ops[$db->f("emailAddress")]["external"] = $db->f("external");
+            }
         }
 
-        $info["selected"] and $sel = " checked";
-        !$info["internal"] && $info["external"] and $c.= " warn";
-        $str.= "<span width=\"150px\" class=\"nobr ".$c."\" id=\"td_ect_".$counter."\" style=\"float:left; width:150px; margin-bottom:5px;\">";
-        $str.= "<input id=\"ect_".$counter."\" type=\"checkbox\" name=\"commentEmailRecipients[]\" value=\"".$info["identifier"]."\"".$sel."> ";
-        $str.= "<label for=\"ect_".$counter."\" title=\"" . $info["name"] . " &lt;" . $info["email"] . "&gt;\">".page::htmlentities($info["name"])."</label></span>";
-      }
-    }
-    return $str;
-  }
+        if (is_array($ops)) {
+            foreach ($ops as $email => $info) {
+                // if there is an @ symbol in email address
+                if (stristr($email, "@")) {
+                    $info["email"] = $email;
+                    $info["identifier"] = interestedParty::get_encoded_interested_party_identifier($info);
+                    $rtn[$email] = $info;
+                }
+            }
 
-  function delete_interested_party($entity, $entityID, $email) {
-    // Delete existing entries
-    list($email,$name) = parse_email_address($email);
-    $row = interestedParty::active($entity,$entityID,$email);
-    if ($row) {
-      $ip = new interestedParty();
-      $ip->read_row_record($row);
-      $ip->delete();
+            uasort($rtn, array("interestedParty","sort_interested_parties"));
+        }
+        return $rtn;
     }
-  }
+
+    public static function get_encoded_interested_party_identifier($info = array())
+    {
+        return base64_encode(serialize($info));
+    }
+
+    function get_decoded_interested_party_identifier($blob)
+    {
+        return unserialize(base64_decode($blob));
+    }
+
+    function get_interested_parties_html($parties = array())
+    {
+        $current_user = &singleton("current_user");
+        if (is_object($current_user) && $current_user->get_id()) {
+            $current_user_email = $current_user->get_value("emailAddress");
+        }
+        foreach ((array)$parties as $email => $info) {
+            $info["name"] or $info["name"] = $email;
+            if ($info["name"]) {
+                unset($sel, $c);
+                $counter++;
+
+                if ($current_user_email && same_email_address($current_user_email, $email)) {
+                    $sel = " checked";
+                }
+
+                $info["selected"] and $sel = " checked";
+                !$info["internal"] && $info["external"] and $c.= " warn";
+                $str.= "<span width=\"150px\" class=\"nobr ".$c."\" id=\"td_ect_".$counter."\" style=\"float:left; width:150px; margin-bottom:5px;\">";
+                $str.= "<input id=\"ect_".$counter."\" type=\"checkbox\" name=\"commentEmailRecipients[]\" value=\"".$info["identifier"]."\"".$sel."> ";
+                $str.= "<label for=\"ect_".$counter."\" title=\"" . $info["name"] . " &lt;" . $info["email"] . "&gt;\">".page::htmlentities($info["name"])."</label></span>";
+            }
+        }
+        return $str;
+    }
+
+    function delete_interested_party($entity, $entityID, $email)
+    {
+      // Delete existing entries
+        list($email,$name) = parse_email_address($email);
+        $row = interestedParty::active($entity, $entityID, $email);
+        if ($row) {
+            $ip = new interestedParty();
+            $ip->read_row_record($row);
+            $ip->delete();
+        }
+    }
   
-  function add_interested_party($data) {
-    static $people;
-    $data["emailAddress"] = str_replace(array("<",">"),"",$data["emailAddress"]);
-    // Add new entry
+    function add_interested_party($data)
+    {
+        static $people;
+        $data["emailAddress"] = str_replace(array("<",">"), "", $data["emailAddress"]);
+      // Add new entry
 
-    $ip = new interestedParty();
-    $existing = interestedParty::exists($data["entity"], $data["entityID"], $data["emailAddress"]);
-    if ($existing) {
-      $ip->set_id($existing["interestedPartyID"]);
-      $ip->select();
-    }
-    $ip->set_value("entity",$data["entity"]);
-    $ip->set_value("entityID",$data["entityID"]);
-    $ip->set_value("fullName",$data["name"]);
-    $ip->set_value("emailAddress",$data["emailAddress"]);
-    $ip->set_value("interestedPartyActive",1);
-    if ($data["personID"]) {
-      $ip->set_value("personID",$data["personID"]);
-      $ip->set_value("fullName",person::get_fullname($data["personID"]));
-
-    } else {
-      $people or $people =& get_cached_table("person");
-      foreach ($people as $personID => $p) {
-        if ($data["emailAddress"] && same_email_address($p["emailAddress"], $data["emailAddress"])) {
-          $ip->set_value("personID",$personID);
-          $ip->set_value("fullName",$p["name"]);
+        $ip = new interestedParty();
+        $existing = interestedParty::exists($data["entity"], $data["entityID"], $data["emailAddress"]);
+        if ($existing) {
+            $ip->set_id($existing["interestedPartyID"]);
+            $ip->select();
         }
-      }
-    }
-    $extra_interested_parties = config::get_config_item("defaultInterestedParties");
-    if (!$ip->get_value("personID") && !in_array($data["emailAddress"],(array)$extra_interested_parties)) {
-      $ip->set_value("external",1);
-      $q = prepare("SELECT * FROM clientContact WHERE clientContactEmail = '%s'",$data["emailAddress"]);
-      $db = new db_alloc();
-      $db->query($q);
-      if ($row = $db->row()) {
-        $ip->set_value("clientContactID",$row["clientContactID"]);
-        $ip->set_value("fullName",$row["clientContactName"]);
-      }
-    }
-    $ip->save();
-    return $ip->get_id();
-  }
-
-  function adjust_by_email_subject($email_receive,$e) {
-    $current_user = &singleton("current_user");
-
-    $entity = $e->classname;
-    $entityID = $e->get_id();
-    $subject = trim($email_receive->mail_headers["subject"]);
-    $body = $email_receive->get_converted_encoding();
-    $msg_uid = $email_receive->msg_uid;
-    list($emailAddress,$fullName) = parse_email_address($email_receive->mail_headers["from"]);
-    list($personID,$clientContactID,$fullName) = comment::get_person_and_client($emailAddress,$fullName,$e->get_project_id());
-
-    // Load up the parent object that this comment refers to, be it task or timeSheet etc
-    if ($entity == "comment" && $entityID) {
-      $c = new comment();
-      $c->set_id($entityID);
-      $c->select();
-      $object = $c->get_parent_object();
-    } else if (class_exists($entity) && $entityID) {
-      $object = new $entity;
-      $object->set_id($entityID);
-      $object->select();
+        $ip->set_value("entity", $data["entity"]);
+        $ip->set_value("entityID", $data["entityID"]);
+        $ip->set_value("fullName", $data["name"]);
+        $ip->set_value("emailAddress", $data["emailAddress"]);
+        $ip->set_value("interestedPartyActive", 1);
+        if ($data["personID"]) {
+            $ip->set_value("personID", $data["personID"]);
+            $ip->set_value("fullName", person::get_fullname($data["personID"]));
+        } else {
+            $people or $people =& get_cached_table("person");
+            foreach ($people as $personID => $p) {
+                if ($data["emailAddress"] && same_email_address($p["emailAddress"], $data["emailAddress"])) {
+                    $ip->set_value("personID", $personID);
+                    $ip->set_value("fullName", $p["name"]);
+                }
+            }
+        }
+        $extra_interested_parties = config::get_config_item("defaultInterestedParties");
+        if (!$ip->get_value("personID") && !in_array($data["emailAddress"], (array)$extra_interested_parties)) {
+            $ip->set_value("external", 1);
+            $q = prepare("SELECT * FROM clientContact WHERE clientContactEmail = '%s'", $data["emailAddress"]);
+            $db = new db_alloc();
+            $db->query($q);
+            if ($row = $db->row()) {
+                $ip->set_value("clientContactID", $row["clientContactID"]);
+                $ip->set_value("fullName", $row["clientContactName"]);
+            }
+        }
+        $ip->save();
+        return $ip->get_id();
     }
 
-    // If we're doing subject line magic, then we're only going to do it with
-    // subject lines that have a {Key:fdsFFeSD} in them.
-    preg_match("/\{Key:[A-Za-z0-9]{8}\}(.*)\s*$/i",$subject,$m);
-    $commands = explode(" ",trim($m[1]));
+    function adjust_by_email_subject($email_receive, $e)
+    {
+        $current_user = &singleton("current_user");
 
-    foreach((array)$commands as $command) {
-      $command = strtolower($command);
-      list($command,$command2) = explode(":",$command); // for eg: duplicate:1234
+        $entity = $e->classname;
+        $entityID = $e->get_id();
+        $subject = trim($email_receive->mail_headers["subject"]);
+        $body = $email_receive->get_converted_encoding();
+        $msg_uid = $email_receive->msg_uid;
+        list($emailAddress,$fullName) = parse_email_address($email_receive->mail_headers["from"]);
+        list($personID,$clientContactID,$fullName) = comment::get_person_and_client($emailAddress, $fullName, $e->get_project_id());
 
-      // If "quiet" in the subject line, then the email/comment won't be re-emailed out again
-      if ($command == "quiet") {
-        $quiet = true;
-
-      // To unsubscribe from this conversation
-      } else if ($command == "unsub" || $command == "unsubscribe") {
-        if (interestedParty::active($entity, $entityID, $emailAddress)) {
-          interestedParty::delete_interested_party($entity, $entityID, $emailAddress);
+      // Load up the parent object that this comment refers to, be it task or timeSheet etc
+        if ($entity == "comment" && $entityID) {
+            $c = new comment();
+            $c->set_id($entityID);
+            $c->select();
+            $object = $c->get_parent_object();
+        } else if (class_exists($entity) && $entityID) {
+            $object = new $entity;
+            $object->set_id($entityID);
+            $object->select();
         }
 
-      // To subscribe to this conversation
-      } else if ($command == "sub" || $command == "subscribe") {
-        $ip = interestedParty::exists($entity, $entityID, $emailAddress);
+      // If we're doing subject line magic, then we're only going to do it with
+      // subject lines that have a {Key:fdsFFeSD} in them.
+        preg_match("/\{Key:[A-Za-z0-9]{8}\}(.*)\s*$/i", $subject, $m);
+        $commands = explode(" ", trim($m[1]));
 
-        if (!$ip) {
-          $data = array("entity"         => $entity
+        foreach ((array)$commands as $command) {
+            $command = strtolower($command);
+            list($command,$command2) = explode(":", $command); // for eg: duplicate:1234
+
+          // If "quiet" in the subject line, then the email/comment won't be re-emailed out again
+            if ($command == "quiet") {
+                $quiet = true;
+
+              // To unsubscribe from this conversation
+            } else if ($command == "unsub" || $command == "unsubscribe") {
+                if (interestedParty::active($entity, $entityID, $emailAddress)) {
+                    interestedParty::delete_interested_party($entity, $entityID, $emailAddress);
+                }
+
+              // To subscribe to this conversation
+            } else if ($command == "sub" || $command == "subscribe") {
+                $ip = interestedParty::exists($entity, $entityID, $emailAddress);
+
+                if (!$ip) {
+                    $data = array("entity"         => $entity
                        ,"entityID"       => $entityID
                        ,"fullName"       => $fullName
                        ,"emailAddress"   => $emailAddress
                        ,"personID"       => $personID
                        ,"clientContactID"=> $clientContactID);
-          interestedParty::add_interested_party($data);
+                    interestedParty::add_interested_party($data);
 
-        // Else reactivate existing IP
-        } else if (!interestedParty::active($entity, $entityID, $emailAddress)) {
-          $interestedParty = new interestedParty();
-          $interestedParty->set_id($ip["interestedPartyID"]);
-          $interestedParty->select();
-          $interestedParty->set_value("interestedPartyActive",1);
-          $interestedParty->save();
-        }
+                // Else reactivate existing IP
+                } else if (!interestedParty::active($entity, $entityID, $emailAddress)) {
+                    $interestedParty = new interestedParty();
+                    $interestedParty->set_id($ip["interestedPartyID"]);
+                    $interestedParty->select();
+                    $interestedParty->set_value("interestedPartyActive", 1);
+                    $interestedParty->save();
+                }
 
 
-      // If there's a number/duration then add some time to a time sheet
-      } else if (is_object($current_user) && $current_user->get_id() && preg_match("/([\.\d]+)/i",$command,$m)) { 
-        $duration = $m[1];
+              // If there's a number/duration then add some time to a time sheet
+            } else if (is_object($current_user) && $current_user->get_id() && preg_match("/([\.\d]+)/i", $command, $m)) {
+                $duration = $m[1];
   
-        if (is_numeric($duration)) {
-          if (is_object($object) && $object->classname == "task" && $object->get_id() && $current_user->get_id()) {
-            $timeSheet = new timeSheet();
-            $tsi_row = $timeSheet->add_timeSheetItem(array("taskID"=>$object->get_id(), "duration"=>$duration, "comment"=>$body, "msg_uid"=>$msg_uid, "msg_id"=>$email_receive->mail_headers["message-id"], "multiplier"=>1));
-            $timeUnit = new timeUnit();
-            $units = $timeUnit->get_assoc_array("timeUnitID","timeUnitLabelA");
-            $unitLabel = $units[$tsi_row["timeSheetItemDurationUnitID"]];
-          }
+                if (is_numeric($duration)) {
+                    if (is_object($object) && $object->classname == "task" && $object->get_id() && $current_user->get_id()) {
+                        $timeSheet = new timeSheet();
+                        $tsi_row = $timeSheet->add_timeSheetItem(array("taskID"=>$object->get_id(), "duration"=>$duration, "comment"=>$body, "msg_uid"=>$msg_uid, "msg_id"=>$email_receive->mail_headers["message-id"], "multiplier"=>1));
+                        $timeUnit = new timeUnit();
+                        $units = $timeUnit->get_assoc_array("timeUnitID", "timeUnitLabelA");
+                        $unitLabel = $units[$tsi_row["timeSheetItemDurationUnitID"]];
+                    }
+                }
+
+              // Otherwise assume it's a status change
+            } else if (is_object($current_user) && $current_user->get_id() && $command) {
+                if (is_object($object) && $object->get_id()) {
+                    $object->set_value("taskStatus", $command);
+                    if ($command2 && preg_match("/dup/i", $command)) {
+                        $object->set_value("duplicateTaskID", $command2);
+                    } else if ($command2 && preg_match("/tasks/i", $command)) {
+                        $object->add_pending_tasks($command2);
+                    }
+                    $object->save();
+                }
+            }
+        }
+        return $quiet;
+    }
+
+    function get_list_filter($filter = array())
+    {
+        $filter["emailAddress"] = str_replace(array("<",">"), "", $filter["emailAddress"]);
+        $filter["emailAddress"]    and $sql[] = prepare("(interestedParty.emailAddress LIKE '%%%s%%')", $filter["emailAddress"]);
+        $filter["fullName"]        and $sql[] = prepare("(interestedParty.fullName LIKE '%%%s%%')", $filter["fullName"]);
+        $filter["personID"]        and $sql[] = prepare("(interestedParty.personID = %d)", $filter["personID"]);
+        $filter["clientContactID"] and $sql[] = prepare("(interestedParty.clientContactID = %d)", $filter["clientContactID"]);
+        $filter["entity"]          and $sql[] = prepare("(interestedParty.entity = '%s')", $filter["entity"]);
+        $filter["entityID"]        and $sql[] = prepare("(interestedParty.entityID = %d)", $filter["entityID"]);
+        $filter["active"]          and $sql[] = prepare("(interestedParty.interestedPartyActive = %d)", $filter["active"]);
+        $filter["taskID"]          and $sql[] = prepare("(comment.commentMaster='task' AND comment.commentMasterID=%d)", $filter["taskID"]);
+        return $sql;
+    }
+
+    public static function get_list($_FORM)
+    {
+
+        if ($_FORM["taskID"]) {
+            $join = " LEFT JOIN comment ON ((interestedParty.entity = comment.commentType AND interestedParty.entityID = comment.commentLinkID) OR (interestedParty.entity = 'comment' and interestedParty.entityID = comment.commentID))";
+            $groupby = ' GROUP BY interestedPartyID';
+        }
+    
+        $filter = interestedParty::get_list_filter($_FORM);
+        $_FORM["return"] or $_FORM["return"] = "html";
+    
+        if (is_array($filter) && count($filter)) {
+            $f = " WHERE ".implode(" AND ", $filter);
+        }
+    
+        $db = new db_alloc();
+        $q = "SELECT * FROM interestedParty ".$join.$f.$groupby;
+
+        $db->query($q);
+        while ($row = $db->next_record()) {
+            $interestedParty = new interestedParty();
+            $interestedParty->read_db_record($db);
+            $rows[$interestedParty->get_id()] = $row;
+        }
+        return (array)$rows;
+    }
+
+    function is_external($entity, $entityID)
+    {
+        $ips = interestedParty::get_interested_parties($entity, $entityID);
+        foreach ($ips as $email => $info) {
+            if ($info["external"] && $info["selected"]) {
+                return true;
+            }
+        }
+    }
+
+    function expand_ip($ip, $projectID = null)
+    {
+
+      // jon               alloc username
+      // jon@jon.com       alloc username or client or stranger
+      // Jon <jon@jon.com> alloc username or client or stranger
+      // Jon Smith         alloc fullname or client fullname
+    
+      // username
+        $people or $people = person::get_people_by_username();
+        if (preg_match("/^\w+$/i", $ip)) {
+            return array($people[$ip]["personID"],$people[$ip]["name"],$people[$ip]["emailAddress"]);
         }
 
-      // Otherwise assume it's a status change
-      } else if (is_object($current_user) && $current_user->get_id() && $command) {
-        if (is_object($object) && $object->get_id()) {
-          $object->set_value("taskStatus",$command);
-          if ($command2 && preg_match("/dup/i",$command)) {
-            $object->set_value("duplicateTaskID",$command2);
-          } else if ($command2 && preg_match("/tasks/i",$command)) {
-            $object->add_pending_tasks($command2);
-          }
-          $object->save();
+      // email address
+        $people = person::get_people_by_username("emailAddress");
+        list($email,$name) = parse_email_address($ip);
+        if ($people[$email]) {
+            return array($people[$email]["personID"],$people[$email]["name"],$people[$email]["emailAddress"]);
         }
-      }
 
-    }
-    return $quiet;
-  }
+      // Jon smith
+        if (preg_match("/^[\w\s]+$/i", $ip)) {
+            $personID = person::find_by_name($ip, 100);
+            if ($personID) {
+                $people = person::get_people_by_username("personID");
+                return array($personID,$people[$personID]["name"],$people[$personID]["emailAddress"]);
+            }
 
-  function get_list_filter($filter=array()) {
-    $filter["emailAddress"] = str_replace(array("<",">"),"",$filter["emailAddress"]);
-    $filter["emailAddress"]    and $sql[] = prepare("(interestedParty.emailAddress LIKE '%%%s%%')",$filter["emailAddress"]);
-    $filter["fullName"]        and $sql[] = prepare("(interestedParty.fullName LIKE '%%%s%%')",$filter["fullName"]);
-    $filter["personID"]        and $sql[] = prepare("(interestedParty.personID = %d)",$filter["personID"]);
-    $filter["clientContactID"] and $sql[] = prepare("(interestedParty.clientContactID = %d)",$filter["clientContactID"]);
-    $filter["entity"]          and $sql[] = prepare("(interestedParty.entity = '%s')",$filter["entity"]);
-    $filter["entityID"]        and $sql[] = prepare("(interestedParty.entityID = %d)",$filter["entityID"]);
-    $filter["active"]          and $sql[] = prepare("(interestedParty.interestedPartyActive = %d)",$filter["active"]);
-    $filter["taskID"]          and $sql[] = prepare("(comment.commentMaster='task' AND comment.commentMasterID=%d)",$filter["taskID"]);
-    return $sql;
-  }
-
-  public static function get_list($_FORM) {
-
-    if ($_FORM["taskID"]) {
-      $join = " LEFT JOIN comment ON ((interestedParty.entity = comment.commentType AND interestedParty.entityID = comment.commentLinkID) OR (interestedParty.entity = 'comment' and interestedParty.entityID = comment.commentID))";
-      $groupby = ' GROUP BY interestedPartyID';
-    }
-    
-    $filter = interestedParty::get_list_filter($_FORM);
-    $_FORM["return"] or $_FORM["return"] = "html";
-    
-    if (is_array($filter) && count($filter)) {
-      $f = " WHERE ".implode(" AND ",$filter);
-    }
-    
-    $db = new db_alloc();
-    $q = "SELECT * FROM interestedParty ".$join.$f.$groupby;
-
-    $db->query($q);
-    while ($row = $db->next_record()) {
-      $interestedParty = new interestedParty();
-      $interestedParty->read_db_record($db);
-      $rows[$interestedParty->get_id()] = $row;
-    }
-    return (array)$rows;
-  }
-
-  function is_external($entity, $entityID) {
-    $ips = interestedParty::get_interested_parties($entity,$entityID);
-    foreach ($ips as $email => $info) {
-      if ($info["external"] && $info["selected"]) {
-        return true;
-      }
-    }
-  }
-
-  function expand_ip($ip,$projectID=null) {
-
-    // jon               alloc username
-    // jon@jon.com       alloc username or client or stranger
-    // Jon <jon@jon.com> alloc username or client or stranger
-    // Jon Smith         alloc fullname or client fullname
-    
-    // username
-    $people or $people = person::get_people_by_username();
-    if (preg_match("/^\w+$/i",$ip)) {
-      return array($people[$ip]["personID"],$people[$ip]["name"],$people[$ip]["emailAddress"]);
-    } 
-
-    // email address
-    $people = person::get_people_by_username("emailAddress");
-    list($email,$name) = parse_email_address($ip);
-    if ($people[$email]) {
-      return array($people[$email]["personID"],$people[$email]["name"],$people[$email]["emailAddress"]);
+            $ccid = clientContact::find_by_name($ip, $projectID, 100);
+            if ($ccid) {
+                $cc = new clientContact();
+                $cc->set_id($ccid);
+                $cc->select();
+                $name = $cc->get_value("clientContactName");
+                $email = $cc->get_value("clientContactEmail");
+            }
+        }
+        return array(null,$name,$email);
     }
 
-    // Jon smith
-    if (preg_match("/^[\w\s]+$/i",$ip)) {
-      $personID = person::find_by_name($ip,100);
-      if ($personID) {
-        $people = person::get_people_by_username("personID");
-        return array($personID,$people[$personID]["name"],$people[$personID]["emailAddress"]);
-      }
+    function add_remove_ips($ip, $entity, $entityID, $projectID = null)
+    {
+        $parties = explode(",", $ip);
+        foreach ($parties as $party) {
+            $party = trim($party);
 
-      $ccid = clientContact::find_by_name($ip,$projectID,100);
-      if ($ccid) {
-        $cc = new clientContact();
-        $cc->set_id($ccid);
-        $cc->select();
-        $name = $cc->get_value("clientContactName");
-        $email = $cc->get_value("clientContactEmail");
-      }
-    }
-    return array(null,$name,$email);
-  }
+          // remove an ip
+            if ($party[0] == "%") {
+                list($personID,$name,$email) = interestedParty::expand_ip(implode("", array_slice(str_split($party), 1)), $projectID);
+                interestedParty::delete_interested_party($entity, $entityID, $email);
 
-  function add_remove_ips($ip,$entity,$entityID,$projectID=null) {
-    $parties = explode(",",$ip);
-    foreach ($parties as $party) {
-      $party = trim($party);
-
-      // remove an ip
-      if ($party[0] == "%") {
-        list($personID,$name,$email) = interestedParty::expand_ip(implode("",array_slice(str_split($party),1)),$projectID);
-        interestedParty::delete_interested_party($entity, $entityID, $email);
-
-      // add an ip
-      } else {
-        list($personID,$name,$email) = interestedParty::expand_ip($party,$projectID);
-        if (!$email || strpos($email,"@") === false) {
-          alloc_error("Unable to add interested party: ".$party);
-        } else {
-          interestedParty::add_interested_party(array("entity"      => $entity
+              // add an ip
+            } else {
+                list($personID,$name,$email) = interestedParty::expand_ip($party, $projectID);
+                if (!$email || strpos($email, "@") === false) {
+                    alloc_error("Unable to add interested party: ".$party);
+                } else {
+                    interestedParty::add_interested_party(array("entity"      => $entity
                                                      ,"entityID"    => $entityID
                                                      ,"fullName"    => $name
                                                      ,"emailAddress"=> $email
                                                      ,"personID"    => $personID));
+                }
+            }
         }
-      }
     }
-  }
-
-
 }
-
-
-
-?>

--- a/shared/lib/meta.inc.php
+++ b/shared/lib/meta.inc.php
@@ -20,13 +20,14 @@
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class meta extends db_entity {
+class meta extends db_entity
+{
 
-  private $t;
+    private $t;
 
   // This variable contains the definitive list of all the referential
   // integrity tables that the user is allowed to edit.
-  public static $tables = array("absenceType"     => "Absence Types"
+    public static $tables = array("absenceType"     => "Absence Types"
                      ,"clientStatus"              => "Client Statuses"
                      #,"configType"                => "Config Types"
                      #,"invoiceStatus"             => "Invoice Statuses"
@@ -49,51 +50,51 @@ class meta extends db_entity {
                      ,"taskType"                 => "Task Types"
                      );
 
-  function __construct($table="") {
-    $this->classname = $table;
-    $this->data_table = $table;
-    $this->display_field_name = $table."ID";
-    $this->key_field = $table."ID";
-    $this->data_fields = array($table."Seq"
+    function __construct($table = "")
+    {
+        $this->classname = $table;
+        $this->data_table = $table;
+        $this->display_field_name = $table."ID";
+        $this->key_field = $table."ID";
+        $this->data_fields = array($table."Seq"
                               ,$table."Active"
                               );
-    if ($table == "taskStatus") {
-      $this->data_fields[] = "taskStatusLabel";
-      $this->data_fields[] = "taskStatusColour";
-    } else if ($table == "currencyType") {
-      $this->data_fields[] = "currencyTypeLabel";
-      $this->data_fields[] = "currencyTypeName";
-      $this->data_fields[] = "numberToBasic";
+        if ($table == "taskStatus") {
+            $this->data_fields[] = "taskStatusLabel";
+            $this->data_fields[] = "taskStatusColour";
+        } else if ($table == "currencyType") {
+            $this->data_fields[] = "currencyTypeLabel";
+            $this->data_fields[] = "currencyTypeName";
+            $this->data_fields[] = "numberToBasic";
+        }
+        $this->t = $table; // for internal use
+        return parent::__construct();
     }
-    $this->t = $table; // for internal use
-    return parent::__construct();
-  }
 
-  function get_tables() {
-    return self::$tables;
-  }
-
-  function get_list($include_inactive=false) {
-    if ($this->data_table) {
-      $include_inactive and $where[$this->data_table."Active"] = "all"; // active and inactive
-      return $this->get_assoc_array(false,false,false,$where);
+    function get_tables()
+    {
+        return self::$tables;
     }
-  }
 
-  function get_label() {
-    if ($this->data_table) {
-      return self::$tables[$this->data_table];
+    function get_list($include_inactive = false)
+    {
+        if ($this->data_table) {
+            $include_inactive and $where[$this->data_table."Active"] = "all"; // active and inactive
+            return $this->get_assoc_array(false, false, false, $where);
+        }
     }
-  }
 
-  function validate() {
-    $this->get_id() or $err[] = "Please enter a Value/ID for the ".$this->get_label();
-    $this->get_value($this->t."Seq") or $err[] = "Please enter a Sequence Number for the ".$this->get_label();
-    return parent::validate($err);
-  }
+    function get_label()
+    {
+        if ($this->data_table) {
+            return self::$tables[$this->data_table];
+        }
+    }
 
+    function validate()
+    {
+        $this->get_id() or $err[] = "Please enter a Value/ID for the ".$this->get_label();
+        $this->get_value($this->t."Seq") or $err[] = "Please enter a Sequence Number for the ".$this->get_label();
+        return parent::validate($err);
+    }
 }
-
-
-
-?>

--- a/shared/lib/module.inc.php
+++ b/shared/lib/module.inc.php
@@ -3,39 +3,40 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class module {
-  var $module = '';
-  var $db_entities = array();   // A list of db_entity class names implemented by this module
-  var $home_items = array();    // A list of all the home page items implemented by this module
+class module
+{
+    var $module = '';
+    var $db_entities = array();   // A list of db_entity class names implemented by this module
+    var $home_items = array();    // A list of all the home page items implemented by this module
 
-  public function __construct() {
-    spl_autoload_register(array($this, 'autoloader'));
-  }
-
-  public function autoloader($class) {
-    $s = DIRECTORY_SEPARATOR;
-    $p = dirname(__FILE__).$s.'..'.$s.'..'.$s.$this->module.$s.'lib'.$s.$class.'.inc.php';
-    if (file_exists($p)) {
-      require_once($p);
+    public function __construct()
+    {
+        spl_autoload_register(array($this, 'autoloader'));
     }
-  }
 
+    public function autoloader($class)
+    {
+        $s = DIRECTORY_SEPARATOR;
+        $p = dirname(__FILE__).$s.'..'.$s.'..'.$s.$this->module.$s.'lib'.$s.$class.'.inc.php';
+        if (file_exists($p)) {
+            require_once($p);
+        }
+    }
 }
-?>

--- a/shared/lib/page.inc.php
+++ b/shared/lib/page.inc.php
@@ -3,514 +3,544 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
  */
 
-class page {
+class page
+{
 
   // Initializer
-  public function __construct() {
-  }
-  public static function header() {
-    global $TPL;
-    $current_user = &singleton("current_user");
-
-    if ($current_user->prefs["showFilters"]) {
-      $TPL["onLoad"] []= "show_filter();";
+    public function __construct()
+    {
     }
+    public static function header()
+    {
+        global $TPL;
+        $current_user = &singleton("current_user");
 
-    $TPL["onLoad"] or $TPL["onLoad"] = array();
-
-    include_template(ALLOC_MOD_DIR."shared/templates/headerS.tpl");
-  }
-  public static function footer() {
-    $current_user = &singleton("current_user");
-
-    include_template(ALLOC_MOD_DIR."shared/templates/footerS.tpl");
-    // close page
-    $sess = new session();
-    $sess->Save();
-    if (is_object($current_user) && method_exists($current_user,"get_id") && $current_user->get_id()) {
-      $current_user->store_prefs();
-    }
-  }
-  public static function tabs() {
-    global $TPL;
-    $current_user = &singleton("current_user");
-    $c = new config();
-    $tabs = config::get_config_item("allocTabs");
-
-    $menu_links["home"]    = array("name"=>"Home",    "url"=>$TPL["url_alloc_home"],           "module"=>"home");
-    $menu_links["client"]  = array("name"=>"Clients", "url"=>$TPL["url_alloc_clientList"],     "module"=>"client");
-    $menu_links["project"] = array("name"=>"Projects","url"=>$TPL["url_alloc_projectList"],    "module"=>"project");
-    $menu_links["task"]    = array("name"=>"Tasks",   "url"=>$TPL["url_alloc_taskList"],       "module"=>"task");
-    $menu_links["time"]    = array("name"=>"Time",    "url"=>$TPL["url_alloc_timeSheetList"],  "module"=>"time");
-    $menu_links["invoice"] = array("name"=>"Invoices","url"=>$TPL["url_alloc_invoiceList"],    "module"=>"invoice");
-    $menu_links["sale"]    = array("name"=>"Sales",   "url"=>$TPL["url_alloc_productSaleList"],"module"=>"sale");
-    $menu_links["person"]  = array("name"=>"People",  "url"=>$TPL["url_alloc_personList"],     "module"=>"person");
-    $menu_links["wiki"]    = array("name"=>"Wiki",    "url"=>$TPL["url_alloc_wiki"],           "module"=>"wiki");
-    if (have_entity_perm("inbox",PERM_READ,$current_user) && config::get_config_item("allocEmailHost")) {
-      $menu_links["inbox"] = array("name"=>"Inbox",   "url"=>$TPL["url_alloc_inbox"],          "module"=>"email");
-    }
-    $menu_links["tools"]   = array("name"=>"Tools",   "url"=>$TPL["url_alloc_tools"],          "module"=>"tools");
-
-    $x = -1;
-    foreach ($menu_links as $key => $arr) {
-      if (in_array($key,$tabs) && has($key)) {
-        $name = $arr["name"];
-        $TPL["x"] = $x;
-        $x+=70;
-        $TPL["url"] = $arr["url"];
-        $TPL["name"] = $name;
-        unset($TPL["active"]);
-        if (preg_match("/".str_replace("/", "\\/", $_SERVER["PHP_SELF"])."/", $url) || preg_match("/".$arr["module"]."/",$_SERVER["PHP_SELF"]) && !$done) {
-          $TPL["active"] = " active";
-          $done = true;
+        if ($current_user->prefs["showFilters"]) {
+            $TPL["onLoad"] []= "show_filter();";
         }
-        include_template(ALLOC_MOD_DIR."shared/templates/tabR.tpl");
-      }
-    }
-  }
-  public static function toolbar() {
-    global $TPL;
-    $current_user = &singleton("current_user");
-    $db = new db_alloc(); 
-    has("task") and $str[] = "<option value=\"create_".$TPL["url_alloc_task"]."\">New Task</option>";
-    has("time") and $str[] = "<option value=\"create_".$TPL["url_alloc_timeSheet"]."\">New Time Sheet</option>";
-    has("task") and $str[] = "<option value=\"create_".$TPL["url_alloc_task"]."tasktype=Fault\">New Fault</option>";
-    has("task") and $str[] = "<option value=\"create_".$TPL["url_alloc_task"]."tasktype=Message\">New Message</option>";
-    if (has("project") && have_entity_perm("project", PERM_CREATE, $current_user)) {
-      $str[] = "<option value=\"create_".$TPL["url_alloc_project"]."\">New Project</option>";
-    } 
-    has("client")   and $str[] = "<option value=\"create_".$TPL["url_alloc_client"]."\">New Client</option>";
-    has("finance")  and $str[] = "<option value=\"create_".$TPL["url_alloc_expenseForm"]."\">New Expense Form</option>";
-    has("reminder") and $str[] = "<option value=\"create_".$TPL["url_alloc_reminder"]."parentType=general&step=2\">New Reminder</option>";
-    if (has("person") && have_entity_perm("person", PERM_CREATE, $current_user)) {
-      $str[] = "<option value=\"create_".$TPL["url_alloc_person"]."\">New Person</option>";
-    }
-    has("item") and $str[] = "<option value=\"create_".$TPL["url_alloc_loanAndReturn"]."\">New Item Loan</option>";
-    $str[] = "<option value=\"\" disabled=\"disabled\">--------------------";
-    $history = new history();
-    $q = $history->get_history_query("DESC");
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $r["history_".$row["value"]] = $row["the_label"];
-    }
-    $str[] = page::select_options($r, $_POST["search_action"]);
-    $TPL["history_options"] = implode("\n",$str);
-    $TPL["category_options"] = page::get_category_options($_POST["search_action"]);
-    $TPL["needle"] = $_POST["needle"];
-    include_template(ALLOC_MOD_DIR."shared/templates/toolbarS.tpl");
-  }
-  public static function extra_links() {
-    $current_user = &singleton("current_user");
-    global $TPL;
-    global $sess;
-    $str = "<a href=\"".$TPL["url_alloc_starList"]."\" class=\"icon-star\"></a>&nbsp;&nbsp;&nbsp;";
-    $str.= $current_user->get_link()."&nbsp;&nbsp;&nbsp;";
-    if (defined("PAGE_IS_PRINTABLE") && PAGE_IS_PRINTABLE) {
-      $sess or $sess = new session();
-      $str.= "<a href=\"".$sess->url($_SERVER["REQUEST_URI"])."media=print\">Print</a>&nbsp;&nbsp;&nbsp;";
-    }
-    if (have_entity_perm("config", PERM_UPDATE, $current_user, true)) {
-      $str.= "<a href=\"".$TPL["url_alloc_config"]."\">Setup</a>&nbsp;&nbsp;&nbsp;";
-    }
-    $url = $sess->url("../help/help.php?topic=".$TPL["alloc_help_link_name"]);
-    $str.= "<a href=\"".$url."\">Help</a>&nbsp;&nbsp;&nbsp;";
-    $url = $TPL["url_alloc_logout"];
-    $str.= "<a href=\"".$url."\">Logout</a>";
-    return $str;
-  }
-  public static function messages() {
-    global $TPL;
 
-    $class_to_icon["good"] = "icon-ok-sign";
-    $class_to_icon["bad"] = "icon-exclamation-sign";
-    $class_to_icon["help"] = "icon-info-sign";
+        $TPL["onLoad"] or $TPL["onLoad"] = array();
 
-    $search  = array("&lt;br&gt;","&lt;br /&gt;","&lt;b&gt;","&lt;/b&gt;","&lt;u&gt;","&lt;/u&gt;",'\\');
-    $replace = array("<br>"      ,"<br />"      ,"<b>"      ,"</b>"      ,"<u>"      ,"</u>"      ,'');
+        include_template(ALLOC_MOD_DIR."shared/templates/headerS.tpl");
+    }
+    public static function footer()
+    {
+        $current_user = &singleton("current_user");
 
-    $types = array("message"             => "bad"
+        include_template(ALLOC_MOD_DIR."shared/templates/footerS.tpl");
+      // close page
+        $sess = new session();
+        $sess->Save();
+        if (is_object($current_user) && method_exists($current_user, "get_id") && $current_user->get_id()) {
+            $current_user->store_prefs();
+        }
+    }
+    public static function tabs()
+    {
+        global $TPL;
+        $current_user = &singleton("current_user");
+        $c = new config();
+        $tabs = config::get_config_item("allocTabs");
+
+        $menu_links["home"]    = array("name"=>"Home",    "url"=>$TPL["url_alloc_home"],           "module"=>"home");
+        $menu_links["client"]  = array("name"=>"Clients", "url"=>$TPL["url_alloc_clientList"],     "module"=>"client");
+        $menu_links["project"] = array("name"=>"Projects","url"=>$TPL["url_alloc_projectList"],    "module"=>"project");
+        $menu_links["task"]    = array("name"=>"Tasks",   "url"=>$TPL["url_alloc_taskList"],       "module"=>"task");
+        $menu_links["time"]    = array("name"=>"Time",    "url"=>$TPL["url_alloc_timeSheetList"],  "module"=>"time");
+        $menu_links["invoice"] = array("name"=>"Invoices","url"=>$TPL["url_alloc_invoiceList"],    "module"=>"invoice");
+        $menu_links["sale"]    = array("name"=>"Sales",   "url"=>$TPL["url_alloc_productSaleList"],"module"=>"sale");
+        $menu_links["person"]  = array("name"=>"People",  "url"=>$TPL["url_alloc_personList"],     "module"=>"person");
+        $menu_links["wiki"]    = array("name"=>"Wiki",    "url"=>$TPL["url_alloc_wiki"],           "module"=>"wiki");
+        if (have_entity_perm("inbox", PERM_READ, $current_user) && config::get_config_item("allocEmailHost")) {
+            $menu_links["inbox"] = array("name"=>"Inbox",   "url"=>$TPL["url_alloc_inbox"],          "module"=>"email");
+        }
+        $menu_links["tools"]   = array("name"=>"Tools",   "url"=>$TPL["url_alloc_tools"],          "module"=>"tools");
+
+        $x = -1;
+        foreach ($menu_links as $key => $arr) {
+            if (in_array($key, $tabs) && has($key)) {
+                $name = $arr["name"];
+                $TPL["x"] = $x;
+                $x+=70;
+                $TPL["url"] = $arr["url"];
+                $TPL["name"] = $name;
+                unset($TPL["active"]);
+                if (preg_match("/".str_replace("/", "\\/", $_SERVER["PHP_SELF"])."/", $url) || preg_match("/".$arr["module"]."/", $_SERVER["PHP_SELF"]) && !$done) {
+                    $TPL["active"] = " active";
+                    $done = true;
+                }
+                include_template(ALLOC_MOD_DIR."shared/templates/tabR.tpl");
+            }
+        }
+    }
+    public static function toolbar()
+    {
+        global $TPL;
+        $current_user = &singleton("current_user");
+        $db = new db_alloc();
+        has("task") and $str[] = "<option value=\"create_".$TPL["url_alloc_task"]."\">New Task</option>";
+        has("time") and $str[] = "<option value=\"create_".$TPL["url_alloc_timeSheet"]."\">New Time Sheet</option>";
+        has("task") and $str[] = "<option value=\"create_".$TPL["url_alloc_task"]."tasktype=Fault\">New Fault</option>";
+        has("task") and $str[] = "<option value=\"create_".$TPL["url_alloc_task"]."tasktype=Message\">New Message</option>";
+        if (has("project") && have_entity_perm("project", PERM_CREATE, $current_user)) {
+            $str[] = "<option value=\"create_".$TPL["url_alloc_project"]."\">New Project</option>";
+        }
+        has("client")   and $str[] = "<option value=\"create_".$TPL["url_alloc_client"]."\">New Client</option>";
+        has("finance")  and $str[] = "<option value=\"create_".$TPL["url_alloc_expenseForm"]."\">New Expense Form</option>";
+        has("reminder") and $str[] = "<option value=\"create_".$TPL["url_alloc_reminder"]."parentType=general&step=2\">New Reminder</option>";
+        if (has("person") && have_entity_perm("person", PERM_CREATE, $current_user)) {
+            $str[] = "<option value=\"create_".$TPL["url_alloc_person"]."\">New Person</option>";
+        }
+        has("item") and $str[] = "<option value=\"create_".$TPL["url_alloc_loanAndReturn"]."\">New Item Loan</option>";
+        $str[] = "<option value=\"\" disabled=\"disabled\">--------------------";
+        $history = new history();
+        $q = $history->get_history_query("DESC");
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $r["history_".$row["value"]] = $row["the_label"];
+        }
+        $str[] = page::select_options($r, $_POST["search_action"]);
+        $TPL["history_options"] = implode("\n", $str);
+        $TPL["category_options"] = page::get_category_options($_POST["search_action"]);
+        $TPL["needle"] = $_POST["needle"];
+        include_template(ALLOC_MOD_DIR."shared/templates/toolbarS.tpl");
+    }
+    public static function extra_links()
+    {
+        $current_user = &singleton("current_user");
+        global $TPL;
+        global $sess;
+        $str = "<a href=\"".$TPL["url_alloc_starList"]."\" class=\"icon-star\"></a>&nbsp;&nbsp;&nbsp;";
+        $str.= $current_user->get_link()."&nbsp;&nbsp;&nbsp;";
+        if (defined("PAGE_IS_PRINTABLE") && PAGE_IS_PRINTABLE) {
+            $sess or $sess = new session();
+            $str.= "<a href=\"".$sess->url($_SERVER["REQUEST_URI"])."media=print\">Print</a>&nbsp;&nbsp;&nbsp;";
+        }
+        if (have_entity_perm("config", PERM_UPDATE, $current_user, true)) {
+            $str.= "<a href=\"".$TPL["url_alloc_config"]."\">Setup</a>&nbsp;&nbsp;&nbsp;";
+        }
+        $url = $sess->url("../help/help.php?topic=".$TPL["alloc_help_link_name"]);
+        $str.= "<a href=\"".$url."\">Help</a>&nbsp;&nbsp;&nbsp;";
+        $url = $TPL["url_alloc_logout"];
+        $str.= "<a href=\"".$url."\">Logout</a>";
+        return $str;
+    }
+    public static function messages()
+    {
+        global $TPL;
+
+        $class_to_icon["good"] = "icon-ok-sign";
+        $class_to_icon["bad"] = "icon-exclamation-sign";
+        $class_to_icon["help"] = "icon-info-sign";
+
+        $search  = array("&lt;br&gt;","&lt;br /&gt;","&lt;b&gt;","&lt;/b&gt;","&lt;u&gt;","&lt;/u&gt;",'\\');
+        $replace = array("<br>"      ,"<br />"      ,"<b>"      ,"</b>"      ,"<u>"      ,"</u>"      ,'');
+
+        $types = array("message"             => "bad"
                   ,"message_good"        => "good"
                   ,"message_help"        => "help"
                   ,"message_good_no_esc" => "good"
                   ,"message_help_no_esc" => "help"
                   );
 
-    foreach ($types as $type => $class) {
-      $str = "";
-      $TPL[$type]  and $str = is_array($TPL[$type])  ? implode("<br>",$TPL[$type])  : $TPL[$type];
-      $_GET[$type] and $str = is_array($_GET[$type]) ? implode("<br>",$_GET[$type]) : $_GET[$type];
-      if (in_str("no_esc",$type)) {
-        $str and $msg[$type] = $str;
-      } else {
-        $str and $msg[$type] = str_replace($search,$replace,page::htmlentities($str));
-      }
-    }
+        foreach ($types as $type => $class) {
+            $str = "";
+            $TPL[$type]  and $str = is_array($TPL[$type])  ? implode("<br>", $TPL[$type])  : $TPL[$type];
+            $_GET[$type] and $str = is_array($_GET[$type]) ? implode("<br>", $_GET[$type]) : $_GET[$type];
+            if (in_str("no_esc", $type)) {
+                $str and $msg[$type] = $str;
+            } else {
+                $str and $msg[$type] = str_replace($search, $replace, page::htmlentities($str));
+            }
+        }
 
-    if (is_array($msg) && count($msg)) {
-      $str = "<div style=\"text-align:center;\"><div class=\"message corner\" style=\"width:60%;\">";
-      $str.= "<table cellspacing=\"0\">";
-      foreach ($msg as $type => $info) {
-        $class = $types[$type];
-        $str.= "<tr>";
-        $str.= "<td class='".$class."' width='1%' style='vertical-align:top;padding:6px;font-size:150%;'>";
-        $str.= "<i class='".$class_to_icon[$class]."'></i><td/>";
-        $str.= "<td class='".$class."' width='99%' style='vertical-align:top;padding-top:11px;text-align:left;font-weight:bold;'>".$info."</td></tr>";
-      }
-      $str.= "</table>";
-      $str.= "</div></div>";
+        if (is_array($msg) && count($msg)) {
+            $str = "<div style=\"text-align:center;\"><div class=\"message corner\" style=\"width:60%;\">";
+            $str.= "<table cellspacing=\"0\">";
+            foreach ($msg as $type => $info) {
+                $class = $types[$type];
+                $str.= "<tr>";
+                $str.= "<td class='".$class."' width='1%' style='vertical-align:top;padding:6px;font-size:150%;'>";
+                $str.= "<i class='".$class_to_icon[$class]."'></i><td/>";
+                $str.= "<td class='".$class."' width='99%' style='vertical-align:top;padding-top:11px;text-align:left;font-weight:bold;'>".$info."</td></tr>";
+            }
+            $str.= "</table>";
+            $str.= "</div></div>";
+        }
+        return $str;
     }
-    return $str;
-  }
-  public static function get_category_options($category="") {
-    has("task")    and $category_options["search_tasks"] = "Search Tasks";
-    has("project") and $category_options["search_projects"] = "Search Projects";
-    has("time")    and $category_options["search_time"] = "Search Time Sheets";
-    has("client")  and $category_options["search_clients"] = "Search Clients";
-    has("comment") and $category_options["search_comment"] = "Search Comments";
-    has("wiki")    and $category_options["search_wiki"] = "Search Wiki";
-    has("item")    and $category_options["search_items"] = "Search Items";
-    has("finance") and $category_options["search_expenseForm"] = "Search Expense Forms";
-    return page::select_options($category_options, $category);
-  } 
-  public static function help($topic, $hovertext=false) {
-    global $TPL;
-    $str = page::prepare_help_string(@file_get_contents($TPL["url_alloc_help"].$topic.".html"));
-    if (strlen($str)) {
-      $img = "<div id='help_button_".$topic."' style='display:inline;'><a href=\"".$TPL["url_alloc_getHelp"]."topic=".$topic."\" target=\"_blank\">";
-      $img.= "<img border='0' class='help_button' onmouseover=\"help_text_on('help_button_".$topic."','".$str."');\" onmouseout=\"help_text_off('help_button_".$topic."');\" src=\"";
-      $img.= $TPL["url_alloc_images"]."help.gif\" alt=\"Help\" /></a></div>";
-    } else if ($topic) {
-      $str = page::prepare_help_string($topic);
-      $img = "<div id='help_button_".md5($topic)."' style='display:inline;'>";
-      if ($hovertext) {
-        $img.= "<span onmouseover=\"help_text_on('help_button_".md5($topic)."','".$str."');\" onmouseout=\"help_text_off('help_button_".md5($topic)."');\">";
-        $img.= $hovertext."</span>";
-      } else {
-        $img.= "<img border='0' class='help_button' onmouseover=\"help_text_on('help_button_".md5($topic)."','".$str."');\" ";
-        $img.= "onmouseout=\"help_text_off('help_button_".md5($topic)."');\" src=\"".$TPL["url_alloc_images"]."help.gif\" alt=\"Help\" />";
-      }
-      $img.= "</div>";
+    public static function get_category_options($category = "")
+    {
+        has("task")    and $category_options["search_tasks"] = "Search Tasks";
+        has("project") and $category_options["search_projects"] = "Search Projects";
+        has("time")    and $category_options["search_time"] = "Search Time Sheets";
+        has("client")  and $category_options["search_clients"] = "Search Clients";
+        has("comment") and $category_options["search_comment"] = "Search Comments";
+        has("wiki")    and $category_options["search_wiki"] = "Search Wiki";
+        has("item")    and $category_options["search_items"] = "Search Items";
+        has("finance") and $category_options["search_expenseForm"] = "Search Expense Forms";
+        return page::select_options($category_options, $category);
     }
-    return $img;
-  }
-  public static function prepare_help_string($str) {
-    $str = page::htmlentities(addslashes($str));
-    $str = str_replace("\r"," ",$str);
-    $str = str_replace("\n"," ",$str);
-    return $str;
-  }
-  public static function textarea($name, $default_value="", $ops=array()) {
-    $heights = array("small"=>40, "medium"=>100, "large"=>340, "jumbo"=>440);
-    $height = $ops["height"] or $height = "small";
+    public static function help($topic, $hovertext = false)
+    {
+        global $TPL;
+        $str = page::prepare_help_string(@file_get_contents($TPL["url_alloc_help"].$topic.".html"));
+        if (strlen($str)) {
+            $img = "<div id='help_button_".$topic."' style='display:inline;'><a href=\"".$TPL["url_alloc_getHelp"]."topic=".$topic."\" target=\"_blank\">";
+            $img.= "<img border='0' class='help_button' onmouseover=\"help_text_on('help_button_".$topic."','".$str."');\" onmouseout=\"help_text_off('help_button_".$topic."');\" src=\"";
+            $img.= $TPL["url_alloc_images"]."help.gif\" alt=\"Help\" /></a></div>";
+        } else if ($topic) {
+            $str = page::prepare_help_string($topic);
+            $img = "<div id='help_button_".md5($topic)."' style='display:inline;'>";
+            if ($hovertext) {
+                $img.= "<span onmouseover=\"help_text_on('help_button_".md5($topic)."','".$str."');\" onmouseout=\"help_text_off('help_button_".md5($topic)."');\">";
+                $img.= $hovertext."</span>";
+            } else {
+                $img.= "<img border='0' class='help_button' onmouseover=\"help_text_on('help_button_".md5($topic)."','".$str."');\" ";
+                $img.= "onmouseout=\"help_text_off('help_button_".md5($topic)."');\" src=\"".$TPL["url_alloc_images"]."help.gif\" alt=\"Help\" />";
+            }
+            $img.= "</div>";
+        }
+        return $img;
+    }
+    public static function prepare_help_string($str)
+    {
+        $str = page::htmlentities(addslashes($str));
+        $str = str_replace("\r", " ", $str);
+        $str = str_replace("\n", " ", $str);
+        return $str;
+    }
+    public static function textarea($name, $default_value = "", $ops = array())
+    {
+        $heights = array("small"=>40, "medium"=>100, "large"=>340, "jumbo"=>440);
+        $height = $ops["height"] or $height = "small";
 
-    $cols = $ops["cols"];
-    !$ops["width"] && !$ops["cols"] and $cols = 85;
+        $cols = $ops["cols"];
+        !$ops["width"] && !$ops["cols"] and $cols = 85;
 
-    $attrs["id"] = $name;
-    $attrs["name"] = $name;
-    $attrs["wrap"] = "virtual";
-    $cols            and $attrs["cols"]     = $cols;
+        $attrs["id"] = $name;
+        $attrs["name"] = $name;
+        $attrs["wrap"] = "virtual";
+        $cols            and $attrs["cols"]     = $cols;
                          $attrs["style"]    = "height:".$heights[$height]."px";
-    $ops["width"]    and $attrs["style"]   .= "; width:".$ops["width"];
-    $ops["class"]    and $attrs["class"]    = $ops["class"];
-    $ops["tabindex"] and $attrs["tabindex"] = $ops["tabindex"];
+        $ops["width"]    and $attrs["style"]   .= "; width:".$ops["width"];
+        $ops["class"]    and $attrs["class"]    = $ops["class"];
+        $ops["tabindex"] and $attrs["tabindex"] = $ops["tabindex"];
 
-    foreach ($attrs as $k => $v) {
-      $str.= sprintf(' %s="%s"',$k,$v);
+        foreach ($attrs as $k => $v) {
+            $str.= sprintf(' %s="%s"', $k, $v);
+        }
+        return "<textarea".$str.">".page::htmlentities($default_value)."</textarea>\n";
     }
-    return "<textarea".$str.">".page::htmlentities($default_value)."</textarea>\n";
-  }
-  public static function calendar($name, $default_value="") {
-    global $TPL;
-    $images = $TPL["url_alloc_images"];
-    $year = date("Y");
-    $str = <<<EOD
+    public static function calendar($name, $default_value = "")
+    {
+        global $TPL;
+        $images = $TPL["url_alloc_images"];
+        $year = date("Y");
+        $str = <<<EOD
       <span class="calendar_container nobr"><input name="${name}" type="text" value="${default_value}" id="" class="datefield"><img src="${images}cal.png" title="Date Selector" alt="Date Selector" id=""></span>
 EOD;
-    return $str;
-  }
-  public static function select_options($options,$selected_value=NULL,$max_length=45,$escape=true) {
-    /**
-     * Builds up options for use in a html select widget (works with multiple selected too)
-     *
-     * @param   $options          mixed   An sql query or an array of options
-     * @param   $selected_value   string  The current selected element
-     * @param   $max_length       int     The maximum string length of the label
-     * @return                    string  The string of options
-     */
-
-    // Build options from an SQL query: "SELECT col_a as value, col_b as label FROM"
-    if (is_string($options)) {
-      $db = new db_alloc();
-      $db->query($options);
-      while ($row = $db->row()) {
-        $rows[$row["value"]] = $row["label"];
-      }
-
-      // Build options from an array: array(value1=>label1, value2=>label2)
-    } else if (is_array($options)) {
-      foreach ($options as $k => $v) {
-        $rows[$k] = $v;
-      }
+        return $str;
     }
+    public static function select_options($options, $selected_value = null, $max_length = 45, $escape = true)
+    {
+      /**
+       * Builds up options for use in a html select widget (works with multiple selected too)
+       *
+       * @param   $options          mixed   An sql query or an array of options
+       * @param   $selected_value   string  The current selected element
+       * @param   $max_length       int     The maximum string length of the label
+       * @return                    string  The string of options
+       */
 
-    if (is_array($rows)) {
-
-      // Coerce selected options into an array
-      if (is_array($selected_value)) {
-        $selected_values = $selected_value;
-      } else if ($selected_value !== NULL) {
-        $selected_values[] = $selected_value;
-      }
-
-      foreach ($rows as $value=>$label) {
-        $sel = "";
-
-        if ($value && !$label) { 
-          $label = $value;
-        }
-
-        // If an array of selected values!
-        if (is_array($selected_values)) {
-          foreach ($selected_values as $selected_value) {
-            if ($selected_value === "" && $value === 0) {
-              // continue
-            } else if ($selected_value == $value) {
-              $sel = " selected";
+      // Build options from an SQL query: "SELECT col_a as value, col_b as label FROM"
+        if (is_string($options)) {
+            $db = new db_alloc();
+            $db->query($options);
+            while ($row = $db->row()) {
+                $rows[$row["value"]] = $row["label"];
             }
-          }
+
+          // Build options from an array: array(value1=>label1, value2=>label2)
+        } else if (is_array($options)) {
+            foreach ($options as $k => $v) {
+                $rows[$k] = $v;
+            }
         }
 
-        $label = str_replace("&nbsp;"," ",$label);
-        if (strlen((string)$label) > $max_length) {
-          $label = substr($label, 0, $max_length - 3)."...";
-        } 
+        if (is_array($rows)) {
+          // Coerce selected options into an array
+            if (is_array($selected_value)) {
+                $selected_values = $selected_value;
+            } else if ($selected_value !== null) {
+                $selected_values[] = $selected_value;
+            }
+
+            foreach ($rows as $value => $label) {
+                $sel = "";
+
+                if ($value && !$label) {
+                    $label = $value;
+                }
+
+                // If an array of selected values!
+                if (is_array($selected_values)) {
+                    foreach ($selected_values as $selected_value) {
+                        if ($selected_value === "" && $value === 0) {
+                              // continue
+                        } else if ($selected_value == $value) {
+                            $sel = " selected";
+                        }
+                    }
+                }
+
+                $label = str_replace("&nbsp;", " ", $label);
+                if (strlen((string)$label) > $max_length) {
+                    $label = substr($label, 0, $max_length - 3)."...";
+                }
       
-        $escape and $label = page::htmlentities($label);
-        $label = str_replace(" ","&nbsp;",$label);
+                $escape and $label = page::htmlentities($label);
+                $label = str_replace(" ", "&nbsp;", $label);
 
-        $str.= "\n<option value=\"".$value."\"".$sel.">".$label."</option>";
-      }
-    }
-    return $str;
-  }
-  public static function expand_link($id, $text="New ",$id_to_hide="") {
-    global $TPL;
-    $id_to_hide and $extra = "$('#".$id_to_hide."').slideToggle('fast');";
-    $str = "<a class=\"growshrink nobr\" href=\"#x\" onClick=\"$('#".$id."').fadeToggle();".$extra."\">".$text."</a>";
-    return $str;
-  }
-  public static function side_by_side_links($items=array(),$url,$redraw="",$title="") {
-    $url = preg_replace("/[&?]+$/", "", $url);
-    if (strpos($url, "?")) {
-      $url.= "&";
-    } else {
-      $url.= "?";
-    }
-    foreach ($items as $id => $label) {
-      $str.= $sp."<a id=\"sbs_link_".$id."\" data-sbs-redraw='".$redraw."' href=\"".$url."sbs_link=".$id."\" class=\"sidebyside noselect\" unselectable=\"on\">".$label."</a>";
-      $sp = "&nbsp;";
-    }
-    $s = "<div class='noprint' style='margin:20px 0px; text-align:center;'>".$str."</div>";
-    $title and $s.= "<span style='font-size:140%;'>".$title."</span>";
-    return $s;
-  }
-  public static function mandatory($field="") {
-    $star = "&lowast;";
-    if (stristr($_SERVER["HTTP_USER_AGENT"],"MSIE")) {
-      $star = "*";
-    }
-    if ($field == "") {
-      return "<b style=\"font-weight:bold;font-size:100%;color:red;display:inline;top:-5px !important;top:-3px;position:relative;\">".$star."</b>";
-    }
-  }
-  public static function exclaim($field="") {
-    $star = "&lowast;";
-    if (stristr($_SERVER["HTTP_USER_AGENT"],"MSIE")) {
-      $star = "*";
-    }
-    if ($field == "") {
-      return "<b style=\"font-weight:bold;font-size:100%;color:green;display:inline;top:-5px !important;top:-3px;position:relative;\">".$star."</b>";
-    }
-  }
-  public static function warn() {
-    $star = "&lowast;";
-    if (stristr($_SERVER["HTTP_USER_AGENT"],"MSIE")) {
-      $star = "*";
-    }
-    return "<b style=\"font-weight:bold;font-size:100%;color:orange;display:inline;top:-5px !important;top:-3px;position:relative;\">".$star."</b>";
-  }
-  public static function stylesheet() {
-    if ($_GET["media"] == "print") {
-      return "print.css";
-    } else {
-      $current_user = &singleton("current_user");
-      $themes = page::get_customizedTheme_array();
-      if (!isset($current_user->prefs["customizedTheme2"])) {
-        $current_user->prefs["customizedTheme2"] = 4;
-      }
-      $style = strtolower($themes[sprintf("%d", $current_user->prefs["customizedTheme2"])]);
-      return "style_".$style.".css";
-    }
-  }
-  public static function default_font_size() {
-    $current_user = &singleton("current_user");
-    $fonts  = page::get_customizedFont_array();
-    $font = $fonts[sprintf("%d",$current_user->prefs["customizedFont"])];
-    $font or $font = 4;
-    $font+= 8;
-    return $font;
-  }
-  public static function get_customizedFont_array() {
-    return array("-3"=>1, "-2"=>2, "-1"=>3, "0"=>"4", "1"=>5, "2"=>6, "3"=>7, "4"=>8, "5"=>9, "6"=>10);
-  }
-  public static function get_customizedTheme_array() {
-    global $TPL;
-    $dir = $TPL["url_alloc_styles"];
-    $rtn = array();
-    if (is_dir($dir)) {
-      $handle = opendir($dir);
-      // TODO add icons to files attachaments in general
-      while (false !== ($file = readdir($handle))) {
-        if (preg_match("/style_(.*)\.ini$/",$file,$m)) {
-          $rtn[] = ucwords($m[1]);
+                $str.= "\n<option value=\"".$value."\"".$sel.">".$label."</option>";
+            }
         }
-      }
-      sort($rtn);
+        return $str;
     }
-    return $rtn;
-  }
-  public static function to_html($str="",$maxlength=false) {
-    $maxlength and $str = wordwrap($str,$maxlength,"\n");
-    $str = page::htmlentities($str);
-    $str = nl2br($str);
-    return $str;
-  }
-  public static function htmlentities($str="") {
-    return htmlentities($str,ENT_QUOTES | ENT_IGNORE,"UTF-8");
-  }
-  public static function money_fmt($c,$amount=null) {
-    $currencies =& get_cached_table("currencyType");
-    $n = $currencies[$c]["numberToBasic"];
-    $num = sprintf("%0.".$n."f",$amount);
-    $num == sprintf("%0.".$n."f",-0) and $num = sprintf("%0.".$n."f",0); // *sigh* to prevent -0.00
-    return $num;
-  }
-  public static function money_out($c,$amount=null) {
-    // AUD,100        -> 100.00
-    // AUD,0|''|false -> 0.00
-    if (imp($amount)) {
-      $c or alloc_error("page::money(): no currency specified for amount $amount.");
-      $currencies =& get_cached_table("currencyType");
-      $n = $currencies[$c]["numberToBasic"];
+    public static function expand_link($id, $text = "New ", $id_to_hide = "")
+    {
+        global $TPL;
+        $id_to_hide and $extra = "$('#".$id_to_hide."').slideToggle('fast');";
+        $str = "<a class=\"growshrink nobr\" href=\"#x\" onClick=\"$('#".$id."').fadeToggle();".$extra."\">".$text."</a>";
+        return $str;
+    }
+    public static function side_by_side_links($items = array(), $url, $redraw = "", $title = "")
+    {
+        $url = preg_replace("/[&?]+$/", "", $url);
+        if (strpos($url, "?")) {
+            $url.= "&";
+        } else {
+            $url.= "?";
+        }
+        foreach ($items as $id => $label) {
+            $str.= $sp."<a id=\"sbs_link_".$id."\" data-sbs-redraw='".$redraw."' href=\"".$url."sbs_link=".$id."\" class=\"sidebyside noselect\" unselectable=\"on\">".$label."</a>";
+            $sp = "&nbsp;";
+        }
+        $s = "<div class='noprint' style='margin:20px 0px; text-align:center;'>".$str."</div>";
+        $title and $s.= "<span style='font-size:140%;'>".$title."</span>";
+        return $s;
+    }
+    public static function mandatory($field = "")
+    {
+        $star = "&lowast;";
+        if (stristr($_SERVER["HTTP_USER_AGENT"], "MSIE")) {
+            $star = "*";
+        }
+        if ($field == "") {
+            return "<b style=\"font-weight:bold;font-size:100%;color:red;display:inline;top:-5px !important;top:-3px;position:relative;\">".$star."</b>";
+        }
+    }
+    public static function exclaim($field = "")
+    {
+        $star = "&lowast;";
+        if (stristr($_SERVER["HTTP_USER_AGENT"], "MSIE")) {
+            $star = "*";
+        }
+        if ($field == "") {
+            return "<b style=\"font-weight:bold;font-size:100%;color:green;display:inline;top:-5px !important;top:-3px;position:relative;\">".$star."</b>";
+        }
+    }
+    public static function warn()
+    {
+        $star = "&lowast;";
+        if (stristr($_SERVER["HTTP_USER_AGENT"], "MSIE")) {
+            $star = "*";
+        }
+        return "<b style=\"font-weight:bold;font-size:100%;color:orange;display:inline;top:-5px !important;top:-3px;position:relative;\">".$star."</b>";
+    }
+    public static function stylesheet()
+    {
+        if ($_GET["media"] == "print") {
+            return "print.css";
+        } else {
+            $current_user = &singleton("current_user");
+            $themes = page::get_customizedTheme_array();
+            if (!isset($current_user->prefs["customizedTheme2"])) {
+                $current_user->prefs["customizedTheme2"] = 4;
+            }
+            $style = strtolower($themes[sprintf("%d", $current_user->prefs["customizedTheme2"])]);
+            return "style_".$style.".css";
+        }
+    }
+    public static function default_font_size()
+    {
+        $current_user = &singleton("current_user");
+        $fonts  = page::get_customizedFont_array();
+        $font = $fonts[sprintf("%d", $current_user->prefs["customizedFont"])];
+        $font or $font = 4;
+        $font+= 8;
+        return $font;
+    }
+    public static function get_customizedFont_array()
+    {
+        return array("-3"=>1, "-2"=>2, "-1"=>3, "0"=>"4", "1"=>5, "2"=>6, "3"=>7, "4"=>8, "5"=>9, "6"=>10);
+    }
+    public static function get_customizedTheme_array()
+    {
+        global $TPL;
+        $dir = $TPL["url_alloc_styles"];
+        $rtn = array();
+        if (is_dir($dir)) {
+            $handle = opendir($dir);
+          // TODO add icons to files attachaments in general
+            while (false !== ($file = readdir($handle))) {
+                if (preg_match("/style_(.*)\.ini$/", $file, $m)) {
+                    $rtn[] = ucwords($m[1]);
+                }
+            }
+            sort($rtn);
+        }
+        return $rtn;
+    }
+    public static function to_html($str = "", $maxlength = false)
+    {
+        $maxlength and $str = wordwrap($str, $maxlength, "\n");
+        $str = page::htmlentities($str);
+        $str = nl2br($str);
+        return $str;
+    }
+    public static function htmlentities($str = "")
+    {
+        return htmlentities($str, ENT_QUOTES | ENT_IGNORE, "UTF-8");
+    }
+    public static function money_fmt($c, $amount = null)
+    {
+        $currencies =& get_cached_table("currencyType");
+        $n = $currencies[$c]["numberToBasic"];
+        $num = sprintf("%0.".$n."f", $amount);
+        $num == sprintf("%0.".$n."f", -0) and $num = sprintf("%0.".$n."f", 0); // *sigh* to prevent -0.00
+        return $num;
+    }
+    public static function money_out($c, $amount = null)
+    {
+      // AUD,100        -> 100.00
+      // AUD,0|''|false -> 0.00
+        if (imp($amount)) {
+            $c or alloc_error("page::money(): no currency specified for amount $amount.");
+            $currencies =& get_cached_table("currencyType");
+            $n = $currencies[$c]["numberToBasic"];
 
-      // We can use foo * 10^-n to move the decimal point left
-      // Eg: sprintf(%0.2f, $amount * 10^-2) => 15000 becomes 150.00
-      // We use the numberToBasic number (eg 2) to a) move the decimal point, and b) dictate the sprintf string
-      return page::money_fmt($c, ($amount * pow(10,-$n)));
+          // We can use foo * 10^-n to move the decimal point left
+          // Eg: sprintf(%0.2f, $amount * 10^-2) => 15000 becomes 150.00
+          // We use the numberToBasic number (eg 2) to a) move the decimal point, and b) dictate the sprintf string
+            return page::money_fmt($c, ($amount * pow(10, -$n)));
+        }
     }
-  }
-  public static function money_in($c, $amount=null) {
-    // AUD,100.00 -> 100
-    // AUD,0      -> 0
-    // AUD        ->
-    if (imp($amount)) {
-      $c or alloc_error("page::money_in(): no currency specified for amount $amount.");
-      $currencies =& get_cached_table("currencyType");
-      $n = $currencies[$c]["numberToBasic"];
+    public static function money_in($c, $amount = null)
+    {
+      // AUD,100.00 -> 100
+      // AUD,0      -> 0
+      // AUD        ->
+        if (imp($amount)) {
+            $c or alloc_error("page::money_in(): no currency specified for amount $amount.");
+            $currencies =& get_cached_table("currencyType");
+            $n = $currencies[$c]["numberToBasic"];
 
-      // We can use foo * 10^n to move the decimal point right
-      // Eg: $amount * 10^-2 => 150.00 becomes 15000
-      // We use the numberToBasic number (eg 2) to move the decimal point
-      return $amount * pow(10,$n);
+          // We can use foo * 10^n to move the decimal point right
+          // Eg: $amount * 10^-2 => 150.00 becomes 15000
+          // We use the numberToBasic number (eg 2) to move the decimal point
+            return $amount * pow(10, $n);
+        }
     }
-  }
-  public static function money($c, $amount=null, $fmt="%s%mo") {
-    // Money print
-    $c or $c = config::get_config_item('currency');
-    $currencies =& get_cached_table("currencyType");
-    $fmt = str_replace("%mo",page::money_out($c,$amount),$fmt);                          //%mo = money_out        eg: 150.21
-    $fmt = str_replace("%mi",page::money_in($c,$amount),$fmt);                           //%mi = money_in         eg: 15021
-    $fmt = str_replace("%m", page::money_fmt($c,$amount),$fmt);                          // %m = format           eg: 150.2 => 150.20
-                     $fmt = str_replace("%S",$currencies[$c]["currencyTypeLabel"],$fmt); // %S = mandatory symbol eg: $
-    imp($amount) and $fmt = str_replace("%s",$currencies[$c]["currencyTypeLabel"],$fmt); // %s = optional symbol  eg: $
-                     $fmt = str_replace("%C",$c,$fmt);                                   // %C = mandatory code   eg: AUD
-    imp($amount) and $fmt = str_replace("%c",$c,$fmt);                                   // %c = optional code    eg: AUD
-                     $fmt = str_replace("%N",$currencies[$c]["currencyTypeName"],$fmt);  // %N = mandatory name   eg: Australian dollars
-    imp($amount) and $fmt = str_replace("%n",$currencies[$c]["currencyTypeName"],$fmt);  // %n = optional name    eg: Australian dollars
-    $fmt = str_replace(array("%mo","%mi","%m","%S","%s","%C","%c","%N","%n"),"",$fmt); // strip leftovers away
-    return $fmt;
-  }
-  public static function money_print($rows=array()) {
-    $mainCurrency = config::get_config_item("currency");
-    foreach ((array)$rows as $row) {
-      $sums[$row["currency"]] += $row["amount"];
-      $k = $row["currency"];
+    public static function money($c, $amount = null, $fmt = "%s%mo")
+    {
+      // Money print
+        $c or $c = config::get_config_item('currency');
+        $currencies =& get_cached_table("currencyType");
+        $fmt = str_replace("%mo", page::money_out($c, $amount), $fmt);                          //%mo = money_out        eg: 150.21
+        $fmt = str_replace("%mi", page::money_in($c, $amount), $fmt);                           //%mi = money_in         eg: 15021
+        $fmt = str_replace("%m", page::money_fmt($c, $amount), $fmt);                          // %m = format           eg: 150.2 => 150.20
+                     $fmt = str_replace("%S", $currencies[$c]["currencyTypeLabel"], $fmt); // %S = mandatory symbol eg: $
+        imp($amount) and $fmt = str_replace("%s", $currencies[$c]["currencyTypeLabel"], $fmt); // %s = optional symbol  eg: $
+                     $fmt = str_replace("%C", $c, $fmt);                                   // %C = mandatory code   eg: AUD
+        imp($amount) and $fmt = str_replace("%c", $c, $fmt);                                   // %c = optional code    eg: AUD
+                     $fmt = str_replace("%N", $currencies[$c]["currencyTypeName"], $fmt);  // %N = mandatory name   eg: Australian dollars
+        imp($amount) and $fmt = str_replace("%n", $currencies[$c]["currencyTypeName"], $fmt);  // %n = optional name    eg: Australian dollars
+        $fmt = str_replace(array("%mo","%mi","%m","%S","%s","%C","%c","%N","%n"), "", $fmt); // strip leftovers away
+        return $fmt;
     }
+    public static function money_print($rows = array())
+    {
+        $mainCurrency = config::get_config_item("currency");
+        foreach ((array)$rows as $row) {
+            $sums[$row["currency"]] += $row["amount"];
+            $k = $row["currency"];
+        }
 
-    // If there's only one currency, then just return that figure.
-    if (count($sums) == 1) {
-      return page::money($k,$sums[$k],"%s%m %c");
-    }
+      // If there's only one currency, then just return that figure.
+        if (count($sums) == 1) {
+            return page::money($k, $sums[$k], "%s%m %c");
+        }
 
-    // Else if there's more than one currency, we'll provide a tooltip of the aggregation.
-    foreach ((array)$sums as $currency => $amount) {
-      $str.= $sep.page::money($currency,$amount,"%s%m %c");
-      $sep = " + ";
-      if ($mainCurrency == $currency) {
-        $total += $amount;
-      } else {
-        $total += exchangeRate::convert($currency,$amount);
-      }
+      // Else if there's more than one currency, we'll provide a tooltip of the aggregation.
+        foreach ((array)$sums as $currency => $amount) {
+            $str.= $sep.page::money($currency, $amount, "%s%m %c");
+            $sep = " + ";
+            if ($mainCurrency == $currency) {
+                $total += $amount;
+            } else {
+                $total += exchangeRate::convert($currency, $amount);
+            }
+        }
+        $total = page::money($mainCurrency, $total, "%s%m %c");
+        if ($str && $str != $total) {
+            $rtn = page::help(page::exclaim()."<b>Approximate currency conversion</b><br>".$str." = ".$total, page::exclaim().$total);
+        } else if ($str) {
+            $rtn = $str;
+        }
+        return $rtn;
     }
-    $total = page::money($mainCurrency,$total,"%s%m %c");
-    if ($str && $str != $total) { 
-      $rtn = page::help(page::exclaim()."<b>Approximate currency conversion</b><br>".$str." = ".$total,page::exclaim().$total);
-    } else if ($str) {
-      $rtn = $str;
-    }
-    return $rtn;
-  }
-  public static function star($entity,$entityID) {
-    $current_user = &singleton("current_user");
-    global $TPL;
-    if ($current_user->prefs["stars"][$entity][$entityID]) {
-      $star_hot = " hot";
-      $star_icon = "icon-star";
-      $star_text = "<b style='display:none'>*</b>";
-    } else {
-      $star_hot = "";
-      $star_icon = "icon-star-empty";
-      $star_text = "<b style='display:none'>.</b>";
-    }
-    return '<a class="star'.$star_hot.'" href="'.$TPL["url_alloc_star"]
+    public static function star($entity, $entityID)
+    {
+        $current_user = &singleton("current_user");
+        global $TPL;
+        if ($current_user->prefs["stars"][$entity][$entityID]) {
+            $star_hot = " hot";
+            $star_icon = "icon-star";
+            $star_text = "<b style='display:none'>*</b>";
+        } else {
+            $star_hot = "";
+            $star_icon = "icon-star-empty";
+            $star_text = "<b style='display:none'>.</b>";
+        }
+        return '<a class="star'.$star_hot.'" href="'.$TPL["url_alloc_star"]
           .'entity='.$entity.'&entityID='.$entityID.'"><b class="'.$star_icon.'">'.$star_text.'</b></a>';
-  }
-  public static function star_sorter($entity,$entityID) {
-    $current_user = &singleton("current_user");
-    if ($current_user->prefs["stars"][$entity][$entityID]) {
-      return 1;
-    } else {
-      return 2;
     }
-  }
+    public static function star_sorter($entity, $entityID)
+    {
+        $current_user = &singleton("current_user");
+        if ($current_user->prefs["stars"][$entity][$entityID]) {
+            return 1;
+        } else {
+            return 2;
+        }
+    }
 }
-?>

--- a/shared/lib/pdf_reader.inc.php
+++ b/shared/lib/pdf_reader.inc.php
@@ -33,7 +33,7 @@ class pdf_reader
             }
         }
  
-        $result_data = NULL;
+        $result_data = null;
  
         // decode the chunks
         foreach ($a_chunks as $chunk) {
@@ -59,7 +59,7 @@ class pdf_reader
  
         // Return the data extracted from the document.
         if ($result_data == "") {
-            return NULL;
+            return null;
         } else {
             return $result_data;
         }
@@ -77,7 +77,7 @@ class pdf_reader
         if (ord($ps_data[0]) < 10) {
             return $ps_data;
         }
-        if (substr($ps_data, 0, 8 ) == '/CIDInit') {
+        if (substr($ps_data, 0, 8) == '/CIDInit') {
             return '';
         }
  
@@ -139,4 +139,3 @@ class pdf_reader
         return $a_result;
     }
 }
-?>

--- a/shared/lib/session.inc.php
+++ b/shared/lib/session.inc.php
@@ -3,206 +3,233 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class session {
+class session
+{
   
-  var $key;          # the unique key for the session 
-  var $db;           # database object 
-  var $session_data; # assoc array which holds all session data
-  var $session_life; # number of seconds the session is alive for
-  var $mode;         # whether to use get or cookies
+    var $key;          # the unique key for the session
+    var $db;           # database object
+    var $session_data; # assoc array which holds all session data
+    var $session_life; # number of seconds the session is alive for
+    var $mode;         # whether to use get or cookies
 
 
   // * * * * * * * * * * * * * * * * *//
   //                                  //
   //         Public Methods           //
   //                                  //
-  // * * * * * * * * * * * * * * * * *// 
+  // * * * * * * * * * * * * * * * * *//
 
 
 
   // Constructor
-  function __construct($key="") {
-    global $TPL;
-    $this->key           = $key or $this->key = $_COOKIE["alloc_cookie"] or $this->key = $_GET["sess"] or $this->key = $_REQUEST["sessID"];
-    $TPL["sessID"]       = $_GET["sess"];
-    $this->db            = new db_alloc();
-    #$this->session_life  = (5); 
-    $this->session_life  = (config::get_config_item("allocSessionMinutes")*60); 
-    $this->session_life < 1 and $this->session_life = 10000; // just in case.
-    $this->session_data  = $this->UnEncode($this->GetSessionData());
-    $this->mode          = $this->Get("session_mode"); 
+    function __construct($key = "")
+    {
+        global $TPL;
+        $this->key           = $key or $this->key = $_COOKIE["alloc_cookie"] or $this->key = $_GET["sess"] or $this->key = $_REQUEST["sessID"];
+        $TPL["sessID"]       = $_GET["sess"];
+        $this->db            = new db_alloc();
+      #$this->session_life  = (5);
+        $this->session_life  = (config::get_config_item("allocSessionMinutes")*60);
+        $this->session_life < 1 and $this->session_life = 10000; // just in case.
+        $this->session_data  = $this->UnEncode($this->GetSessionData());
+        $this->mode          = $this->Get("session_mode");
 
-    if ($this->Expired()) {
-      $this->Destroy();
-    }
-    return $this;
-  }
-
-
-  // Call this in a login page to start session 
-  function Start($row,$nuke_prev_sessions=true) {
-    $this->key = md5($row["personID"]."mix it up#@!".md5(mktime().md5(microtime())));
-    $this->Put("session_started", mktime());
-    if ($nuke_prev_sessions && config::get_config_item("singleSession")) {
-      $this->db->query("DELETE FROM sess WHERE personID = %d",$row["personID"]);
-    }
-    $this->db->query("INSERT INTO sess (sessID,sessData,personID) VALUES ('%s','%s',%d)"
-                             ,$this->key, $this->Encode($this->session_data), $row["personID"]);
-    $this->Put("username" ,strtolower($row["username"]));
-    $this->Put("perms" ,$row["perms"]);
-    $this->Put("personID" ,$row["personID"]);
-  }
-
-  // Test whether session has started 
-  function Started() {
-    if ($this->Get("session_started") && !$this->Expired())
-      return true;
-  }
-
-  function Save() {
-    if ($this->Expired()) {
-      $this->Destroy();
-    } else if ($this->Started()) {
-      $this->Put("session_started",mktime());
-      $this->db->query("UPDATE sess SET sessData = '%s' WHERE sessID = '%s'"
-                  , $this->Encode($this->session_data), $this->key);
-    }
-  } 
-
-  function Destroy() {
-    if ($this->Started() && $this->key) {
-      $this->db->query("DELETE FROM sess WHERE sessID = '%s'",$this->key);
-    }
-    $this->DestroyCookie();
-    $this->key = "";
-  }
-
-  function Put($name,$value) {
-    $this->session_data[$name] = $value;
-  }
-
-  function Get($name) {
-    return $this->session_data[$name];
-  }
-
-  function GetKey() {
-    return $this->key;
-  }
-
-  function MakeCookie() {
-
-    // Attempt to unset the test cookie
-    #SetCookie("alloc_test_cookie",FALSE,0,"/","");
-
-    // Set the session cookie
-    $rtn = SetCookie("alloc_cookie",$this->key,0,"/","");
-    if (!$rtn) {
-      $this->mode = "get";
-    } else if (!isset($_COOKIE["alloc_cookie"])) {
-      $_COOKIE["alloc_cookie"] = $this->key;
-    }
-  } 
-
-  function DestroyCookie() {
-    SetCookie("alloc_cookie",FALSE,0,"/","");
-    unset($_COOKIE["alloc_cookie"]);
-  }
-
-  function SetTestCookie($val="alloc_test_cookie") {
-    SetCookie("alloc_test_cookie",$val,0,"/","");
-  }
-
-  function TestCookie() {
-    return $_COOKIE["alloc_test_cookie"];
-  }
-
-  function GetUrl($url="") {
-    return $this->url($url);
-  }
-
-  function url($url="") {
-    $url = preg_replace("/[&?]+$/", "", $url);
-
-    if ($this->mode == "get") {
-      if (!strpos($url, "sess=") && $this->key) {
-        $extra = "sess=".$this->key."&";
-      }
+        if ($this->Expired()) {
+            $this->Destroy();
+        }
+        return $this;
     }
 
-    if (strpos($url, "?")) {
-      $url.= "&";
-    } else {
-      $url.= "?";
+
+  // Call this in a login page to start session
+    function Start($row, $nuke_prev_sessions = true)
+    {
+        $this->key = md5($row["personID"]."mix it up#@!".md5(mktime().md5(microtime())));
+        $this->Put("session_started", mktime());
+        if ($nuke_prev_sessions && config::get_config_item("singleSession")) {
+            $this->db->query("DELETE FROM sess WHERE personID = %d", $row["personID"]);
+        }
+        $this->db->query(
+            "INSERT INTO sess (sessID,sessData,personID) VALUES ('%s','%s',%d)",
+            $this->key,
+            $this->Encode($this->session_data),
+            $row["personID"]
+        );
+        $this->Put("username", strtolower($row["username"]));
+        $this->Put("perms", $row["perms"]);
+        $this->Put("personID", $row["personID"]);
     }
 
-    return $url.$extra;
-  }
+  // Test whether session has started
+    function Started()
+    {
+        if ($this->Get("session_started") && !$this->Expired()) {
+            return true;
+        }
+    }
 
-  function UseGet() {
-    $this->mode = "get";
-    $this->DestroyCookie();
-    $this->Put("session_mode",$this->mode);
-  }
+    function Save()
+    {
+        if ($this->Expired()) {
+            $this->Destroy();
+        } else if ($this->Started()) {
+            $this->Put("session_started", mktime());
+            $this->db->query(
+                "UPDATE sess SET sessData = '%s' WHERE sessID = '%s'",
+                $this->Encode($this->session_data),
+                $this->key
+            );
+        }
+    }
+
+    function Destroy()
+    {
+        if ($this->Started() && $this->key) {
+            $this->db->query("DELETE FROM sess WHERE sessID = '%s'", $this->key);
+        }
+        $this->DestroyCookie();
+        $this->key = "";
+    }
+
+    function Put($name, $value)
+    {
+        $this->session_data[$name] = $value;
+    }
+
+    function Get($name)
+    {
+        return $this->session_data[$name];
+    }
+
+    function GetKey()
+    {
+        return $this->key;
+    }
+
+    function MakeCookie()
+    {
+
+      // Attempt to unset the test cookie
+      #SetCookie("alloc_test_cookie",FALSE,0,"/","");
+
+      // Set the session cookie
+        $rtn = SetCookie("alloc_cookie", $this->key, 0, "/", "");
+        if (!$rtn) {
+            $this->mode = "get";
+        } else if (!isset($_COOKIE["alloc_cookie"])) {
+            $_COOKIE["alloc_cookie"] = $this->key;
+        }
+    }
+
+    function DestroyCookie()
+    {
+        SetCookie("alloc_cookie", false, 0, "/", "");
+        unset($_COOKIE["alloc_cookie"]);
+    }
+
+    function SetTestCookie($val = "alloc_test_cookie")
+    {
+        SetCookie("alloc_test_cookie", $val, 0, "/", "");
+    }
+
+    function TestCookie()
+    {
+        return $_COOKIE["alloc_test_cookie"];
+    }
+
+    function GetUrl($url = "")
+    {
+        return $this->url($url);
+    }
+
+    function url($url = "")
+    {
+        $url = preg_replace("/[&?]+$/", "", $url);
+
+        if ($this->mode == "get") {
+            if (!strpos($url, "sess=") && $this->key) {
+                $extra = "sess=".$this->key."&";
+            }
+        }
+
+        if (strpos($url, "?")) {
+            $url.= "&";
+        } else {
+            $url.= "?";
+        }
+
+        return $url.$extra;
+    }
+
+    function UseGet()
+    {
+        $this->mode = "get";
+        $this->DestroyCookie();
+        $this->Put("session_mode", $this->mode);
+    }
  
-  function UseCookie() {
-    $this->mode = "cookie";
-    $this->MakeCookie();
-    $this->Put("session_mode",$this->mode);
-  }
+    function UseCookie()
+    {
+        $this->mode = "cookie";
+        $this->MakeCookie();
+        $this->Put("session_mode", $this->mode);
+    }
 
 
   // * * * * * * * * * * * * * * * * *//
   //                                  //
   //         Private Methods          //
   //                                  //
-  // * * * * * * * * * * * * * * * * *// 
+  // * * * * * * * * * * * * * * * * *//
 
   // Fetches data given a key
-  function GetSessionData() {
-    if ($this->key) {
-      $row = $this->db->qr("SELECT sessData FROM sess WHERE sessID = '%s'", $this->key);
-      return $row["sessData"];
+    function GetSessionData()
+    {
+        if ($this->key) {
+            $row = $this->db->qr("SELECT sessData FROM sess WHERE sessID = '%s'", $this->key);
+            return $row["sessData"];
+        }
     }
-  }
 
   // if $this->session_life seconds have passed then session has expired
-  function Expired() {
-    if ($this->Get("session_started") && (mktime() > ($this->Get("session_started")+$this->session_life))) {
-      return true;
+    function Expired()
+    {
+        if ($this->Get("session_started") && (mktime() > ($this->Get("session_started")+$this->session_life))) {
+            return true;
+        }
     }
-  } 
-  // add encryption for session_data here 
-  function Encode($data){
-    return serialize($data);
-  }
+  // add encryption for session_data here
+    function Encode($data)
+    {
+        return serialize($data);
+    }
 
   // and add unencryption for session_data here
-  function UnEncode($data){
-    return unserialize($data);
-  }
+    function UnEncode($data)
+    {
+        return unserialize($data);
+    }
   
-  // errors fix me 
-  function Error($msg) {
-    alloc_error($msg);
-  }
+  // errors fix me
+    function Error($msg)
+    {
+        alloc_error($msg);
+    }
 }
-
-
-?>

--- a/shared/lib/template.inc.php
+++ b/shared/lib/template.inc.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -27,96 +27,99 @@
 // relying on braces within css or javascript to always have nice readable
 // white space around them. Where as PHP curly braces usually won't. m =
 // multiline, need it for the ^$ anchor matching.
-function fix_curly_braces($matches) {
-  $str = $matches[0];
-  $str = preg_replace('/{ /',"TPL_START_BRACE ",$str);
-  $str = preg_replace('/{$/m',"TPL_START_BRACE",$str);
-  $str = preg_replace('/ }/'," TPL_END_BRACE",$str);
-  $str = preg_replace('/^}/m',"TPL_END_BRACE",$str);
+function fix_curly_braces($matches)
+{
+    $str = $matches[0];
+    $str = preg_replace('/{ /', "TPL_START_BRACE ", $str);
+    $str = preg_replace('/{$/m', "TPL_START_BRACE", $str);
+    $str = preg_replace('/ }/', " TPL_END_BRACE", $str);
+    $str = preg_replace('/^}/m', "TPL_END_BRACE", $str);
 
   // added because windows doesn't always respect $
-  $str = preg_replace('/{'.PHP_EOL.'/m',"TPL_START_BRACE",$str); 
+    $str = preg_replace('/{'.PHP_EOL.'/m', "TPL_START_BRACE", $str);
 
-  return $str;
+    return $str;
 }
 
 
-// This function basically returns: echo $var; $var can be a multi-dimensional 
+// This function basically returns: echo $var; $var can be a multi-dimensional
 // array. $var can also be html entity protected if prefixed with the equals sign.
-function echo_var($matches) {
-  $str = $matches[1];
-  if (substr($str,0,1) == "=") {
-    $str = preg_replace("/^=/","",$str);
-    $starts_with_equals = true;
-  }
+function echo_var($matches)
+{
+    $str = $matches[1];
+    if (substr($str, 0, 1) == "=") {
+        $str = preg_replace("/^=/", "", $str);
+        $starts_with_equals = true;
+    }
 
-  // If it doesn't have periods in it, then explode will 
+  // If it doesn't have periods in it, then explode will
   // return an array with one element, the entire string
-  $bits = explode(".",$str);
+    $bits = explode(".", $str);
 
   // Build up something like $var["little"][$colour]["riding"]["hood"]
   // array_shift returns the 0th element, and shortens the array by one
-  $var = array_shift($bits); 
-  foreach ($bits as $b) {
-    $var.= substr($b,0,1)=='$' ? '['.$b.']' : '["'.$b.'"]';
-  }
+    $var = array_shift($bits);
+    foreach ($bits as $b) {
+        $var.= substr($b, 0, 1)=='$' ? '['.$b.']' : '["'.$b.'"]';
+    }
 
-  if ($var && $starts_with_equals) {
-    return '<?php echo page::htmlentities('.$var.'); ?>';
-  } else if ($var) {
-    return '<?php echo '.$var.'; ?>';
-  }
+    if ($var && $starts_with_equals) {
+        return '<?php echo page::htmlentities('.$var.'); ?>';
+    } else if ($var) {
+        return '<?php echo '.$var.'; ?>';
+    }
 }
 
 // Read a template and return the mixed php/html, ready for processing
-function get_template($filename) {
+function get_template($filename)
+{
 
-  $template = implode("", (@file($filename)));
-  if ((!$template) or(empty($template))) {
-    echo "get_template() failure: [$filename]";
-  }
+    $template = implode("", (@file($filename)));
+    if ((!$template) or(empty($template))) {
+        echo "get_template() failure: [$filename]";
+    }
 
   // This allows us to use curly braces in our templates for javascript and CSS rules
   // The TPL_*_BRACE keyword gets replaces by an actual curly brace later
   // on in this template function. Uis means: ungreedy, case-insensitive and
   // include newlines for dot matches.
-  $pattern = "/<script.*<\/script>/Uis";
-  $template = preg_replace_callback($pattern,"fix_curly_braces",$template);
+    $pattern = "/<script.*<\/script>/Uis";
+    $template = preg_replace_callback($pattern, "fix_curly_braces", $template);
 
-  $pattern = "/<style.*<\/style>/Uis";
-  $template = preg_replace_callback($pattern,"fix_curly_braces",$template);
+    $pattern = "/<style.*<\/style>/Uis";
+    $template = preg_replace_callback($pattern, "fix_curly_braces", $template);
 
   // Replace {$hello}           with: echo $hello
   // Replace {=$hello}          with: echo page::htmlentities($hello)
   // Replace {$arr.here.we.go}  with: echo $arr["here"]["we"]["go"]
   // Replace {$arr.here.$we.go} with: echo $arr["here"][$we]["go"]
-  $pattern = '/{(=?\$[\w\d_\.\$]+)}/i';
-  $template = preg_replace_callback($pattern,"echo_var",$template);
+    $pattern = '/{(=?\$[\w\d_\.\$]+)}/i';
+    $template = preg_replace_callback($pattern, "echo_var", $template);
 
-  // Replace {if hey}    with if (hey) { 
-  // Replace {while hey} with while (hey) { 
-  // Replace {foreach hey} with foreach (hey) { 
-  $pattern = '/{(if|while|foreach){1} ([^}]*)}/i';
-  $replace = '<?php ${1} (${2}) TPL_START_BRACE ?>';
-  $template = preg_replace($pattern,$replace,$template);
+  // Replace {if hey}    with if (hey) {
+  // Replace {while hey} with while (hey) {
+  // Replace {foreach hey} with foreach (hey) {
+    $pattern = '/{(if|while|foreach){1} ([^}]*)}/i';
+    $replace = '<?php ${1} (${2}) TPL_START_BRACE ?>';
+    $template = preg_replace($pattern, $replace, $template);
   
   // Replace {else with {TPL_END_BRACE else
-  $pattern = '{else';
-  $replace = '{TPL_END_BRACE else';
-  $template = str_replace($pattern,$replace,$template);
+    $pattern = '{else';
+    $replace = '{TPL_END_BRACE else';
+    $template = str_replace($pattern, $replace, $template);
 
   // Replace {TPL_END_BRACE else} with {TPL_END_BRACE else TPL_START_BRACE
-  $pattern = '{TPL_END_BRACE else}';
-  $replace = '{TPL_END_BRACE else TPL_START_BRACE}';
-  $template = str_replace($pattern,$replace,$template);
+    $pattern = '{TPL_END_BRACE else}';
+    $replace = '{TPL_END_BRACE else TPL_START_BRACE}';
+    $template = str_replace($pattern, $replace, $template);
 
   // Replace {TPL_END_BRACE else if hey} with {TPL_END_BRACE else if (hey) TPL_START_BRACE}
-  $pattern = '/{TPL_END_BRACE else\s?if\s?([^}]+)}/i';
-  $replace = '{TPL_END_BRACE else if (${1}) TPL_START_BRACE}';
-  $template = preg_replace($pattern,$replace,$template);
+    $pattern = '/{TPL_END_BRACE else\s?if\s?([^}]+)}/i';
+    $replace = '{TPL_END_BRACE else if (${1}) TPL_START_BRACE}';
+    $template = preg_replace($pattern, $replace, $template);
 
   
-  $sr = array("{/}"             => "<?php TPL_END_BRACE ?>"
+    $sr = array("{/}"             => "<?php TPL_END_BRACE ?>"
              ,"{page::"         => "<?php echo page::"
              ,"{"               => "<?php "
              ,"}"               => " ?>"
@@ -125,61 +128,56 @@ function get_template($filename) {
              ,".php&"           => ".php?"
             );
 
-  foreach ($sr as $s => $r) {
-    $searches[] = $s;
-    $replaces[] = $r;
-  }
-  $template = str_replace($searches,$replaces,$template);
+    foreach ($sr as $s => $r) {
+        $searches[] = $s;
+        $replaces[] = $r;
+    }
+    $template = str_replace($searches, $replaces, $template);
 
 
-  return "?>$template<?php ";
+    return "?>$template<?php ";
 }
 
 
 // This is the publically callable function, used to include template files
-function include_template($filename, $getString=false) {
-  global $TPL;
-  $current_user = &singleton("current_user");
-  $TPL["current_user"] = $current_user;
-  $template = get_template($filename);
-  #echo "<pre>".htmlspecialchars($template)."</pre>"; 
+function include_template($filename, $getString = false)
+{
+    global $TPL;
+    $current_user = &singleton("current_user");
+    $TPL["current_user"] = $current_user;
+    $template = get_template($filename);
+  #echo "<pre>".htmlspecialchars($template)."</pre>";
 
   // Make all variables available via $var
-  is_array($TPL) && extract($TPL, EXTR_OVERWRITE);
+    is_array($TPL) && extract($TPL, EXTR_OVERWRITE);
 
-  if ($getString) {
-    // Begin buffering output to halt anything being sent to the web browser.
-    ob_start();
-  }
-
-  $rtn = eval($template);
-
-  if ($rtn === false && ($error = error_get_last())) {
-    $s = DIRECTORY_SEPARATOR;
-    $f = $filename;
-    echo "<b style='color:red'>Error line ".$error['line']." in template: ";
-    echo basename(dirname(dirname($f))).$s.basename(dirname($f)).$s.basename($f)."</b>";
-
-
-    $bits = explode("\n",$template);
-    
-    foreach ($bits as $k =>$bit) {
-      echo "<br>".$k."&nbsp;&nbsp;&nbsp;&nbsp;".page::htmlentities($bit);
+    if ($getString) {
+      // Begin buffering output to halt anything being sent to the web browser.
+        ob_start();
     }
 
+    $rtn = eval($template);
 
-    exit;
-  }
-
-  if ($getString) {
-    // Grab everything that was captured in the output buffer and return
-    // it as a string.
-    return (string)ob_get_clean();
-  }
-} 
+    if ($rtn === false && ($error = error_get_last())) {
+        $s = DIRECTORY_SEPARATOR;
+        $f = $filename;
+        echo "<b style='color:red'>Error line ".$error['line']." in template: ";
+        echo basename(dirname(dirname($f))).$s.basename(dirname($f)).$s.basename($f)."</b>";
 
 
+        $bits = explode("\n", $template);
+    
+        foreach ($bits as $k => $bit) {
+            echo "<br>".$k."&nbsp;&nbsp;&nbsp;&nbsp;".page::htmlentities($bit);
+        }
 
 
+        exit;
+    }
 
-?>
+    if ($getString) {
+      // Grab everything that was captured in the output buffer and return
+      // it as a string.
+        return (string)ob_get_clean();
+    }
+}

--- a/shared/logo.php
+++ b/shared/logo.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -25,4 +25,3 @@ $image = ALLOC_LOGO;
 $_GET["type"] == "small" and $image = ALLOC_LOGO_SMALL;
 header('Content-type: image/jpg');
 echo file_get_contents($image);
-?>

--- a/shared/menuSubmit.php
+++ b/shared/menuSubmit.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -24,17 +24,13 @@
 require_once("../alloc.php");
 
 if ($_REQUEST["search_action"]) {
-  list($method,$thing) = explode("_",$_REQUEST["search_action"]);
+    list($method,$thing) = explode("_", $_REQUEST["search_action"]);
 
-  if ($method == "search") {
-    alloc_redirect($TPL["url_alloc_search"]."needle=".urlencode($_REQUEST["needle"])."&category=".$_REQUEST["search_action"]."&search=true");
-
-  } else if ($method == "create") {
-    alloc_redirect($sess->url($thing));
-
-  } else if ($method == "history") {
-    alloc_redirect($TPL["url_alloc_history"]."historyID=".$thing);
-  }
+    if ($method == "search") {
+        alloc_redirect($TPL["url_alloc_search"]."needle=".urlencode($_REQUEST["needle"])."&category=".$_REQUEST["search_action"]."&search=true");
+    } else if ($method == "create") {
+        alloc_redirect($sess->url($thing));
+    } else if ($method == "history") {
+        alloc_redirect($TPL["url_alloc_history"]."historyID=".$thing);
+    }
 }
-
-?>

--- a/shared/settings.php
+++ b/shared/settings.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,11 +23,9 @@
 require_once("../alloc.php");
 
 if ($_POST["customize_save"]) {
-  $current_user = &singleton("current_user");
-  $current_user->load_prefs();
-  $current_user->update_prefs($_POST);
-  $current_user->store_prefs();
-  alloc_redirect($TPL["url_alloc_home"]);
+    $current_user = &singleton("current_user");
+    $current_user->load_prefs();
+    $current_user->update_prefs($_POST);
+    $current_user->store_prefs();
+    alloc_redirect($TPL["url_alloc_home"]);
 }
-
-?>

--- a/shared/star.php
+++ b/shared/star.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,16 +23,14 @@
 require_once("../alloc.php");
 
 if ($_REQUEST["entity"] && $_REQUEST["entityID"]) {
-  $stars = $current_user->prefs["stars"];
-  if ($stars[$_REQUEST["entity"]][$_REQUEST["entityID"]]) {
-    unset($stars[$_REQUEST["entity"]][$_REQUEST["entityID"]]);
-  } else {
-    $stars[$_REQUEST["entity"]][$_REQUEST["entityID"]] = true;
-  }
-  $current_user->prefs["stars"] = $stars;
-  $current_user->store_prefs();
+    $stars = $current_user->prefs["stars"];
+    if ($stars[$_REQUEST["entity"]][$_REQUEST["entityID"]]) {
+        unset($stars[$_REQUEST["entity"]][$_REQUEST["entityID"]]);
+    } else {
+        $stars[$_REQUEST["entity"]][$_REQUEST["entityID"]] = true;
+    }
+    $current_user->prefs["stars"] = $stars;
+    $current_user->store_prefs();
 
-  alloc_redirect($TPL["url_alloc_".$_REQUEST["entity"]."List"]);
+    alloc_redirect($TPL["url_alloc_".$_REQUEST["entity"]."List"]);
 }
-
-?>

--- a/shared/starList.php
+++ b/shared/starList.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -66,5 +66,3 @@ $TPL["star_entities"] = $star_entities;
 
 
 include_template("templates/starListM.tpl");
-
-?>

--- a/shared/util.inc.php
+++ b/shared/util.inc.php
@@ -21,293 +21,307 @@
 */
 
 
-function path_under_path($unsafe,$safe,$use_realpath=true) {
+function path_under_path($unsafe, $safe, $use_realpath = true)
+{
   // Checks that the potentially unsafe path is under the safe path
-  if ($use_realpath) {
-    $unsafe = realpath($unsafe);
-    $safe = realpath($safe);
-  }
+    if ($use_realpath) {
+        $unsafe = realpath($unsafe);
+        $safe = realpath($safe);
+    }
 
   // strip trailing slash
-  substr($safe,-1,1) == DIRECTORY_SEPARATOR and $safe = substr($safe,0,-1);
-  substr($unsafe,-1,1) == DIRECTORY_SEPARATOR and $unsafe = substr($unsafe,0,-1);
+    substr($safe, -1, 1) == DIRECTORY_SEPARATOR and $safe = substr($safe, 0, -1);
+    substr($unsafe, -1, 1) == DIRECTORY_SEPARATOR and $unsafe = substr($unsafe, 0, -1);
 
-  if ($safe && $unsafe) {
-    // Make sure the unsafe dir is under the safe dir
-    if (substr($unsafe,0,strlen($safe)) == $safe) {
-      return true;
+    if ($safe && $unsafe) {
+      // Make sure the unsafe dir is under the safe dir
+        if (substr($unsafe, 0, strlen($safe)) == $safe) {
+            return true;
+        }
     }
-  }
 }
 
 // Format a time offset in seconds to (+|-)HH:MM
-function format_offset($secs) {
+function format_offset($secs)
+{
   // sign will be included in the hours
-  $sign = $secs < 0 ? '' : '+';
-  $h = $secs / 3600;
-  $m = $secs % 3600 / 60;
+    $sign = $secs < 0 ? '' : '+';
+    $h = $secs / 3600;
+    $m = $secs % 3600 / 60;
 
-  return sprintf('%s%2d:%02d', $sign,$h,$m);
+    return sprintf('%s%2d:%02d', $sign, $h, $m);
 }
 
 // List of Timezone => Offset Timezone
 // i.e. Australia/Melbourne => +11:00 Australia/Melbourne
 // Ordered by GMT offset
-function get_timezone_array() {
-  $zones = timezone_identifiers_list();
-  $zonelist = array();
+function get_timezone_array()
+{
+    $zones = timezone_identifiers_list();
+    $zonelist = array();
 
   // List format suitable for sorting
-  $now = new DateTime();
+    $now = new DateTime();
 
-  $idx = 0; //to distinguish timezones on the same offset
-  foreach ($zones as $zone) {
-    $tz = new DateTimeZone($zone);
-    $offset = $tz->getOffset($now);
-    // Index is [actual offset]+[arbitrary index]{3}
-    $zonelist[$offset * 10000 + $idx++] = array($zone, format_offset($offset) . " " . $zone);
-  }
+    $idx = 0; //to distinguish timezones on the same offset
+    foreach ($zones as $zone) {
+        $tz = new DateTimeZone($zone);
+        $offset = $tz->getOffset($now);
+      // Index is [actual offset]+[arbitrary index]{3}
+        $zonelist[$offset * 10000 + $idx++] = array($zone, format_offset($offset) . " " . $zone);
+    }
 
   // Sort and unpack
-  $list = array();
-  ksort($zonelist);
-  foreach ($zonelist as $zone) {
-    $list[$zone[0]] = $zone[1];
-  }
+    $list = array();
+    ksort($zonelist);
+    foreach ($zonelist as $zone) {
+        $list[$zone[0]] = $zone[1];
+    }
 
-  return $list;
+    return $list;
 }
-function format_date($format="Y/m/d", $date="") {
+function format_date($format = "Y/m/d", $date = "")
+{
 
   // If looks like this: 2003-07-07 21:37:01
-  if (preg_match("/^[\d]{4}-[\d]{1,2}-[\d]{1,2} [\d]{2}:[\d]{2}:[\d]{2}$/",$date)) {
-    list($d,$t) = explode(" ", $date);
+    if (preg_match("/^[\d]{4}-[\d]{1,2}-[\d]{1,2} [\d]{2}:[\d]{2}:[\d]{2}$/", $date)) {
+        list($d,$t) = explode(" ", $date);
 
-  // If looks like this: 2003-07-07
-  } else if (preg_match("/^[\d]{4}-[\d]{1,2}-[\d]{1,2}$/",$date)) {
-    $d = $date;
+    // If looks like this: 2003-07-07
+    } else if (preg_match("/^[\d]{4}-[\d]{1,2}-[\d]{1,2}$/", $date)) {
+        $d = $date;
 
-  // If looks like this: 12:01:01
-  } else if (preg_match("/^[\d]{2}:[\d]{2}:[\d]{2}$/",$date)) {
-    $d = "2000-01-01";
-    $t = $date;
+    // If looks like this: 12:01:01
+    } else if (preg_match("/^[\d]{2}:[\d]{2}:[\d]{2}$/", $date)) {
+        $d = "2000-01-01";
+        $t = $date;
 
-  // Nasty hobbitses!
-  } else if ($date) {
-    return "Date unrecognized: ".$date;
-  } else {
-    return;
-  }
-  list($y,$m,$d) = explode("-", $d);
-  list($h,$i,$s) = explode(":", $t);
-  list($y,$m,$d,$h,$i,$s) = array(sprintf("%d",$y),sprintf("%d",$m),sprintf("%d",$d)
-                                 ,sprintf("%d",$h),sprintf("%d",$i),sprintf("%d",$s)
+    // Nasty hobbitses!
+    } else if ($date) {
+        return "Date unrecognized: ".$date;
+    } else {
+        return;
+    }
+    list($y,$m,$d) = explode("-", $d);
+    list($h,$i,$s) = explode(":", $t);
+    list($y,$m,$d,$h,$i,$s) = array(sprintf("%d", $y),sprintf("%d", $m),sprintf("%d", $d)
+                                 ,sprintf("%d", $h),sprintf("%d", $i),sprintf("%d", $s)
                                  );
-  return date($format, mktime(date($h),date($i),date($s),date($m),date($d),date($y)));
+    return date($format, mktime(date($h), date($i), date($s), date($m), date($d), date($y)));
 }
-function add_brackets($email="") {
-  if ($email) {
-    $l = strpos($email, "<");
-    $r = strpos($email, ">");
-    $l === false and $email = "<".$email;
-    $r === false and $email .= ">";
-    return $email;
-  }
+function add_brackets($email = "")
+{
+    if ($email) {
+        $l = strpos($email, "<");
+        $r = strpos($email, ">");
+        $l === false and $email = "<".$email;
+        $r === false and $email .= ">";
+        return $email;
+    }
 }
-function get_alloc_version() {
-  static $version;
-  if ($version) {
+function get_alloc_version()
+{
+    static $version;
+    if ($version) {
+        return $version;
+    }
+    if (file_exists(ALLOC_MOD_DIR."util/alloc_version") && is_readable(ALLOC_MOD_DIR."util/alloc_version")) {
+        $v = file(ALLOC_MOD_DIR."util/alloc_version");
+        $version = trim($v[0]);
+    }
     return $version;
-  }
-  if (file_exists(ALLOC_MOD_DIR."util/alloc_version") && is_readable(ALLOC_MOD_DIR."util/alloc_version")) {
-    $v = file(ALLOC_MOD_DIR."util/alloc_version");
-    $version = trim($v[0]);
-  }
-  return $version;
 }
-function seconds_to_display_format($seconds) {
-  $day = config::get_config_item("hoursInDay");
+function seconds_to_display_format($seconds)
+{
+    $day = config::get_config_item("hoursInDay");
 
-  $day_in_seconds = $day * 60 * 60;
-  $hours = $seconds / 60 / 60;
-  if ($seconds != "") {
-    return sprintf("%0.2f hrs",$hours);
-  }
-  return;
+    $day_in_seconds = $day * 60 * 60;
+    $hours = $seconds / 60 / 60;
+    if ($seconds != "") {
+        return sprintf("%0.2f hrs", $hours);
+    }
+    return;
 
-  if ($seconds < $day_in_seconds) {
-    return sprintf("%0.2f hrs",$hours);
-  } else {
-    $days = $seconds / $day_in_seconds;
-    #return sprintf("%0.1f days", $days);
-    return sprintf("%0.2f hrs (%0.1f days)",$hours, $days);
-
-  }
-
+    if ($seconds < $day_in_seconds) {
+        return sprintf("%0.2f hrs", $hours);
+    } else {
+        $days = $seconds / $day_in_seconds;
+      #return sprintf("%0.1f days", $days);
+        return sprintf("%0.2f hrs (%0.1f days)", $hours, $days);
+    }
 }
-function get_all_form_data($array=array(),$defaults=array()) {
+function get_all_form_data($array = array(), $defaults = array())
+{
   // Load up $_FORM with $_GET and $_POST
-  $_FORM = array();
-  foreach ($array as $name) {
-    $_FORM[$name] = $_POST[$name] or $_FORM[$name] = $_GET[$name] or $_FORM[$name] = $defaults[$name];
-  }
-  return $_FORM;
-}
-function timetook($start, $friendly_output=true) {
-  $end = microtime();
-  list($start_micro,$start_epoch,$end_micro,$end_epoch) = explode(" ",$start." ".$end);
-  $started  = (substr($start_epoch,-4) + $start_micro);
-  $finished = (substr($end_epoch  ,-4) + $end_micro);
-  $dur = $finished - $started;
-  if ($friendly_output) {
-    $unit = " seconds.";
-    if ($dur > 60) {
-      $unit = " mins.";
-      $dur = $dur / 60;
+    $_FORM = array();
+    foreach ($array as $name) {
+        $_FORM[$name] = $_POST[$name] or $_FORM[$name] = $_GET[$name] or $_FORM[$name] = $defaults[$name];
     }
-    return sprintf("%0.5f", $dur). $unit;
-  }
-  return sprintf("%0.5f", $dur);
+    return $_FORM;
 }
-function sort_by_name($a, $b) {
-  return strtolower($a["name"]) >= strtolower($b["name"]);
-}
-function rebuild_cache($table) {
-  $cache =& singleton("cache");
-
-  if (meta::$tables[$table]) {
-    $m = new meta($table);
-    $cache[$table] = $m->get_list();
-
-  } else {
-    $db = new db_alloc();
-    $db->query("SELECT * FROM ".$table);
-    while ($row = $db->row()) {
-      $cache[$table][$db->f($table."ID")] = $row;
+function timetook($start, $friendly_output = true)
+{
+    $end = microtime();
+    list($start_micro,$start_epoch,$end_micro,$end_epoch) = explode(" ", $start." ".$end);
+    $started  = (substr($start_epoch, -4) + $start_micro);
+    $finished = (substr($end_epoch, -4) + $end_micro);
+    $dur = $finished - $started;
+    if ($friendly_output) {
+        $unit = " seconds.";
+        if ($dur > 60) {
+            $unit = " mins.";
+            $dur = $dur / 60;
+        }
+        return sprintf("%0.5f", $dur). $unit;
     }
-  }
+    return sprintf("%0.5f", $dur);
+}
+function sort_by_name($a, $b)
+{
+    return strtolower($a["name"]) >= strtolower($b["name"]);
+}
+function rebuild_cache($table)
+{
+    $cache =& singleton("cache");
+
+    if (meta::$tables[$table]) {
+        $m = new meta($table);
+        $cache[$table] = $m->get_list();
+    } else {
+        $db = new db_alloc();
+        $db->query("SELECT * FROM ".$table);
+        while ($row = $db->row()) {
+            $cache[$table][$db->f($table."ID")] = $row;
+        }
+    }
 
   // Special processing for person and config tables
-  if ($table == "person") {
-    $people = $cache["person"];
-    foreach ($people as $id => $row) {
-      if ($people[$id]["firstName"] && $people[$id]["surname"]) {
-        $people[$id]["name"] = $people[$id]["firstName"]." ".$people[$id]["surname"];
-      } else {
-        $people[$id]["name"] = $people[$id]["username"];
-      }
+    if ($table == "person") {
+        $people = $cache["person"];
+        foreach ($people as $id => $row) {
+            if ($people[$id]["firstName"] && $people[$id]["surname"]) {
+                $people[$id]["name"] = $people[$id]["firstName"]." ".$people[$id]["surname"];
+            } else {
+                $people[$id]["name"] = $people[$id]["username"];
+            }
+        }
+        uasort($people, "sort_by_name");
+        $cache["person"] = $people;
+    } else if ($table == "config") {
+      // Special processing for config table
+        $config = $cache["config"];
+        foreach ($config as $id => $row) {
+            $rows_config[$row["name"]] = $row;
+        }
+        $cache["config"] = $rows_config;
     }
-    uasort($people,"sort_by_name");
-    $cache["person"] = $people;
-
-  } else if ($table == "config") {
-    // Special processing for config table
-    $config = $cache["config"];
-    foreach ($config as $id => $row) {
-      $rows_config[$row["name"]] = $row;
+    singleton("cache", $cache);
+}
+function &get_cached_table($table, $anew = false)
+{
+    $cache =& singleton("cache");
+    if ($anew || !$cache[$table]) {
+        rebuild_cache($table);
     }
-    $cache["config"] = $rows_config;
-  }
-  singleton("cache",$cache);
+    return $cache[$table];
 }
-function &get_cached_table($table,$anew=false) {
-  $cache =& singleton("cache");
-  if ($anew || !$cache[$table]) {
-    rebuild_cache($table);
-  }
-  return $cache[$table];
-}
-function get_mimetype($filename="") {
+function get_mimetype($filename = "")
+{
   // We define our own mime_content_type() function (if the inbuilt one is
   // not available) at the end of this file.
-  return mime_content_type($filename);
+    return mime_content_type($filename);
 }
-function sort_by_mtime($a, $b) {
-  return $a["mtime"] >= $b["mtime"];
+function sort_by_mtime($a, $b)
+{
+    return $a["mtime"] >= $b["mtime"];
 }
-function util_show_attachments($entity, $id, $options=array()) {
-  global $TPL;
-  $TPL["entity_url"] = $TPL["url_alloc_".$entity];
-  $TPL["entity_key_name"] = $entity."ID";
-  $TPL["entity_key_value"] = $id;
-  $TPL["bottom_button"] = $options["bottom_button"];
-  $TPL["show_buttons"] = !$options["hide_buttons"];
+function util_show_attachments($entity, $id, $options = array())
+{
+    global $TPL;
+    $TPL["entity_url"] = $TPL["url_alloc_".$entity];
+    $TPL["entity_key_name"] = $entity."ID";
+    $TPL["entity_key_value"] = $id;
+    $TPL["bottom_button"] = $options["bottom_button"];
+    $TPL["show_buttons"] = !$options["hide_buttons"];
 
-  $rows = get_attachments($entity, $id);
-  if (!$rows && $options["hide_buttons"]) {
-    return; // no rows, and no buttons, leave the whole thing out.
-  }
-  $rows or $rows = array();
-  foreach ($rows as $row) {
-    $TPL["attachments"].= "<tr><td>".$row["file"]."</td><td class=\"nobr\">".$row["mtime"]."</td><td>".$row["size"]."</td>";
-    $TPL["attachments"].= "<td align=\"right\" width=\"1%\" style=\"padding:5px;\">".$row["delete"]."</td></tr>";
-  }
-  include_template("../shared/templates/attachmentM.tpl");
+    $rows = get_attachments($entity, $id);
+    if (!$rows && $options["hide_buttons"]) {
+        return; // no rows, and no buttons, leave the whole thing out.
+    }
+    $rows or $rows = array();
+    foreach ($rows as $row) {
+        $TPL["attachments"].= "<tr><td>".$row["file"]."</td><td class=\"nobr\">".$row["mtime"]."</td><td>".$row["size"]."</td>";
+        $TPL["attachments"].= "<td align=\"right\" width=\"1%\" style=\"padding:5px;\">".$row["delete"]."</td></tr>";
+    }
+    include_template("../shared/templates/attachmentM.tpl");
 }
-function get_filesize_label($file) {
-  $size = filesize($file);
-  return get_size_label($size);
+function get_filesize_label($file)
+{
+    $size = filesize($file);
+    return get_size_label($size);
 }
-function get_size_label($size) {
-  $size > 1023 and $rtn = sprintf("%dK",$size/1024);
-  $size < 1024 and $rtn = sprintf("%d",$size);
-  $size > (1024 * 1024) and $rtn = sprintf("%0.1fM",$size/(1024*1024));
-  return $rtn;
+function get_size_label($size)
+{
+    $size > 1023 and $rtn = sprintf("%dK", $size/1024);
+    $size < 1024 and $rtn = sprintf("%d", $size);
+    $size > (1024 * 1024) and $rtn = sprintf("%0.1fM", $size/(1024*1024));
+    return $rtn;
 }
-function get_file_type_image($file) {
-  global $TPL;
+function get_file_type_image($file)
+{
+    global $TPL;
   // hardcoded types ...
-  $types["pdf"] = "pdf.gif";
-  $types["xls"] = "xls.gif";
-  $types["csv"] = "xls.gif";
-  $types["zip"] = "zip.gif";
-  $types[".gz"] = "zip.gif";
-  $types["doc"] = "doc.gif";
-  $types["sxw"] = "doc.gif";
+    $types["pdf"] = "pdf.gif";
+    $types["xls"] = "xls.gif";
+    $types["csv"] = "xls.gif";
+    $types["zip"] = "zip.gif";
+    $types[".gz"] = "zip.gif";
+    $types["doc"] = "doc.gif";
+    $types["sxw"] = "doc.gif";
   #$types["odf"] = "doc.gif";
 
-  $type = strtolower(substr($file,-3));
-  $icon_dir = ALLOC_MOD_DIR."images".DIRECTORY_SEPARATOR."fileicons".DIRECTORY_SEPARATOR;
-  if ($types[$type]) {
-    $t = $types[$type];
-  } else if (file_exists($icon_dir.$type.".gif")) {
-    $t = $type.".gif";
-  } else if (file_exists($icon_dir.$type.".png")) {
-    $t = $type.".png";
-  } else {
-    $t = "unknown.gif";
-  }
-  return "<img border=\"0\" alt=\"icon\" src=\"".$TPL["url_alloc_images"]."/fileicons/".$t."\">";
+    $type = strtolower(substr($file, -3));
+    $icon_dir = ALLOC_MOD_DIR."images".DIRECTORY_SEPARATOR."fileicons".DIRECTORY_SEPARATOR;
+    if ($types[$type]) {
+        $t = $types[$type];
+    } else if (file_exists($icon_dir.$type.".gif")) {
+        $t = $type.".gif";
+    } else if (file_exists($icon_dir.$type.".png")) {
+        $t = $type.".png";
+    } else {
+        $t = "unknown.gif";
+    }
+    return "<img border=\"0\" alt=\"icon\" src=\"".$TPL["url_alloc_images"]."/fileicons/".$t."\">";
 }
-function get_attachments($entity, $id, $ops=array()) {
+function get_attachments($entity, $id, $ops = array())
+{
 
-  global $TPL;
-  $rows = array();
-  $dir = ATTACHMENTS_DIR.$entity.DIRECTORY_SEPARATOR.$id;
+    global $TPL;
+    $rows = array();
+    $dir = ATTACHMENTS_DIR.$entity.DIRECTORY_SEPARATOR.$id;
 
-  if (isset($id)) {
-    #if (!is_dir($dir)) {
-      #mkdir($dir, 0777);
-    #}
+    if (isset($id)) {
+      #if (!is_dir($dir)) {
+        #mkdir($dir, 0777);
+      #}
 
 
-    if (is_dir($dir)) {
-      $handle = opendir($dir);
+        if (is_dir($dir)) {
+            $handle = opendir($dir);
 
-      // TODO add icons to files attachaments in general
-      while (false !== ($file = readdir($handle))) {
-        clearstatcache();
+          // TODO add icons to files attachaments in general
+            while (false !== ($file = readdir($handle))) {
+                clearstatcache();
 
-        if ($file != "." && $file != "..") {
+                if ($file != "." && $file != "..") {
+                    $image = get_file_type_image($dir.DIRECTORY_SEPARATOR.$file);
 
-          $image = get_file_type_image($dir.DIRECTORY_SEPARATOR.$file);
-
-          $row["size"] = get_filesize_label($dir.DIRECTORY_SEPARATOR.$file);
-          $row["path"] = $dir.DIRECTORY_SEPARATOR.$file;
-          $row["file"] = "<a href=\"".$TPL["url_alloc_getDoc"]."id=".$id."&entity=".$entity."&file=".urlencode($file)."\">".$image.$ops["sep"].page::htmlentities($file)."</a>";
-          $row["text"] = page::htmlentities($file);
-          #$row["delete"] = "<a href=\"".$TPL["url_alloc_delDoc"]."id=".$id."&entity=".$entity."&file=".urlencode($file)."\">Delete</a>";
-          $row["delete"] = "<form action=\"".$TPL["url_alloc_delDoc"]."\" method=\"post\">
+                    $row["size"] = get_filesize_label($dir.DIRECTORY_SEPARATOR.$file);
+                    $row["path"] = $dir.DIRECTORY_SEPARATOR.$file;
+                    $row["file"] = "<a href=\"".$TPL["url_alloc_getDoc"]."id=".$id."&entity=".$entity."&file=".urlencode($file)."\">".$image.$ops["sep"].page::htmlentities($file)."</a>";
+                    $row["text"] = page::htmlentities($file);
+                  #$row["delete"] = "<a href=\"".$TPL["url_alloc_delDoc"]."id=".$id."&entity=".$entity."&file=".urlencode($file)."\">Delete</a>";
+                    $row["delete"] = "<form action=\"".$TPL["url_alloc_delDoc"]."\" method=\"post\">
                             <input type=\"hidden\" name=\"id\" value=\"".$id."\">
                             <input type=\"hidden\" name=\"file\" value=\"".$file."\">
                             <input type=\"hidden\" name=\"entity\" value=\"".$entity."\">
@@ -316,266 +330,279 @@ function get_attachments($entity, $id, $ops=array()) {
                           .'<button type="submit" name="delete_file_attachment" value="1" class="delete_button">Delete<i class="icon-trash"></i></button>'."</form>";
 
 
-          $row["mtime"] = date("Y-m-d H:i:s",filemtime($dir.DIRECTORY_SEPARATOR.$file));
-          $row["restore_name"] = $file;
+                    $row["mtime"] = date("Y-m-d H:i:s", filemtime($dir.DIRECTORY_SEPARATOR.$file));
+                    $row["restore_name"] = $file;
 
-          $rows[] = $row;
+                    $rows[] = $row;
+                }
+            }
+            closedir($handle);
         }
-      }
-      closedir($handle);
+        is_array($rows) && usort($rows, "sort_by_mtime");
     }
-    is_array($rows) && usort($rows, "sort_by_mtime");
-  }
-  return $rows;
+    return $rows;
 }
-function rejig_files_array($f) {
+function rejig_files_array($f)
+{
   // Re-jig the $_FILES array so that it can handle <input type="file" name="many_files[]">
-  if ($f) {
-    foreach ($f as $key => $thing) {
-      if (is_array($f[$key]["tmp_name"])) {
-        foreach ($f[$key]["tmp_name"] as $k=>$v) {
-          if ($f[$key]["tmp_name"][$k]) {
-            $files[] = array("name"     =>$f[$key]["name"][$k]
+    if ($f) {
+        foreach ($f as $key => $thing) {
+            if (is_array($f[$key]["tmp_name"])) {
+                foreach ($f[$key]["tmp_name"] as $k => $v) {
+                    if ($f[$key]["tmp_name"][$k]) {
+                        $files[] = array("name"     =>$f[$key]["name"][$k]
                             ,"tmp_name" =>$f[$key]["tmp_name"][$k]
                             ,"type"     =>$f[$key]["type"][$k]
                             ,"error"    =>$f[$key]["error"][$k]
                             ,"size"     =>$f[$key]["size"][$k]
-                            );
-          }
-        }
-      } else if ($f[$key]["tmp_name"]) {
-          $files[] = array("name"     =>$f[$key]["name"]
+                                  );
+                    }
+                }
+            } else if ($f[$key]["tmp_name"]) {
+                $files[] = array("name"     =>$f[$key]["name"]
                           ,"tmp_name" =>$f[$key]["tmp_name"]
                           ,"type"     =>$f[$key]["type"]
                           ,"error"    =>$f[$key]["error"]
                           ,"size"     =>$f[$key]["size"]
                           );
-      }
+            }
+        }
     }
-  }
-  return (array)$files;
+    return (array)$files;
 }
-function move_attachment($entity, $id=false) {
-  global $TPL;
+function move_attachment($entity, $id = false)
+{
+    global $TPL;
 
-  $id = sprintf("%d",$id);
-  $files = rejig_files_array($_FILES);
+    $id = sprintf("%d", $id);
+    $files = rejig_files_array($_FILES);
 
-  if (is_array($files) && count($files)) {
+    if (is_array($files) && count($files)) {
+        foreach ($files as $file) {
+            if (is_uploaded_file($file["tmp_name"])) {
+                $dir = ATTACHMENTS_DIR.$entity.DIRECTORY_SEPARATOR.$id;
+                if (!is_dir($dir)) {
+                    mkdir($dir, 0777);
+                }
+                $newname = basename($file["name"]);
 
-    foreach ($files as $file) {
-
-      if (is_uploaded_file($file["tmp_name"])) {
-
-        $dir = ATTACHMENTS_DIR.$entity.DIRECTORY_SEPARATOR.$id;
-        if (!is_dir($dir)) {
-          mkdir($dir, 0777);
+                if (!move_uploaded_file($file["tmp_name"], $dir.DIRECTORY_SEPARATOR.$newname)) {
+                    alloc_error("Could not move attachment to: ".$dir.DIRECTORY_SEPARATOR.$newname);
+                } else {
+                    chmod($dir.DIRECTORY_SEPARATOR.$newname, 0777);
+                }
+            } else {
+                switch ($file['error']) {
+                    case 0:
+                        alloc_error("There was a problem with your upload.");
+                        break;
+                    case 1: // upload_max_filesize in php.ini
+                        alloc_error("The file you are trying to upload is too big(1).");
+                        break;
+                    case 2: // MAX_FILE_SIZE
+                        alloc_error("The file you are trying to upload is too big(2).");
+                        break;
+                    case 3:
+                              alloc_error("The file you are trying upload was only partially uploaded.");
+                        break;
+                    case 4:
+                              alloc_error("You must select a file for upload.");
+                        break;
+                    default:
+                              alloc_error("There was a problem with your upload.");
+                        break;
+                }
+            }
         }
-        $newname = basename($file["name"]);
-
-        if (!move_uploaded_file($file["tmp_name"], $dir.DIRECTORY_SEPARATOR.$newname)) {
-          alloc_error("Could not move attachment to: ".$dir.DIRECTORY_SEPARATOR.$newname);
-        } else {
-          chmod($dir.DIRECTORY_SEPARATOR.$newname, 0777);
-        }
-
-      } else {
-        switch($file['error']){
-          case 0:
-            alloc_error("There was a problem with your upload.");
-            break;
-          case 1: // upload_max_filesize in php.ini
-            alloc_error("The file you are trying to upload is too big(1).");
-            break;
-          case 2: // MAX_FILE_SIZE
-            alloc_error("The file you are trying to upload is too big(2).");
-            break;
-          case 3:
-            alloc_error("The file you are trying upload was only partially uploaded.");
-            break;
-          case 4:
-            alloc_error("You must select a file for upload.");
-            break;
-          default:
-            alloc_error("There was a problem with your upload.");
-            break;
-        }
-      }
     }
-  }
 }
-function db_esc($str = "") {
-  $db =& singleton("db");
-  return $db->esc($str);
+function db_esc($str = "")
+{
+    $db =& singleton("db");
+    return $db->esc($str);
 }
-function parse_sql_file($file) {
+function parse_sql_file($file)
+{
 
   // Filename must be readable and end in .sql
-  if (!is_readable($file) || substr($file,-4) != strtolower(".sql")) {
-    return;
-  }
-
-  $sql = array();
-  $comments = array();
-  $mqr = @get_magic_quotes_runtime();
-  @set_magic_quotes_runtime(0);
-  $lines = file($file);
-  @set_magic_quotes_runtime($mqr);
-
-  foreach ($lines as $line) {
-    if (preg_match("/^[\s]*(--[^\n]*)$/", $line, $m)) {
-      $comments[] = str_replace("-- ","",trim($m[1]));
-    } else if (!empty($line) && substr($line,0,2) != "--" && $line) {
-      $queries[] = trim($line);
+    if (!is_readable($file) || substr($file, -4) != strtolower(".sql")) {
+        return;
     }
-  }
 
-  $bits = array();
-  foreach ((array)$queries as $query) {
-    if(!empty($query)) {
-      $query = trim($query);
-      $bits[] = $query;
-      if (preg_match('/;\s*$/',$query)) {
-        $sql[] = implode(" ",$bits);
-        $bits = array();
-      }
+    $sql = array();
+    $comments = array();
+    $mqr = @get_magic_quotes_runtime();
+    @set_magic_quotes_runtime(0);
+    $lines = file($file);
+    @set_magic_quotes_runtime($mqr);
+
+    foreach ($lines as $line) {
+        if (preg_match("/^[\s]*(--[^\n]*)$/", $line, $m)) {
+            $comments[] = str_replace("-- ", "", trim($m[1]));
+        } else if (!empty($line) && substr($line, 0, 2) != "--" && $line) {
+            $queries[] = trim($line);
+        }
     }
-  }
-  return array($sql,$comments);
+
+    $bits = array();
+    foreach ((array)$queries as $query) {
+        if (!empty($query)) {
+            $query = trim($query);
+            $bits[] = $query;
+            if (preg_match('/;\s*$/', $query)) {
+                $sql[] = implode(" ", $bits);
+                $bits = array();
+            }
+        }
+    }
+    return array($sql,$comments);
 }
-function parse_php_file($file) {
+function parse_php_file($file)
+{
   // Filename must be readable and end in .php
-  if (!is_readable($file) || substr($file,-4) != strtolower(".php")) {
-    return;
-  }
-
-  $php = array();
-  $comments = array();
-  $mqr = @get_magic_quotes_runtime();
-  @set_magic_quotes_runtime(0);
-  $lines = file($file);
-  @set_magic_quotes_runtime($mqr);
-
-  foreach ($lines as $line) {
-    if (preg_match("/^[\s]*(\/\/[^\n]*)$/", $line, $m)) {
-      $comments[] = str_replace("//","",trim($m[1]));
-    } else if (!empty($line) && substr($line,0,2) != "//" && $line) {
-      $php[] = trim($line);
+    if (!is_readable($file) || substr($file, -4) != strtolower(".php")) {
+        return;
     }
-  }
-  return array($php,$comments);
-}
-function parse_patch_file($file) {
-  if (!is_readable($file)) {
-    return;
-  }
 
-  if (substr($file,-4) == strtolower(".php")) {
-    return parse_php_file($file);
+    $php = array();
+    $comments = array();
+    $mqr = @get_magic_quotes_runtime();
+    @set_magic_quotes_runtime(0);
+    $lines = file($file);
+    @set_magic_quotes_runtime($mqr);
 
-  } else if (substr($file,-4) == strtolower(".sql")) {
-    return parse_sql_file($file);
-  }
+    foreach ($lines as $line) {
+        if (preg_match("/^[\s]*(\/\/[^\n]*)$/", $line, $m)) {
+            $comments[] = str_replace("//", "", trim($m[1]));
+        } else if (!empty($line) && substr($line, 0, 2) != "//" && $line) {
+            $php[] = trim($line);
+        }
+    }
+    return array($php,$comments);
 }
-function execute_php_file($file_to_execute) {
-   global $TPL;
-   ob_start();
-   include($file_to_execute);
-   return ob_get_contents();
+function parse_patch_file($file)
+{
+    if (!is_readable($file)) {
+        return;
+    }
+
+    if (substr($file, -4) == strtolower(".php")) {
+        return parse_php_file($file);
+    } else if (substr($file, -4) == strtolower(".sql")) {
+        return parse_sql_file($file);
+    }
 }
-function bad_filename($filename) {
-  return preg_match("@[/\\\]@", $filename);
+function execute_php_file($file_to_execute)
+{
+    global $TPL;
+    ob_start();
+    include($file_to_execute);
+    return ob_get_contents();
 }
-function has_backup_perm() {
-  $current_user = &singleton("current_user");
-  if (is_object($current_user)) {
-    return $current_user->have_role("god");
-  }
-  return false;
+function bad_filename($filename)
+{
+    return preg_match("@[/\\\]@", $filename);
 }
-function parse_email_address($email="") {
+function has_backup_perm()
+{
+    $current_user = &singleton("current_user");
+    if (is_object($current_user)) {
+        return $current_user->have_role("god");
+    }
+    return false;
+}
+function parse_email_address($email = "")
+{
   // Takes Alex Lance <alla@cyber.com.au> and returns array("alla@cyber.com.au", "Alex Lance");
-  if ($email) {
-    $structure = Mail_RFC822::parseAddressList($email);
-    $name = (string)$structure[0]->personal;
-    if ($structure[0]->mailbox && $structure[0]->host) {
-      $addr = (string)$structure[0]->mailbox."@".(string)$structure[0]->host;
+    if ($email) {
+        $structure = Mail_RFC822::parseAddressList($email);
+        $name = (string)$structure[0]->personal;
+        if ($structure[0]->mailbox && $structure[0]->host) {
+            $addr = (string)$structure[0]->mailbox."@".(string)$structure[0]->host;
+        }
+        return array($addr, $name);
     }
-    return array($addr, $name);
-  }
-  return array();
+    return array();
 }
-function same_email_address($addy1, $addy2) {
-  list($from_address1,$from_name1) = parse_email_address($addy1);
-  list($from_address2,$from_name2) = parse_email_address($addy2);
-  if ($from_address1 == $from_address2) {
-    return true;
-  }
+function same_email_address($addy1, $addy2)
+{
+    list($from_address1,$from_name1) = parse_email_address($addy1);
+    list($from_address2,$from_name2) = parse_email_address($addy2);
+    if ($from_address1 == $from_address2) {
+        return true;
+    }
 }
-  function get_max_alloc_users() {
+function get_max_alloc_users()
+{
     if (function_exists("ace_get_max_alloc_users")) {
-      return ace_get_max_alloc_users();
+        return ace_get_max_alloc_users();
     }
     return 0;
-  }
-  function get_max_alloc_users_message() {
+}
+function get_max_alloc_users_message()
+{
     if (function_exists("ace_get_max_alloc_users_message")) {
-      return ace_get_max_alloc_users_message();
+        return ace_get_max_alloc_users_message();
     }
     return "The number of active allocPSA user accounts has exceeded the maximum allowed.";
-  }
-  function get_num_alloc_users() {
+}
+function get_num_alloc_users()
+{
     $db = new db_alloc();
     $db->query("SELECT COUNT(*) AS total FROM person WHERE personActive = 1");
     $row = $db->row();
     return $row["total"];
-  }
-function alloc_redirect($url) {
-  global $TPL;
-
-  $sep = "&";
-  strpos($url,"?") === false and $sep = "?";
-
-  foreach (array("message","message_good","message_help","message_help_no_esc","message_good_no_esc") as $type) {
-    if ($TPL[$type]) {
-      is_array($TPL[$type]) and $TPL[$type] = implode("<br>",$TPL[$type]);
-      is_string($TPL[$type]) && strlen($TPL[$type]) and $str[] = $type."=".urlencode($TPL[$type]);
-    }
-  }
-
-  $str and $str = $sep.implode("&",$str);
-  header("Location: ".$url.$str);
-  exit();
 }
-function obj2array($obj) {
-  $out = array();
-  foreach ($obj as $key => $val) {
-    switch(true) {
-        case is_object($val):
-         $out[$key] = obj2array($val);
-         break;
-      case is_array($val):
-         $out[$key] = obj2array($val);
-         break;
-      default:
-        $out[$key] = $val;
+function alloc_redirect($url)
+{
+    global $TPL;
+
+    $sep = "&";
+    strpos($url, "?") === false and $sep = "?";
+
+    foreach (array("message","message_good","message_help","message_help_no_esc","message_good_no_esc") as $type) {
+        if ($TPL[$type]) {
+            is_array($TPL[$type]) and $TPL[$type] = implode("<br>", $TPL[$type]);
+            is_string($TPL[$type]) && strlen($TPL[$type]) and $str[] = $type."=".urlencode($TPL[$type]);
+        }
     }
-  }
-  return $out;
+
+    $str and $str = $sep.implode("&", $str);
+    header("Location: ".$url.$str);
+    exit();
 }
-function query_string_to_array($str="") {
-  $pairs = explode("&", $str);
-  foreach ($pairs as $pair) {
-      $nv = explode("=", $pair);
-      $name = urldecode($nv[0]);
-      $value = urldecode($nv[1]);
-      $vars[$name] = $value;
-  }
-  return (array)$vars;
+function obj2array($obj)
+{
+    $out = array();
+    foreach ($obj as $key => $val) {
+        switch (true) {
+            case is_object($val):
+                $out[$key] = obj2array($val);
+                break;
+            case is_array($val):
+                 $out[$key] = obj2array($val);
+                break;
+            default:
+                $out[$key] = $val;
+        }
+    }
+    return $out;
+}
+function query_string_to_array($str = "")
+{
+    $pairs = explode("&", $str);
+    foreach ($pairs as $pair) {
+        $nv = explode("=", $pair);
+        $name = urldecode($nv[0]);
+        $value = urldecode($nv[1]);
+        $vars[$name] = $value;
+    }
+    return (array)$vars;
 }
 if (!function_exists('mime_content_type')) {
-  function mime_content_type($filename="") {
-    $mime_types = array('txt'   => 'text/plain'
+    function mime_content_type($filename = "")
+    {
+        $mime_types = array('txt'   => 'text/plain'
                        ,'mdwn'  => 'text/plain' // markdown text files
                        ,'htm'   => 'text/html'
                        ,'html'  => 'text/html'
@@ -616,252 +643,279 @@ if (!function_exists('mime_content_type')) {
                        ,'ppt'   => 'application/vnd.ms-powerpoint'
                        ,'odt'   => 'application/vnd.oasis.opendocument.text'
                        ,'ods'   => 'application/vnd.oasis.opendocument.spreadsheet'
-    );
+        );
 
-    $bits = explode('.',basename($filename));
-    count($bits) > 1 and $ext = strtolower(end($bits));
+        $bits = explode('.', basename($filename));
+        count($bits) > 1 and $ext = strtolower(end($bits));
 
-    // Or look for the suffix in our array
-    if (array_key_exists($ext, $mime_types)) {
-      $mt = $mime_types[$ext];
+      // Or look for the suffix in our array
+        if (array_key_exists($ext, $mime_types)) {
+            $mt = $mime_types[$ext];
 
-    // Or if we have the PECL FileInfo stuff available, use that to determine mimetype
-    } else if (file_exists($filename) && function_exists('finfo_open')) {
-      $finfo = finfo_open(FILEINFO_MIME);
-      $mimetype = finfo_file($finfo, $filename);
-      finfo_close($finfo);
-      $mt = $mimetype;
-      $mt = current(explode(" ",$mimetype));
+          // Or if we have the PECL FileInfo stuff available, use that to determine mimetype
+        } else if (file_exists($filename) && function_exists('finfo_open')) {
+            $finfo = finfo_open(FILEINFO_MIME);
+            $mimetype = finfo_file($finfo, $filename);
+            finfo_close($finfo);
+            $mt = $mimetype;
+            $mt = current(explode(" ", $mimetype));
 
-    // Or if the file is an image, get mime type the old-fashioned way
-    } else if (file_exists($filename) && $size = @getimagesize($filename)) {
-      $mt = $size['mime'];
+        // Or if the file is an image, get mime type the old-fashioned way
+        } else if (file_exists($filename) && $size = @getimagesize($filename)) {
+            $mt = $size['mime'];
 
-    // Or if no suffix at all, return text/plain
-    } else if (!$ext) {
-      $mt = 'text/plain';
+        // Or if no suffix at all, return text/plain
+        } else if (!$ext) {
+            $mt = 'text/plain';
 
-    // Else unrecognised suffix, force browser to offer download dialog
-    } else {
-      $mt = 'application/octet-stream';
+        // Else unrecognised suffix, force browser to offer download dialog
+        } else {
+            $mt = 'application/octet-stream';
+        }
+        return $mt;
     }
-    return $mt;
-  }
 }
-function alloc_json_encode($arr=array()) {
-  $sj = new Services_JSON(SERVICES_JSON_LOOSE_TYPE);
-  return $sj->encode($arr);
+function alloc_json_encode($arr = array())
+{
+    $sj = new Services_JSON(SERVICES_JSON_LOOSE_TYPE);
+    return $sj->encode($arr);
 }
-function alloc_json_decode($str="") {
-  $sj = new Services_JSON(SERVICES_JSON_LOOSE_TYPE);
-  return $sj->decode($str);
+function alloc_json_decode($str = "")
+{
+    $sj = new Services_JSON(SERVICES_JSON_LOOSE_TYPE);
+    return $sj->decode($str);
 }
-function image_create_from_file($path) {
-  $info = getimagesize($path);
-  if(!$info) {
-    echo "unable to determine getimagesize($path)";
-    return false;
-  }
-  $functions = array(
+function image_create_from_file($path)
+{
+    $info = getimagesize($path);
+    if (!$info) {
+        echo "unable to determine getimagesize($path)";
+        return false;
+    }
+    $functions = array(
     IMAGETYPE_GIF => 'imagecreatefromgif',
     IMAGETYPE_JPEG => 'imagecreatefromjpeg',
     IMAGETYPE_PNG => 'imagecreatefrompng',
     IMAGETYPE_WBMP => 'imagecreatefromwbmp',
     IMAGETYPE_XBM => 'imagecreatefromwxbm',
-  );
+    );
 
-  if(!$functions[$info[2]]) {
-    echo "no function to handle $info[2]";
-    return false;
-  }
-  if(!function_exists($functions[$info[2]])) {
-    echo "no function exists to handle ".$functions[$info[2]];
-    return false;
-  }
-  $f = $functions[$info[2]];
-  return $f($path);
+    if (!$functions[$info[2]]) {
+        echo "no function to handle $info[2]";
+        return false;
+    }
+    if (!function_exists($functions[$info[2]])) {
+        echo "no function exists to handle ".$functions[$info[2]];
+        return false;
+    }
+    $f = $functions[$info[2]];
+    return $f($path);
 }
-function operator_comparison($operator,$figure,$subject) {
-  if ($operator == '=')  { return $figure == $subject; }
-  if ($operator == '>')  { return $figure >  $subject; }
-  if ($operator == '>=') { return $figure >= $subject; }
-  if ($operator == '<')  { return $figure <  $subject; }
-  if ($operator == '<=') { return $figure <= $subject; }
-  if ($operator == '!=') { return $figure != $subject; }
+function operator_comparison($operator, $figure, $subject)
+{
+    if ($operator == '=') {
+        return $figure == $subject;
+    }
+    if ($operator == '>') {
+        return $figure >  $subject;
+    }
+    if ($operator == '>=') {
+        return $figure >= $subject;
+    }
+    if ($operator == '<') {
+        return $figure <  $subject;
+    }
+    if ($operator == '<=') {
+        return $figure <= $subject;
+    }
+    if ($operator == '!=') {
+        return $figure != $subject;
+    }
 }
-function parse_operator_comparison($str,$figure) {
-  $operator_regex = "/\s*([><=!]*)\s*([\d\.]+)\s*/";
+function parse_operator_comparison($str, $figure)
+{
+    $operator_regex = "/\s*([><=!]*)\s*([\d\.]+)\s*/";
 
   // 5
-  if (is_numeric($str)) {
-    $operator = '=';
-    $number = $str;
-    return operator_comparison($operator,$figure,$number);
+    if (is_numeric($str)) {
+        $operator = '=';
+        $number = $str;
+        return operator_comparison($operator, $figure, $number);
 
-  // <5 OR =10
-  } else if (stristr($str,"OR")) {
-    $criterias = explode("OR",$str);
-    foreach ($criterias as $criteria) {
-      if (parse_operator_comparison($criteria,$figure)) {
-        return true;
-      }
+    // <5 OR =10
+    } else if (stristr($str, "OR")) {
+        $criterias = explode("OR", $str);
+        foreach ($criterias as $criteria) {
+            if (parse_operator_comparison($criteria, $figure)) {
+                return true;
+            }
+        }
+
+    // >5 AND <10
+    } else if (stristr($str, "AND")) {
+        $criterias = explode("AND", $str);
+        foreach ($criterias as $criteria) {
+            preg_match($operator_regex, $criteria, $matches);
+            $operator = $matches[1];
+            $number = $matches[2];
+            if (operator_comparison($operator, $figure, $number)) {
+                $alive = true;
+            } else {
+                $dead = true;
+            }
+        }
+        return $alive && !$dead;
+
+    // >5
+    } else if (preg_match($operator_regex, $str, $matches)) {
+        $operator = $matches[1];
+        $number = $matches[2];
+        return operator_comparison($operator, $figure, $number);
     }
-
-  // >5 AND <10
-  } else if (stristr($str,"AND")) {
-    $criterias = explode("AND",$str);
-    foreach ($criterias as $criteria) {
-      preg_match($operator_regex,$criteria,$matches);
-      $operator = $matches[1];
-      $number = $matches[2];
-      if (operator_comparison($operator,$figure,$number)) {
-        $alive = true;
-      } else {
-        $dead = true;
-      }
-    }
-    return $alive && !$dead;
-
-  // >5
-  } else if (preg_match($operator_regex,$str,$matches)) {
-    $operator = $matches[1];
-    $number = $matches[2];
-    return operator_comparison($operator,$figure,$number);
-  }
 }
-function imp($var) {
+function imp($var)
+{
   // This function exists because php equates zeroes to false values.
   // imp == important == is this variable important == if imp($var)
-  return $var !== array() && trim((string)$var) !== '' && $var !== null && $var !== false;
+    return $var !== array() && trim((string)$var) !== '' && $var !== null && $var !== false;
 }
-function get_exchange_rate($from, $to) {
+function get_exchange_rate($from, $to)
+{
 
   // eg: AUD to AUD == 1
-  if ($from == $to) {
-    return 1;
-  }
+    if ($from == $to) {
+        return 1;
+    }
 
-  $debug = $_REQUEST["debug"];
+    $debug = $_REQUEST["debug"];
 
-  usleep(500000); // So we don't hit their servers too hard
-  $debug and print "<br>";
+    usleep(500000); // So we don't hit their servers too hard
+    $debug and print "<br>";
 
-  $url = 'http://finance.yahoo.com/d/quotes.csv?f=l1d1t1&s='.$from.$to.'=X';
-  $data = file_get_contents($url);
-  $debug and print "<br>Y: ".htmlentities($data);
-  $results = explode(",",$data);
-  $rate = $results[0];
-  $debug and print "<br>Yahoo says 5 ".$from." is worth ".($rate*5)." ".$to." at this exchange rate: ".$rate;
-
-  if (!$rate) {
-    $url = 'http://www.google.com/ig/calculator?hl=en&q='.urlencode('1'.$from.'=?'.$to);
+    $url = 'http://finance.yahoo.com/d/quotes.csv?f=l1d1t1&s='.$from.$to.'=X';
     $data = file_get_contents($url);
-    $debug and print "<br>G: ".htmlentities($data);
-    $arr = alloc_json_decode($data);
-    $rate = current(explode(" ",$arr["rhs"]));
-    $debug and print "<br>Google says 5 ".$from." is worth ".($rate*5)." ".$to." at this exchange rate: ".$rate;
-  }
+    $debug and print "<br>Y: ".htmlentities($data);
+    $results = explode(",", $data);
+    $rate = $results[0];
+    $debug and print "<br>Yahoo says 5 ".$from." is worth ".($rate*5)." ".$to." at this exchange rate: ".$rate;
 
-  return trim($rate);
-}
-function array_kv($arr,$k,$v) {
-  foreach ((array)$arr as $key => $value) {
-    if (is_array($v)) {
-      $sep = '';
-      foreach ($v as $i) {
-        $rtn[$value[$k]].= $sep.$value[$i];
-        $sep = " ";
-      }
-    } else if ($k) {
-      $rtn[$value[$k]] = $value[$v];
-    } else {
-      $rtn[$key] = $value[$v];
+    if (!$rate) {
+        $url = 'http://www.google.com/ig/calculator?hl=en&q='.urlencode('1'.$from.'=?'.$to);
+        $data = file_get_contents($url);
+        $debug and print "<br>G: ".htmlentities($data);
+        $arr = alloc_json_decode($data);
+        $rate = current(explode(" ", $arr["rhs"]));
+        $debug and print "<br>Google says 5 ".$from." is worth ".($rate*5)." ".$to." at this exchange rate: ".$rate;
     }
-  }
-  return $rtn;
+
+    return trim($rate);
 }
-function in_str($in,$str) {
-  return strpos($str,$in) !== false;
-}
-function rmdir_if_empty($dir) {
-  if (is_dir($dir)) {
-    // Nuke dir if empty
-    if (dir_is_empty($dir)) {
-      rmdir($dir);
+function array_kv($arr, $k, $v)
+{
+    foreach ((array)$arr as $key => $value) {
+        if (is_array($v)) {
+            $sep = '';
+            foreach ($v as $i) {
+                $rtn[$value[$k]].= $sep.$value[$i];
+                $sep = " ";
+            }
+        } else if ($k) {
+            $rtn[$value[$k]] = $value[$v];
+        } else {
+            $rtn[$key] = $value[$v];
+        }
     }
-  }
+    return $rtn;
 }
-function dir_is_empty($dir) {
-  if (is_dir($dir)) {
-    $handle = opendir($dir);
-    clearstatcache();
-    while (false !== ($file = readdir($handle))) {
-      if ($file != "." && $file != "..") {
-        $num_files++;
+function in_str($in, $str)
+{
+    return strpos($str, $in) !== false;
+}
+function rmdir_if_empty($dir)
+{
+    if (is_dir($dir)) {
+      // Nuke dir if empty
+        if (dir_is_empty($dir)) {
+            rmdir($dir);
+        }
+    }
+}
+function dir_is_empty($dir)
+{
+    if (is_dir($dir)) {
+        $handle = opendir($dir);
         clearstatcache();
-      }
+        while (false !== ($file = readdir($handle))) {
+            if ($file != "." && $file != "..") {
+                $num_files++;
+                clearstatcache();
+            }
+        }
+        return !$num_files;
     }
-    return !$num_files;
-  }
 }
-function tax($amount,$taxPercent=null) {
+function tax($amount, $taxPercent = null)
+{
   // take a tax included amount and return the untaxed amount, and the amount of tax
   // eg: 500 including 10% tax, returns array(454.54, 45.45)
-  imp($taxPercent) or $taxPercent = config::get_config_item("taxPercent");
-  $amount_minus_tax = $amount / (($taxPercent/100) + 1);
-  $amount_of_tax    = $amount / ((100/$taxPercent) + 1);
-  return array($amount_minus_tax, $amount_of_tax);
+    imp($taxPercent) or $taxPercent = config::get_config_item("taxPercent");
+    $amount_minus_tax = $amount / (($taxPercent/100) + 1);
+    $amount_of_tax    = $amount / ((100/$taxPercent) + 1);
+    return array($amount_minus_tax, $amount_of_tax);
 }
-function add_tax($amount=0) {
-  return $amount * (config::get_config_item("taxPercent")/100 +1);
+function add_tax($amount = 0)
+{
+    return $amount * (config::get_config_item("taxPercent")/100 +1);
 }
-function alloc_error($str="",$force=null) {
-  $errors_logged = &singleton("errors_logged");
-  $errors_thrown = &singleton("errors_thrown");
-  $errors_fatal = &singleton("errors_fatal");
-  isset($force) and $errors_fatal = $force; // permit override
-  $errors_format = &singleton("errors_format");
-  $errors_format or $errors_format = "html";
-  $errors_haltdb = &singleton("errors_haltdb");
+function alloc_error($str = "", $force = null)
+{
+    $errors_logged = &singleton("errors_logged");
+    $errors_thrown = &singleton("errors_thrown");
+    $errors_fatal = &singleton("errors_fatal");
+    isset($force) and $errors_fatal = $force; // permit override
+    $errors_format = &singleton("errors_format");
+    $errors_format or $errors_format = "html";
+    $errors_haltdb = &singleton("errors_haltdb");
 
   // Load up a nicely rendered html error
-  if ($errors_format == "html") {
-    global $TPL;
-    $TPL["message"][] = $str;
-  }
+    if ($errors_format == "html") {
+        global $TPL;
+        $TPL["message"][] = $str;
+    }
 
   // Output a plain-text error suitable for logfiles and CLI
-  if ($errors_format == "text" && ini_get('display_errors')) {
-    echo(strip_tags($str));
-  }
+    if ($errors_format == "text" && ini_get('display_errors')) {
+        echo(strip_tags($str));
+    }
 
   // Log the error message
-  if ($errors_logged) {
-    error_log(strip_tags($str));
-  }
+    if ($errors_logged) {
+        error_log(strip_tags($str));
+    }
 
   // Prevent further db queries
-  if ($errors_haltdb) {
-    db_alloc::$stop_doing_queries = true;
-  }
+    if ($errors_haltdb) {
+        db_alloc::$stop_doing_queries = true;
+    }
 
   // Throw an exception, that can be caught and handled (eg receiveEmail.php)
-  if ($errors_thrown) {
-    throw new Exception(strip_tags($str));
-  }
+    if ($errors_thrown) {
+        throw new Exception(strip_tags($str));
+    }
 
   // Print message to a blank webpage (eg tools/backup.php)
-  if ($force) {
-    echo $str;
-  }
+    if ($force) {
+        echo $str;
+    }
 
   // If it was a serious error, then halt
-  if ($errors_fatal) {
-    exit(1); // exit status matters to pipeEmail.php
-  }
+    if ($errors_fatal) {
+        exit(1); // exit status matters to pipeEmail.php
+    }
 }
 
-function sprintf_implode() {
+function sprintf_implode()
+{
   // I am crippling this function to make its purpose clearer, max 6 arguments.
   //
   // $numbers = array(20,21,22);
@@ -880,95 +934,101 @@ function sprintf_implode() {
   // sprintf_implode(" AND ", "(name != '%s')", $words);
   // Returns: ((name != 'howdy') AND (name != 'hello') AND (name != 'goodbye'))
   //
-  $args = func_get_args();
-  $glue = " OR ";
-  if (!in_str("%",$args[0])) {
-    $glue = array_shift($args);
-  }
-
-  $str = array_shift($args);
-
-  $f["arg1"] = $args[0];
-  $f["arg2"] = $args[1];
-  $f["arg3"] = $args[2];
-  $f["arg4"] = $args[3];
-  $f["arg5"] = $args[4];
-  $f["arg6"] = $args[5];
-  $length = count($f["arg1"]);
-
-  foreach ($f as $k => $v) {
-    if ($v && count($v) != $length) {
-      alloc_error("One of the values passed to sprintf_implode was the wrong length: ".$str." ".print_r($args,1));
+    $args = func_get_args();
+    $glue = " OR ";
+    if (!in_str("%", $args[0])) {
+        $glue = array_shift($args);
     }
-    if ($v && !is_array($v)) {
-      $f[$k] = array($v);
-    }
-  }
 
-  $x = 0;
-  while ($x < $length) {
-    $rtn.= $comma.sprintf($str
-                         ,db_esc($f["arg1"][$x]),db_esc($f["arg2"][$x]),db_esc($f["arg3"][$x])
-                         ,db_esc($f["arg4"][$x]),db_esc($f["arg5"][$x]),db_esc($f["arg6"][$x]));
-    $comma = $glue;
-    $x++;
-  }
-  return "(".$rtn.")";
+    $str = array_shift($args);
+
+    $f["arg1"] = $args[0];
+    $f["arg2"] = $args[1];
+    $f["arg3"] = $args[2];
+    $f["arg4"] = $args[3];
+    $f["arg5"] = $args[4];
+    $f["arg6"] = $args[5];
+    $length = count($f["arg1"]);
+
+    foreach ($f as $k => $v) {
+        if ($v && count($v) != $length) {
+            alloc_error("One of the values passed to sprintf_implode was the wrong length: ".$str." ".print_r($args, 1));
+        }
+        if ($v && !is_array($v)) {
+            $f[$k] = array($v);
+        }
+    }
+
+    $x = 0;
+    while ($x < $length) {
+        $rtn.= $comma.sprintf(
+            $str,
+            db_esc($f["arg1"][$x]),
+            db_esc($f["arg2"][$x]),
+            db_esc($f["arg3"][$x]),
+            db_esc($f["arg4"][$x]),
+            db_esc($f["arg5"][$x]),
+            db_esc($f["arg6"][$x])
+        );
+        $comma = $glue;
+        $x++;
+    }
+    return "(".$rtn.")";
 }
 
-function prepare() {
-  $args = func_get_args();
+function prepare()
+{
+    $args = func_get_args();
 
-  if (count($args) == 1) {
-    return $args[0];
-  }
+    if (count($args) == 1) {
+        return $args[0];
+    }
 
   // First element of $args get assigned to zero index of $clean_args
   // Array_shift removes the first value and returns it..
-  $clean_args[] = array_shift($args);
+    $clean_args[] = array_shift($args);
 
   // The rest of $args are escaped and then assigned to $clean_args
-  foreach ($args as $arg) {
-
-    if (is_array($arg)) {
-      foreach ((array)$arg as $v) {
-        $str.= $comma."'".db_esc($v)."'";
-        $comma = ",";
-      }
-      $clean_args[] = $str;
-
-    } else {
-      $clean_args[] = db_esc($arg);
+    foreach ($args as $arg) {
+        if (is_array($arg)) {
+            foreach ((array)$arg as $v) {
+                $str.= $comma."'".db_esc($v)."'";
+                $comma = ",";
+            }
+            $clean_args[] = $str;
+        } else {
+            $clean_args[] = db_esc($arg);
+        }
     }
-  }
 
   // Have to use this coz we don't know how many args we're gonna pass to sprintf..
-  $query = @call_user_func_array("sprintf",$clean_args);
+    $query = @call_user_func_array("sprintf", $clean_args);
 
   // Trackdown poorly formulated queries
-  $err = error_get_last();
-  if ($err["type"] == 2 && in_str("sprintf",$err["message"])) {
-    $e = new Exception();
-    alloc_error("Error in prepared query: \n".$e->getTraceAsString()."\n".print_r($err,1)."\n".print_r($clean_args,1));
-  }
+    $err = error_get_last();
+    if ($err["type"] == 2 && in_str("sprintf", $err["message"])) {
+        $e = new Exception();
+        alloc_error("Error in prepared query: \n".$e->getTraceAsString()."\n".print_r($err, 1)."\n".print_r($clean_args, 1));
+    }
 
-  return $query;
+    return $query;
 }
-function refcount(&$var) {
-  ob_start();
-  debug_zval_dump(array(&$var));
-  $rtn = preg_replace("/^.+?refcount\((\d+)\).+$/ms", '$1', substr(ob_get_clean(), 24), 1) - 4;
-  echo "<br>refcount:".$rtn;
-  return $rtn;
+function refcount(&$var)
+{
+    ob_start();
+    debug_zval_dump(array(&$var));
+    $rtn = preg_replace("/^.+?refcount\((\d+)\).+$/ms", '$1', substr(ob_get_clean(), 24), 1) - 4;
+    echo "<br>refcount:".$rtn;
+    return $rtn;
 }
-function reference(&$a, &$b) {
-  $d = refcount($b);
-  $e = &$a;
-  return refcount($b) != $d;
+function reference(&$a, &$b)
+{
+    $d = refcount($b);
+    $e = &$a;
+    return refcount($b) != $d;
 }
-function has($module) {
-  $modules = &singleton("modules");
-  return (isset($modules[$module]) && $modules[$module]) || class_exists($module);
+function has($module)
+{
+    $modules = &singleton("modules");
+    return (isset($modules[$module]) && $modules[$module]) || class_exists($module);
 }
-
-?>

--- a/task/lib/init.php
+++ b/task/lib/init.php
@@ -3,27 +3,27 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class task_module extends module {
-  var $module = "task";
-  var $db_entities = array("task");
-  var $home_items = array("task_list_home_item","task_message_list_home_item");
+class task_module extends module
+{
+    var $module = "task";
+    var $db_entities = array("task");
+    var $home_items = array("task_list_home_item","task_message_list_home_item");
 }
-?>

--- a/task/lib/task.inc.php
+++ b/task/lib/task.inc.php
@@ -3,31 +3,32 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 define("PERM_PROJECT_READ_TASK_DETAIL", 256);
 
-class task extends db_entity {
-  public $classname = "task";
-  public $data_table = "task";
-  public $display_field_name = "taskName";
-  public $key_field = "taskID";
-  public $data_fields = array("taskName"
+class task extends db_entity
+{
+    public $classname = "task";
+    public $data_table = "task";
+    public $display_field_name = "taskName";
+    public $key_field = "taskID";
+    public $data_fields = array("taskName"
                              ,"taskDescription"
                              ,"creatorID"
                              ,"closerID"
@@ -53,51 +54,53 @@ class task extends db_entity {
                              ,"estimatorID"
                              ,"duplicateTaskID"
                              );
-  public $permissions = array(PERM_PROJECT_READ_TASK_DETAIL => "read details");
+    public $permissions = array(PERM_PROJECT_READ_TASK_DETAIL => "read details");
 
-  function save() {
-    $current_user = &singleton("current_user");
-    global $TPL;
+    function save()
+    {
+        $current_user = &singleton("current_user");
+        global $TPL;
 
-    $errors = $this->validate();
-    if ($errors) {
-      alloc_error($errors);
-
-    } else {
-      $existing = $this->all_row_fields;
-      if ($existing["taskStatus"] != $this->get_value("taskStatus")) {
-        $db = new db_alloc();
-        $db->query("call change_task_status(%d,'%s')",$this->get_id(),$this->get_value("taskStatus"));
-        $row = $db->qr("SELECT taskStatus
+        $errors = $this->validate();
+        if ($errors) {
+            alloc_error($errors);
+        } else {
+            $existing = $this->all_row_fields;
+            if ($existing["taskStatus"] != $this->get_value("taskStatus")) {
+                $db = new db_alloc();
+                $db->query("call change_task_status(%d,'%s')", $this->get_id(), $this->get_value("taskStatus"));
+                $row = $db->qr("SELECT taskStatus
                               ,dateActualCompletion
                               ,dateActualStart
                               ,dateClosed
                               ,closerID
                           FROM task
-                         WHERE taskID = %d",$this->get_id());
-        // Changing a task's status changes these fields.
-        // Unfortunately the call to save() below erroneously nukes these fields.
-        // So we manually set them to whatever change_task_status() has dictated.
-        $this->set_value("taskStatus",$row["taskStatus"]);
-        $this->set_value("dateActualCompletion",$row["dateActualCompletion"]);
-        $this->set_value("dateActualStart",$row["dateActualStart"]);
-        $this->set_value("dateClosed",$row["dateClosed"]);
-        $this->set_value("closerID",$row["closerID"]);
-      }
+                         WHERE taskID = %d", $this->get_id());
+                // Changing a task's status changes these fields.
+                // Unfortunately the call to save() below erroneously nukes these fields.
+                // So we manually set them to whatever change_task_status() has dictated.
+                $this->set_value("taskStatus", $row["taskStatus"]);
+                $this->set_value("dateActualCompletion", $row["dateActualCompletion"]);
+                $this->set_value("dateActualStart", $row["dateActualStart"]);
+                $this->set_value("dateClosed", $row["dateClosed"]);
+                $this->set_value("closerID", $row["closerID"]);
+            }
 
-      return parent::save();
+            return parent::save();
+        }
     }
-  }
 
-  function delete() {
-    if ($this->can_be_deleted()) {
-      return parent::delete();
+    function delete()
+    {
+        if ($this->can_be_deleted()) {
+            return parent::delete();
+        }
     }
-  }
 
-  function validate() {
-    // Validate/coerce the fields
-    $coerce = array("inprogress"=>"open_inprogress"
+    function validate()
+    {
+      // Validate/coerce the fields
+        $coerce = array("inprogress"=>"open_inprogress"
                    ,"notstarted"=>"open_notstarted"
                    ,"info"      =>"pending_info"
                    ,"client"    =>"pending_client"
@@ -113,91 +116,96 @@ class task extends db_entity {
                    ,"close"     =>"closed_complete"
                    ,"closed"    =>"closed_complete"
                    );
-    if ($this->get_value("taskStatus") && !in_array($this->get_value("taskStatus"),$coerce)) {
-      $orig = $this->get_value("taskStatus");
-      $cleaned = str_replace("-","_",strtolower($orig));
-      if (in_array($cleaned,$coerce)) {
-        $this->set_value("taskStatus",$cleaned);
-      } else if ($coerce[$cleaned]) {
-        $this->set_value("taskStatus",$coerce[$cleaned]);
-      }
+        if ($this->get_value("taskStatus") && !in_array($this->get_value("taskStatus"), $coerce)) {
+            $orig = $this->get_value("taskStatus");
+            $cleaned = str_replace("-", "_", strtolower($orig));
+            if (in_array($cleaned, $coerce)) {
+                $this->set_value("taskStatus", $cleaned);
+            } else if ($coerce[$cleaned]) {
+                $this->set_value("taskStatus", $coerce[$cleaned]);
+            }
 
-      if (!in_array($this->get_value("taskStatus"),$coerce)) {
-        $err[] = "Unrecognised task status: ".$orig;
-      }
-    }
-
-    in_array($this->get_value("priority"),array(1,2,3,4,5)) or $err[] = "Invalid priority.";
-    in_array(ucwords($this->get_value("taskTypeID")),array("Task","Fault","Message","Milestone","Parent")) or $err[] = "Invalid Task Type.";
-    $this->get_value("taskName") or $err[] = "Please enter a name for the Task.";
-    $this->get_value("taskDescription") and $this->set_value("taskDescription",rtrim($this->get_value("taskDescription")));
-    return parent::validate($err);
-  }
-
-  function add_pending_tasks($str) {
-    $db = new db_alloc();
-    $db->query("SELECT * FROM pendingTask WHERE taskID = %d",$this->get_id());
-    $rows = array();
-    while ($row = $db->row()) {
-      $rows[] = $row["pendingTaskID"]; 
-    }
-    asort($rows);
-
-    $bits = preg_split("/\b/",$str);
-    $bits or $bits = array();
-    asort($bits);
-
-    $str1 = implode(",",(array)$rows);
-    $str2 = implode(",",(array)$bits);
-
-    if ($str1 != $str2) {
-      $db->query("DELETE FROM pendingTask WHERE taskID = %d",$this->get_id());
-      foreach ((array)$bits as $id) {
-        if (is_numeric($id)) {
-          $db->query("INSERT INTO pendingTask (taskID,pendingTaskID) VALUES (%d,%d)",$this->get_id(),$id);
+            if (!in_array($this->get_value("taskStatus"), $coerce)) {
+                $err[] = "Unrecognised task status: ".$orig;
+            }
         }
-      }
-    }
-  }
 
-  function add_tags($tags=array()) {
-    count($tags) == 1 and $tags = explode(",",current($tags));
-    $db = new db_alloc();
-    $db->query("DELETE FROM tag WHERE taskID = %d",$this->get_id());
-    foreach ((array)$tags as $tag) {
-      if (trim($tag)) {
-        $db->query("INSERT INTO tag (taskID,name) VALUES (%d,'%s')",$this->get_id(),trim($tag));
-      }
+        in_array($this->get_value("priority"), array(1,2,3,4,5)) or $err[] = "Invalid priority.";
+        in_array(ucwords($this->get_value("taskTypeID")), array("Task","Fault","Message","Milestone","Parent")) or $err[] = "Invalid Task Type.";
+        $this->get_value("taskName") or $err[] = "Please enter a name for the Task.";
+        $this->get_value("taskDescription") and $this->set_value("taskDescription", rtrim($this->get_value("taskDescription")));
+        return parent::validate($err);
     }
-  }
 
-  function get_tags($all=false) {
-    $db = new db_alloc();
-    if ($all) {
-      $q = prepare("SELECT DISTINCT name FROM tag ORDER BY name");
-    } else {
-      $q = prepare("SELECT name FROM tag WHERE taskID = %d ORDER BY name",$this->get_id());
-    }
-    $db->query($q);
-    $arr = array();
-    while ($row = $db->row()) {
-      $row["name"] and $arr[$row["name"]] = $row["name"];
-    }
-    return (array)$arr;
-  }
+    function add_pending_tasks($str)
+    {
+        $db = new db_alloc();
+        $db->query("SELECT * FROM pendingTask WHERE taskID = %d", $this->get_id());
+        $rows = array();
+        while ($row = $db->row()) {
+            $rows[] = $row["pendingTaskID"];
+        }
+        asort($rows);
 
-  function get_pending_tasks($invert=false) {
-    $db = new db_alloc();
-    $q = prepare("SELECT * FROM pendingTask WHERE %s = %d",($invert ? "pendingTaskID" : "taskID"),$this->get_id());
-    $db->query($q);
-    while ($row = $db->row()) {
-      $rows[] = $row[($invert ? "taskID" : "pendingTaskID")];
-    }
-    return (array)$rows;
-  }
+        $bits = preg_split("/\b/", $str);
+        $bits or $bits = array();
+        asort($bits);
 
-  function get_reopen_reminders() {
-    $q = prepare("SELECT reminder.*,token.*,tokenAction.*, reminder.reminderID as rID
+        $str1 = implode(",", (array)$rows);
+        $str2 = implode(",", (array)$bits);
+
+        if ($str1 != $str2) {
+            $db->query("DELETE FROM pendingTask WHERE taskID = %d", $this->get_id());
+            foreach ((array)$bits as $id) {
+                if (is_numeric($id)) {
+                    $db->query("INSERT INTO pendingTask (taskID,pendingTaskID) VALUES (%d,%d)", $this->get_id(), $id);
+                }
+            }
+        }
+    }
+
+    function add_tags($tags = array())
+    {
+        count($tags) == 1 and $tags = explode(",", current($tags));
+        $db = new db_alloc();
+        $db->query("DELETE FROM tag WHERE taskID = %d", $this->get_id());
+        foreach ((array)$tags as $tag) {
+            if (trim($tag)) {
+                $db->query("INSERT INTO tag (taskID,name) VALUES (%d,'%s')", $this->get_id(), trim($tag));
+            }
+        }
+    }
+
+    function get_tags($all = false)
+    {
+        $db = new db_alloc();
+        if ($all) {
+            $q = prepare("SELECT DISTINCT name FROM tag ORDER BY name");
+        } else {
+            $q = prepare("SELECT name FROM tag WHERE taskID = %d ORDER BY name", $this->get_id());
+        }
+        $db->query($q);
+        $arr = array();
+        while ($row = $db->row()) {
+            $row["name"] and $arr[$row["name"]] = $row["name"];
+        }
+        return (array)$arr;
+    }
+
+    function get_pending_tasks($invert = false)
+    {
+        $db = new db_alloc();
+        $q = prepare("SELECT * FROM pendingTask WHERE %s = %d", ($invert ? "pendingTaskID" : "taskID"), $this->get_id());
+        $db->query($q);
+        while ($row = $db->row()) {
+            $rows[] = $row[($invert ? "taskID" : "pendingTaskID")];
+        }
+        return (array)$rows;
+    }
+
+    function get_reopen_reminders()
+    {
+        $q = prepare("SELECT reminder.*,token.*,tokenAction.*, reminder.reminderID as rID
                     FROM reminder
                LEFT JOIN token ON reminder.reminderHash = token.tokenHash
                LEFT JOIN tokenAction ON token.tokenActionID = tokenAction.tokenActionID
@@ -206,774 +214,801 @@ class task extends db_entity {
                      AND reminder.reminderActive = 1
                      AND token.tokenActionID = 4
                 GROUP BY reminder.reminderID
-                 ",$this->get_id());
+                 ", $this->get_id());
 
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $rows[] = $row;
-    }
-    return (array)$rows;
-  }
-
-
-  function add_reopen_reminder($date) {
-    $rows = $this->get_reopen_reminders();
-    // If this reopen event already exists, do nothing
-    // Allows the form to be saved without changing anything
-    // the 8:30 is the same as creation, below.
-    if ($date) {
-      $check_date = strtotime($date . " 08:30:00");
-      foreach ($rows as $r) {
-        if (strtotime($r['reminderTime']) == $check_date) {
-          return;
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $rows[] = $row;
         }
-      }
+        return (array)$rows;
     }
 
-    foreach ($rows as $r) {
-      $reminder = new reminder();
-      $reminder->set_id($r['rID']);
-      $reminder->select();
-      $reminder->deactivate();
+
+    function add_reopen_reminder($date)
+    {
+        $rows = $this->get_reopen_reminders();
+      // If this reopen event already exists, do nothing
+      // Allows the form to be saved without changing anything
+      // the 8:30 is the same as creation, below.
+        if ($date) {
+            $check_date = strtotime($date . " 08:30:00");
+            foreach ($rows as $r) {
+                if (strtotime($r['reminderTime']) == $check_date) {
+                    return;
+                }
+            }
+        }
+
+        foreach ($rows as $r) {
+            $reminder = new reminder();
+            $reminder->set_id($r['rID']);
+            $reminder->select();
+            $reminder->deactivate();
+        }
+
+      // alloc-cli can pass 'null' to kill future reopening
+      // Removing the field in the web UI does the same
+        if ($check_date && $date != 'null') {
+            $tokenActionID = 4;
+          //$maxUsed = 1; nope, so people can have recurring reminders
+            $name = "Task reopened: ".$this->get_name(array("prefixTaskID"=>true));
+            $desc = "This reminder will have automatically reopened this task, if it was pending:\n\n".$this->get_name(array("prefixTaskID"=>true));
+            $recipients = array(array("field"=>"metaPersonID","who"=>-2),array("field"=>"metaPersonID","who"=>-3));
+            if (strlen($date) <= "10") {
+                $date.= " 08:30:00";
+            }
+            $this->add_notification($tokenActionID, $maxUsed, $name, $desc, $recipients, $date);
+        }
     }
 
-    // alloc-cli can pass 'null' to kill future reopening
-    // Removing the field in the web UI does the same
-    if ($check_date && $date != 'null') {
-      $tokenActionID = 4;
-      //$maxUsed = 1; nope, so people can have recurring reminders
-      $name = "Task reopened: ".$this->get_name(array("prefixTaskID"=>true));
-      $desc = "This reminder will have automatically reopened this task, if it was pending:\n\n".$this->get_name(array("prefixTaskID"=>true));
-      $recipients = array(array("field"=>"metaPersonID","who"=>-2),array("field"=>"metaPersonID","who"=>-3));
-      if (strlen($date) <= "10") {
-        $date.= " 08:30:00";
-      }
-      $this->add_notification($tokenActionID,$maxUsed,$name,$desc,$recipients,$date);
-    }
-  }
+    function create_task_reminder()
+    {
+      // Create a reminder for this task based on the priority.
+        $current_user = &singleton("current_user");
 
-  function create_task_reminder() {
-    // Create a reminder for this task based on the priority.
-    $current_user = &singleton("current_user");
+      // Get the task type
+        $taskTypeName = $this->get_value("taskTypeID");
+        $label = $this->get_priority_label();
+        $reminderInterval = "Day";
+        $intervalValue = $this->get_value("priority");
+        $taskTypeName == "Parent" and $taskTypeName.= " Task";
 
-    // Get the task type
-    $taskTypeName = $this->get_value("taskTypeID");
-    $label = $this->get_priority_label();
-    $reminderInterval = "Day";
-    $intervalValue = $this->get_value("priority");
-    $taskTypeName == "Parent" and $taskTypeName.= " Task";
+        $subject = $taskTypeName." Reminder: ".$this->get_id()." ".$this->get_name()." [".$label."]";
+        $message = "\n\n".$subject;
+        $message.= "\n\n".$this->get_url(true);
+        $this->get_value("taskDescription") and $message.= "\n\n".$this->get_value("taskDescription");
+        $message.= "\n\n-- \nReminder created by ".$current_user->get_name()." at ".date("Y-m-d H:i:s");
+        $people[] = $this->get_value("personID");
 
-    $subject = $taskTypeName." Reminder: ".$this->get_id()." ".$this->get_name()." [".$label."]";
-    $message = "\n\n".$subject;
-    $message.= "\n\n".$this->get_url(true);
-    $this->get_value("taskDescription") and $message.= "\n\n".$this->get_value("taskDescription");
-    $message.= "\n\n-- \nReminder created by ".$current_user->get_name()." at ".date("Y-m-d H:i:s");
-    $people[] = $this->get_value("personID");
+        $label = $this->get_priority_label();
 
-    $label = $this->get_priority_label();
-
-    $reminder = new reminder();
-    $reminder->set_value('reminderType', "task");
-    $reminder->set_value('reminderLinkID', $this->get_id());
-    $reminder->set_value('reminderRecuringInterval', $reminderInterval);
-    $reminder->set_value('reminderRecuringValue', $intervalValue);
-    $reminder->set_value('reminderSubject', $subject);
-    $reminder->set_value('reminderContent', $message);
-    $reminder->set_value('reminderAdvNoticeSent', "0");
-    if ($this->get_value("dateTargetStart") && $this->get_value("dateTargetStart") != date("Y-m-d")) {
-      $date = $this->get_value("dateTargetStart")." 09:00:00";
-      $reminder->set_value('reminderAdvNoticeInterval', "Hour");
-      $reminder->set_value('reminderAdvNoticeValue', "24");
-    } else {
-      $date = date("Y-m-d")." 09:00:00";
-      $reminder->set_value('reminderAdvNoticeInterval', "No");
-      $reminder->set_value('reminderAdvNoticeValue', "0");
-    }
-    $reminder->set_value('reminderTime', $date);
-    $reminder->save();
-    // the negative is due to ugly reminder internals
-    $reminder->update_recipients(array(-REMINDER_METAPERSON_TASK_ASSIGNEE));
-  }
-
-  function is_owner($person = "") {
-
-    if (!is_object($person)) {
-      return false;
+        $reminder = new reminder();
+        $reminder->set_value('reminderType', "task");
+        $reminder->set_value('reminderLinkID', $this->get_id());
+        $reminder->set_value('reminderRecuringInterval', $reminderInterval);
+        $reminder->set_value('reminderRecuringValue', $intervalValue);
+        $reminder->set_value('reminderSubject', $subject);
+        $reminder->set_value('reminderContent', $message);
+        $reminder->set_value('reminderAdvNoticeSent', "0");
+        if ($this->get_value("dateTargetStart") && $this->get_value("dateTargetStart") != date("Y-m-d")) {
+            $date = $this->get_value("dateTargetStart")." 09:00:00";
+            $reminder->set_value('reminderAdvNoticeInterval', "Hour");
+            $reminder->set_value('reminderAdvNoticeValue', "24");
+        } else {
+            $date = date("Y-m-d")." 09:00:00";
+            $reminder->set_value('reminderAdvNoticeInterval', "No");
+            $reminder->set_value('reminderAdvNoticeValue', "0");
+        }
+        $reminder->set_value('reminderTime', $date);
+        $reminder->save();
+      // the negative is due to ugly reminder internals
+        $reminder->update_recipients(array(-REMINDER_METAPERSON_TASK_ASSIGNEE));
     }
 
-    // A user owns a task if they 'own' the project
-    if ($this->get_id()) {
-      // Check for existing task
-      has("project") and $p = $this->get_foreign_object("project");
-    } else if (has("project") && $_POST["projectID"]) {
-      // Or maybe they are creating a new task
-      $p = new project();
-      $p->set_id($_POST["projectID"]);
+    function is_owner($person = "")
+    {
+
+        if (!is_object($person)) {
+            return false;
+        }
+
+      // A user owns a task if they 'own' the project
+        if ($this->get_id()) {
+          // Check for existing task
+            has("project") and $p = $this->get_foreign_object("project");
+        } else if (has("project") && $_POST["projectID"]) {
+          // Or maybe they are creating a new task
+            $p = new project();
+            $p->set_id($_POST["projectID"]);
+        }
+
+      // if this task doesn't exist (no ID)
+      // OR the person has isManager or canEditTasks for this tasks project
+      // OR if this person is the Creator of this task.
+      // OR if this person is the For Person of this task.
+      // OR if this person has super 'manage' perms
+      // OR if we're skipping the perms checking because i.e. we're having our task status updated by a timesheet
+        if (!$this->get_id()
+        || (is_object($p) && ($p->has_project_permission($person, array("isManager", "canEditTasks", "timeSheetRecipient")))
+        || $this->get_value("creatorID") == $person->get_id()
+        || $this->get_value("personID") == $person->get_id()
+        || $this->get_value("managerID") == $person->get_id()
+        || $person->have_role("manage")
+        || $this->skip_perms_check
+        )) {
+            return true;
+        }
     }
 
-    // if this task doesn't exist (no ID) 
-    // OR the person has isManager or canEditTasks for this tasks project 
-    // OR if this person is the Creator of this task.
-    // OR if this person is the For Person of this task.
-    // OR if this person has super 'manage' perms
-    // OR if we're skipping the perms checking because i.e. we're having our task status updated by a timesheet
-    if (
-       !$this->get_id() 
-    || (is_object($p) && ($p->has_project_permission($person, array("isManager", "canEditTasks", "timeSheetRecipient"))) 
-    || $this->get_value("creatorID") == $person->get_id()
-    || $this->get_value("personID") == $person->get_id()
-    || $this->get_value("managerID") == $person->get_id()
-    || $person->have_role("manage")
-    || $this->skip_perms_check
-    )) {
-      return true;
+    function has_attachment_permission($person)
+    {
+        return $this->is_owner($person);
     }
-  }
 
-  function has_attachment_permission($person) {
-    return $this->is_owner($person);
-  }
-
-  function has_attachment_permission_delete($person) {
-    return $this->is_owner($person);
-  }
-
-  function update_children($field,$value="") {
-    $q = prepare("SELECT * FROM task WHERE parentTaskID = %d",$this->get_id());
-    $db = new db_alloc();
-    $db->query($q);
-    while ($db->row()) {
-      $t = new task();
-      $t->read_db_record($db);
-      $t->set_value($field,$value);
-      $t->save();
-      if ($t->get_value("taskTypeID") == "Parent") {
-        $t->update_children($field,$value);
-      }
+    function has_attachment_permission_delete($person)
+    {
+        return $this->is_owner($person);
     }
-  }
 
-  function get_parent_task_select($projectID="") {
-    global $TPL;
+    function update_children($field, $value = "")
+    {
+        $q = prepare("SELECT * FROM task WHERE parentTaskID = %d", $this->get_id());
+        $db = new db_alloc();
+        $db->query($q);
+        while ($db->row()) {
+            $t = new task();
+            $t->read_db_record($db);
+            $t->set_value($field, $value);
+            $t->save();
+            if ($t->get_value("taskTypeID") == "Parent") {
+                $t->update_children($field, $value);
+            }
+        }
+    }
+
+    function get_parent_task_select($projectID = "")
+    {
+        global $TPL;
     
-    if (is_object($this)) {
-      $projectID = $this->get_value("projectID");
-      $parentTaskID = $this->get_value("parentTaskID");
-    }
+        if (is_object($this)) {
+            $projectID = $this->get_value("projectID");
+            $parentTaskID = $this->get_value("parentTaskID");
+        }
 
-    $projectID or $projectID = $_GET["projectID"];
-    $parentTaskID or $parentTaskID = $_GET["parentTaskID"];
+        $projectID or $projectID = $_GET["projectID"];
+        $parentTaskID or $parentTaskID = $_GET["parentTaskID"];
 
-    $db = new db_alloc();
-    if ($projectID) {
-      list($ts_open,$ts_pending,$ts_closed) = task::get_task_status_in_set_sql();
-      // Status may be closed_<something>
-      $query = prepare("SELECT taskID AS value, taskName AS label
+        $db = new db_alloc();
+        if ($projectID) {
+            list($ts_open,$ts_pending,$ts_closed) = task::get_task_status_in_set_sql();
+          // Status may be closed_<something>
+            $query = prepare("SELECT taskID AS value, taskName AS label
                         FROM task 
                         WHERE projectID= '%d' 
                         AND taskTypeID = 'Parent'
                         AND (taskStatus NOT IN (".$ts_closed.") OR taskID = %d)
                         ORDER BY taskName", $projectID, $parentTaskID);
-      $options = page::select_options($query, $parentTaskID,70);
-    }
-    return "<select name=\"parentTaskID\"><option value=\"\">".$options."</select>";
-  }
-
-  function get_task_cc_list_select($projectID="") {
-
-    // If task exists, grab existing IPs
-    if (is_object($this)) {
-      $interestedPartyOptions = $this->get_all_parties($projectID);
-
-    // Else get default IPs from project and config
-    } else {
-      if ($_GET["projectID"]) {
-        $projectID = $_GET["projectID"];
-      }
-      if ($projectID) {
-        $project = new project($projectID);
-        $interestedPartyOptions = $project->get_all_parties();
-      }
-      $extra_interested_parties = config::get_config_item("defaultInterestedParties");
-      foreach ((array)$extra_interested_parties as $name => $email) {
-        $interestedPartyOptions[$email]["name"] = $name;
-      }
-      $interestedPartyOptions = interestedParty::get_interested_parties("task",null,$interestedPartyOptions);
+            $options = page::select_options($query, $parentTaskID, 70);
+        }
+        return "<select name=\"parentTaskID\"><option value=\"\">".$options."</select>";
     }
 
-    foreach ((array)$interestedPartyOptions as $email => $info) {
-      if ($info["role"] == "interested" && $info["selected"]) {
-        $selected[] = $info["identifier"];
-      }
-      if ($email) {
-        $options[$info["identifier"]] = trim(page::htmlentities(trim($info["name"])." <".$email.">"));
-      }
-    }
-    return "<select name=\"interestedParty[]\" multiple=\"true\">".page::select_options($options,$selected,100,false)."</select>";
-  }
+    function get_task_cc_list_select($projectID = "")
+    {
 
-  function get_all_parties($projectID="") {
-    $db = new db_alloc();
-    $interestedPartyOptions = array();
-    if ($_GET["projectID"]) {
-      $projectID = $_GET["projectID"];
-    } else if (!$projectID) {
-      $projectID = $this->get_value("projectID");
-    }
-    if ($projectID) {
-      $project = new project($projectID);
-      $interestedPartyOptions = $project->get_all_parties(false, $this->get_id());
-    }
-    $extra_interested_parties = config::get_config_item("defaultInterestedParties") or $extra_interested_parties=array();
-    foreach ($extra_interested_parties as $name => $email) {
-      $interestedPartyOptions[$email]["name"] = $name;
-    }
-    if ($this->get_value("creatorID")) {
-      $p = new person();
-      $p->set_id($this->get_value("creatorID"));
-      $p->select();
-      if ($p->get_value("emailAddress")) {
-        $interestedPartyOptions[$p->get_value("emailAddress")]["name"] = $p->get_name();
-        $interestedPartyOptions[$p->get_value("emailAddress")]["role"] = "creator";
-        $interestedPartyOptions[$p->get_value("emailAddress")]["personID"] = $this->get_value("creatorID");
-      }
-    }
-    if ($this->get_value("personID")) {
-      $p = new person();
-      $p->set_id($this->get_value("personID"));
-      $p->select();
-      if ($p->get_value("emailAddress")) {
-        $interestedPartyOptions[$p->get_value("emailAddress")]["name"] = $p->get_name();
-        $interestedPartyOptions[$p->get_value("emailAddress")]["role"] = "assignee";
-        $interestedPartyOptions[$p->get_value("emailAddress")]["personID"] = $this->get_value("personID");
-        $interestedPartyOptions[$p->get_value("emailAddress")]["selected"] = 1;
-      }
-    }
-    if ($this->get_value("managerID")) {
-      $p = new person();
-      $p->set_id($this->get_value("managerID"));
-      $p->select();
-      if ($p->get_value("emailAddress")) {
-        $interestedPartyOptions[$p->get_value("emailAddress")]["name"] = $p->get_name();
-        $interestedPartyOptions[$p->get_value("emailAddress")]["role"] = "manager";
-        $interestedPartyOptions[$p->get_value("emailAddress")]["personID"] = $this->get_value("managerID");
-        $interestedPartyOptions[$p->get_value("emailAddress")]["selected"] = 1;
-      }
-    }
-    // return an aggregation of the current task/proj/client parties + the existing interested parties
-    $interestedPartyOptions = interestedParty::get_interested_parties("task",$this->get_id(),$interestedPartyOptions);
-    return $interestedPartyOptions;
-  }
+      // If task exists, grab existing IPs
+        if (is_object($this)) {
+            $interestedPartyOptions = $this->get_all_parties($projectID);
 
-  function get_personList_dropdown($projectID,$field,$selected=null) {
-    $current_user = &singleton("current_user");
+        // Else get default IPs from project and config
+        } else {
+            if ($_GET["projectID"]) {
+                $projectID = $_GET["projectID"];
+            }
+            if ($projectID) {
+                $project = new project($projectID);
+                $interestedPartyOptions = $project->get_all_parties();
+            }
+            $extra_interested_parties = config::get_config_item("defaultInterestedParties");
+            foreach ((array)$extra_interested_parties as $name => $email) {
+                $interestedPartyOptions[$email]["name"] = $name;
+            }
+            $interestedPartyOptions = interestedParty::get_interested_parties("task", null, $interestedPartyOptions);
+        }
+
+        foreach ((array)$interestedPartyOptions as $email => $info) {
+            if ($info["role"] == "interested" && $info["selected"]) {
+                $selected[] = $info["identifier"];
+            }
+            if ($email) {
+                $options[$info["identifier"]] = trim(page::htmlentities(trim($info["name"])." <".$email.">"));
+            }
+        }
+        return "<select name=\"interestedParty[]\" multiple=\"true\">".page::select_options($options, $selected, 100, false)."</select>";
+    }
+
+    function get_all_parties($projectID = "")
+    {
+        $db = new db_alloc();
+        $interestedPartyOptions = array();
+        if ($_GET["projectID"]) {
+            $projectID = $_GET["projectID"];
+        } else if (!$projectID) {
+            $projectID = $this->get_value("projectID");
+        }
+        if ($projectID) {
+            $project = new project($projectID);
+            $interestedPartyOptions = $project->get_all_parties(false, $this->get_id());
+        }
+        $extra_interested_parties = config::get_config_item("defaultInterestedParties") or $extra_interested_parties=array();
+        foreach ($extra_interested_parties as $name => $email) {
+            $interestedPartyOptions[$email]["name"] = $name;
+        }
+        if ($this->get_value("creatorID")) {
+            $p = new person();
+            $p->set_id($this->get_value("creatorID"));
+            $p->select();
+            if ($p->get_value("emailAddress")) {
+                $interestedPartyOptions[$p->get_value("emailAddress")]["name"] = $p->get_name();
+                $interestedPartyOptions[$p->get_value("emailAddress")]["role"] = "creator";
+                $interestedPartyOptions[$p->get_value("emailAddress")]["personID"] = $this->get_value("creatorID");
+            }
+        }
+        if ($this->get_value("personID")) {
+            $p = new person();
+            $p->set_id($this->get_value("personID"));
+            $p->select();
+            if ($p->get_value("emailAddress")) {
+                $interestedPartyOptions[$p->get_value("emailAddress")]["name"] = $p->get_name();
+                $interestedPartyOptions[$p->get_value("emailAddress")]["role"] = "assignee";
+                $interestedPartyOptions[$p->get_value("emailAddress")]["personID"] = $this->get_value("personID");
+                $interestedPartyOptions[$p->get_value("emailAddress")]["selected"] = 1;
+            }
+        }
+        if ($this->get_value("managerID")) {
+            $p = new person();
+            $p->set_id($this->get_value("managerID"));
+            $p->select();
+            if ($p->get_value("emailAddress")) {
+                $interestedPartyOptions[$p->get_value("emailAddress")]["name"] = $p->get_name();
+                $interestedPartyOptions[$p->get_value("emailAddress")]["role"] = "manager";
+                $interestedPartyOptions[$p->get_value("emailAddress")]["personID"] = $this->get_value("managerID");
+                $interestedPartyOptions[$p->get_value("emailAddress")]["selected"] = 1;
+            }
+        }
+      // return an aggregation of the current task/proj/client parties + the existing interested parties
+        $interestedPartyOptions = interestedParty::get_interested_parties("task", $this->get_id(), $interestedPartyOptions);
+        return $interestedPartyOptions;
+    }
+
+    function get_personList_dropdown($projectID, $field, $selected = null)
+    {
+        $current_user = &singleton("current_user");
  
-    $db = new db_alloc();
+        $db = new db_alloc();
 
-    if ($this->get_id()) {
-      $origval = $this->get_value($field);
-    } else {
-      $origval = $current_user->get_id();
-    }
+        if ($this->get_id()) {
+            $origval = $this->get_value($field);
+        } else {
+            $origval = $current_user->get_id();
+        }
 
-    $peoplenames = person::get_username_list($origval);
+        $peoplenames = person::get_username_list($origval);
 
-    if ($projectID) {
-      if ($field == "managerID") {
-        $manager_sql = " AND role.roleHandle in ('isManager','timeSheetRecipient')";
-        $managers_only = true;
-      }
+        if ($projectID) {
+            if ($field == "managerID") {
+                $manager_sql = " AND role.roleHandle in ('isManager','timeSheetRecipient')";
+                $managers_only = true;
+            }
 
-      $q = prepare("SELECT * 
+            $q = prepare("SELECT * 
                       FROM projectPerson 
                  LEFT JOIN person ON person.personID = projectPerson.personID
                  LEFT JOIN role ON role.roleID = projectPerson.roleID
                      WHERE person.personActive = 1 ".$manager_sql."
                        AND projectID = %d
                   ORDER BY firstName, username
-                   ",$projectID);
-      $db->query($q);
-      while ($row = $db->row()) {
-        if ($managers_only && $current_user->get_id() == $row["personID"]) {
-          $current_user_is_manager = true;
+                   ", $projectID);
+            $db->query($q);
+            while ($row = $db->row()) {
+                if ($managers_only && $current_user->get_id() == $row["personID"]) {
+                    $current_user_is_manager = true;
+                }
+                  $ops[$row["personID"]] = $peoplenames[$row["personID"]];
+            }
+
+        // Everyone
+        } else {
+            $ops = $peoplenames;
         }
-        $ops[$row["personID"]] = $peoplenames[$row["personID"]];
-      }
 
-    // Everyone
-    } else {
-      $ops = $peoplenames;
+        $origval and $ops[$origval] = $peoplenames[$origval];
+
+        if ($managers_only && !$current_user_is_manager) {
+            unset($ops[$current_user->get_id()]);
+        }
+
+        if ($selected === null) {
+            $selected = $origval;
+        }
+
+        return page::select_options($ops, $selected);
     }
 
-    $origval and $ops[$origval] = $peoplenames[$origval];
-
-    if ($managers_only && !$current_user_is_manager) {
-      unset($ops[$current_user->get_id()]);
-    }
-
-    if ($selected === null) {
-      $selected = $origval;
-    }
-
-    return page::select_options($ops, $selected);
-  }
-
-  function get_project_options($projectID="") {
-    $projectID or $projectID = $_GET["projectID"];
-    // Project Options - Select all projects 
-    $db = new db_alloc();
-    $query = prepare("SELECT projectID AS value, projectName AS label 
+    function get_project_options($projectID = "")
+    {
+        $projectID or $projectID = $_GET["projectID"];
+      // Project Options - Select all projects
+        $db = new db_alloc();
+        $query = prepare("SELECT projectID AS value, projectName AS label 
                         FROM project 
                        WHERE projectStatus IN ('Current', 'Potential') OR projectID = %d
-                    ORDER BY projectName",$projectID);
-    $str = page::select_options($query, $projectID, 60);
-    return $str;
-  }
+                    ORDER BY projectName", $projectID);
+        $str = page::select_options($query, $projectID, 60);
+        return $str;
+    }
 
-  function set_option_tpl_values() {
-    // Set template values to provide options for edit selects
-    global $TPL;
-    $current_user = &singleton("current_user");
-    global $isMessage;
-    $db = new db_alloc();
-    $projectID = $_GET["projectID"] or $projectID = $this->get_value("projectID");
-    $TPL["personOptions"] = "<select name=\"personID\"><option value=\"\">".$this->get_personList_dropdown($projectID, "personID")."</select>";
-    $TPL["managerPersonOptions"] = "<select name=\"managerID\"><option value=\"\">".$this->get_personList_dropdown($projectID, "managerID")."</select>";
-    $TPL["estimatorPersonOptions"] = "<select name=\"estimatorID\"><option value=\"\">".$this->get_personList_dropdown($projectID, "estimatorID")."</select>";
+    function set_option_tpl_values()
+    {
+      // Set template values to provide options for edit selects
+        global $TPL;
+        $current_user = &singleton("current_user");
+        global $isMessage;
+        $db = new db_alloc();
+        $projectID = $_GET["projectID"] or $projectID = $this->get_value("projectID");
+        $TPL["personOptions"] = "<select name=\"personID\"><option value=\"\">".$this->get_personList_dropdown($projectID, "personID")."</select>";
+        $TPL["managerPersonOptions"] = "<select name=\"managerID\"><option value=\"\">".$this->get_personList_dropdown($projectID, "managerID")."</select>";
+        $TPL["estimatorPersonOptions"] = "<select name=\"estimatorID\"><option value=\"\">".$this->get_personList_dropdown($projectID, "estimatorID")."</select>";
 
-    // TaskType Options
-    $taskType = new meta("taskType");
-    $taskType_array = $taskType->get_assoc_array("taskTypeID","taskTypeID");
-    $TPL["taskTypeOptions"] = page::select_options($taskType_array,$this->get_value("taskTypeID"));
+      // TaskType Options
+        $taskType = new meta("taskType");
+        $taskType_array = $taskType->get_assoc_array("taskTypeID", "taskTypeID");
+        $TPL["taskTypeOptions"] = page::select_options($taskType_array, $this->get_value("taskTypeID"));
 
-    // Project dropdown
-    $TPL["projectOptions"] = task::get_project_options($projectID);
+      // Project dropdown
+        $TPL["projectOptions"] = task::get_project_options($projectID);
     
-    // We're building these two with the <select> tags because they will be
-    // replaced by an AJAX created dropdown when the projectID changes.
-    $TPL["parentTaskOptions"] = $this->get_parent_task_select();
-    $TPL["interestedPartyOptions"] = $this->get_task_cc_list_select();
+      // We're building these two with the <select> tags because they will be
+      // replaced by an AJAX created dropdown when the projectID changes.
+        $TPL["parentTaskOptions"] = $this->get_parent_task_select();
+        $TPL["interestedPartyOptions"] = $this->get_task_cc_list_select();
 
-    $db->query(prepare("SELECT fullName, emailAddress, clientContactPhone, clientContactMobile
+        $db->query(prepare("SELECT fullName, emailAddress, clientContactPhone, clientContactMobile
                           FROM interestedParty
                      LEFT JOIN clientContact ON interestedParty.clientContactID = clientContact.clientContactID
                          WHERE entity='task' 
                            AND entityID = %d
                            AND interestedPartyActive = 1
-                      ORDER BY fullName",$this->get_id()));
-    while ($db->next_record()) {
-      $value = interestedParty::get_encoded_interested_party_identifier($db->f("fullName"), $db->f("emailAddress"));
-      $phone = array("p"=>$db->f('clientContactPhone'),"m"=>$db->f('clientContactMobile'));
-      $TPL["interestedParties"][] = array('key'=>$value, 'name'=>$db->f("fullName"), 'email'=>$db->f("emailAddress"), 'phone'=>$phone);
-    }
-
-    $TPL["task_taskStatusLabel"] = $this->get_task_status("label");
-    $TPL["task_taskStatusColour"] = $this->get_task_status("colour");
-    $TPL["task_taskStatusValue"] = $this->get_value("taskStatus");
-    $TPL["task_taskStatusOptions"] = page::select_options(task::get_task_statii_array(true),$this->get_value("taskStatus"));
-
-    // Project label
-    if (has("project")) {
-      $p = new project();
-      $p->set_id($this->get_value("projectID"));
-      $p->select();
-      $TPL["projectName"] = $p->get_display_value();
-    }
-
-    $taskPriorities = config::get_config_item("taskPriorities") or $taskPriorities = array();
-    $projectPriorities = config::get_config_item("projectPriorities") or $projectPriorities = array();
-    $priority = $this->get_value("priority") or $priority = 3;
-    $TPL["priorityOptions"] = page::select_options(array_kv($taskPriorities,null,"label"),$priority);
-    $TPL["priorityLabel"] = " <div style=\"display:inline; color:".$taskPriorities[$priority]["colour"]."\">[";
-
-    if (is_object($p)) {
-      list($priorityFactor,$daysUntilDue) = $this->get_overall_priority($p->get_value("projectPriority"),$this->get_value("priority"),$this->get_value("dateTargetCompletion"));
-      $str = "Task priority: ".$taskPriorities[$this->get_value("priority")]["label"]."<br>";
-      $str.= "Project priority: ".$projectPriorities[$p->get_value("projectPriority")]["label"]."<br>";
-      $str.= "Days until due: ".$daysUntilDue."<br>";
-      $str.= "Calculated priority: ".$priorityFactor;
-      $TPL["priorityLabel"].= page::help($str,$this->get_priority_label());
-    } else {
-      $TPL["priorityLabel"].= $this->get_priority_label();
-    }
-    $TPL["priorityLabel"].= "]</div>";
-
-
-    // If we're viewing the printer friendly view
-    if ($_GET["media"] == "print") {
-      // Parent Task label
-      $t = new task();
-      $t->set_id($this->get_value("parentTaskID"));
-      $t->select();
-      $TPL["parentTask"] = $t->get_display_value();
-
-      // Task Type label
-      $TPL["taskType"] = $this->get_value("taskTypeID"); 
-
-      // Priority
-      $TPL["priority"] = $this->get_value("priority");
-
-      // Assignee label
-      $p = new person();
-      $p->set_id($this->get_value("personID"));
-      $p->select();
-      $TPL["person"] = $p->get_display_value();
-    }
-  }
-
-  function get_task_comments_array() {
-    $rows = comment::util_get_comments_array("task",$this->get_id());
-    $rows or $rows = array();
-    return $rows;
-  }
-
-  function get_task_link($_FORM=array()) {
-    $_FORM["return"] or $_FORM["return"] = "html";
-    $rtn = "<a href=\"".$this->get_url()."\">";
-    $rtn.= $this->get_name($_FORM);
-    $rtn.= "</a>";
-    return $rtn;
-  }
-
-  function get_task_image() {
-    global $TPL;
-    return "<img class=\"taskType\" alt=\"".$this->get_value("taskTypeID")."\" title=\"".$this->get_value("taskTypeID")."\" src=\"".$TPL["url_alloc_images"]."taskType_".strtolower($this->get_value("taskTypeID")).".gif\">";
-  }
-
-  function get_name($_FORM=array()) {
-
-    $_FORM["prefixTaskID"] and $id = $this->get_id()." ";
-
-    if ($this->get_value("taskTypeID") == "Parent" && $_FORM["return"] == "html") {
-      $rtn = "<strong>".$id.$this->get_value("taskName",DST_HTML_DISPLAY)."</strong>";
-    } else if ($_FORM["return"] == "html") {
-      $rtn = $id.$this->get_value("taskName",DST_HTML_DISPLAY);
-    } else {
-      $rtn = $id.$this->get_value("taskName");
-    }
-    return $rtn;
-  }
-
-  function get_url($absolute=false,$id=false) {
-    global $sess;
-    $sess or $sess = new session();
-    $id or $id = $this->get_id();
-    $url = "task/task.php?taskID=".$id;
-
-    if ($sess->Started() && !$absolute) {
-      $url = $sess->url(SCRIPT_PATH.$url);
-
-    // This for urls that are emailed
-    } else {
-      static $prefix;
-      $prefix or $prefix = config::get_config_item("allocURL");
-      $url = $prefix.$url;
-    }
-    return $url;
-  }
-
-  public static function get_task_statii_array($flat=false) {
-    // This gets an array that is useful for building the two types of dropdown lists that taskStatus uses
-    $taskStatii = task::get_task_statii();
-    if ($flat) {
-      $m = new meta("taskStatus");
-      $taskStatii = $m->get_assoc_array();
-      foreach ($taskStatii as $status => $arr) {
-        $taskStatiiArray[$status] = task::get_task_status_thing("label",$status);
-      }
-    } else {
-      foreach ($taskStatii as $status => $sub) {
-        $taskStatiiArray[$status] = ucwords($status);
-        foreach ($sub as $subStatus => $arr) {
-          $taskStatiiArray[$status."_".$subStatus] = "&nbsp;&nbsp;&nbsp;&nbsp;".$arr["label"];
+                      ORDER BY fullName", $this->get_id()));
+        while ($db->next_record()) {
+            $value = interestedParty::get_encoded_interested_party_identifier($db->f("fullName"), $db->f("emailAddress"));
+            $phone = array("p"=>$db->f('clientContactPhone'),"m"=>$db->f('clientContactMobile'));
+            $TPL["interestedParties"][] = array('key'=>$value, 'name'=>$db->f("fullName"), 'email'=>$db->f("emailAddress"), 'phone'=>$phone);
         }
-      }
-    } 
 
-    return $taskStatiiArray;
-  }
+        $TPL["task_taskStatusLabel"] = $this->get_task_status("label");
+        $TPL["task_taskStatusColour"] = $this->get_task_status("colour");
+        $TPL["task_taskStatusValue"] = $this->get_value("taskStatus");
+        $TPL["task_taskStatusOptions"] = page::select_options(task::get_task_statii_array(true), $this->get_value("taskStatus"));
 
-  function get_task_statii() {
-    // looks like:
-    //$arr["open"]["notstarted"] = array("label"=>"Not Started","colour"=>"#ffffff");
-    //$arr["open"]["inprogress"] = array("label"=>"In Progress","colour"=>"#ffffff");
-    //etc
-    static $rows;
-    if (!$rows) {
-      $m = new meta("taskStatus");
-      $rows = $m->get_assoc_array();
-    }
-    foreach ($rows as $taskStatusID => $arr) {
-      list($s,$ss) = explode("_",$taskStatusID);
-      $rtn[$s][$ss] = array("label"=>$arr["taskStatusLabel"],"colour"=>$arr["taskStatusColour"]);
-    }
-    return $rtn;
-  }
+      // Project label
+        if (has("project")) {
+            $p = new project();
+            $p->set_id($this->get_value("projectID"));
+            $p->select();
+            $TPL["projectName"] = $p->get_display_value();
+        }
 
-  function get_task_status($thing="") {
-    return task::get_task_status_thing($thing,$this->get_value("taskStatus"));
-  }
+        $taskPriorities = config::get_config_item("taskPriorities") or $taskPriorities = array();
+        $projectPriorities = config::get_config_item("projectPriorities") or $projectPriorities = array();
+        $priority = $this->get_value("priority") or $priority = 3;
+        $TPL["priorityOptions"] = page::select_options(array_kv($taskPriorities, null, "label"), $priority);
+        $TPL["priorityLabel"] = " <div style=\"display:inline; color:".$taskPriorities[$priority]["colour"]."\">[";
 
-  public static function get_task_status_thing($thing="",$status="") {
-    list($taskStatus,$taskSubStatus) = explode("_",$status);
-    $arr = task::get_task_statii();
-    if ($thing && $arr[$taskStatus][$taskSubStatus][$thing]) {
-      return $arr[$taskStatus][$taskSubStatus][$thing];
-    }
-  }
+        if (is_object($p)) {
+            list($priorityFactor,$daysUntilDue) = $this->get_overall_priority($p->get_value("projectPriority"), $this->get_value("priority"), $this->get_value("dateTargetCompletion"));
+            $str = "Task priority: ".$taskPriorities[$this->get_value("priority")]["label"]."<br>";
+            $str.= "Project priority: ".$projectPriorities[$p->get_value("projectPriority")]["label"]."<br>";
+            $str.= "Days until due: ".$daysUntilDue."<br>";
+            $str.= "Calculated priority: ".$priorityFactor;
+            $TPL["priorityLabel"].= page::help($str, $this->get_priority_label());
+        } else {
+            $TPL["priorityLabel"].= $this->get_priority_label();
+        }
+        $TPL["priorityLabel"].= "]</div>";
 
-  public static function get_task_status_in_set_sql() {
-    $m = new meta("taskStatus");
-    $arr = $m->get_assoc_array();
-    foreach ($arr as $taskStatusID => $r) {
-      $id = strtolower(substr($taskStatusID,0,4));
-      if ($id == "open") {
-        $sql_open.= $commar1.'"'.$taskStatusID.'"';
-        $commar1 = ",";
-      } else if ($id == "clos") {
-        $sql_clos.= $commar2.'"'.$taskStatusID.'"';
-        $commar2 = ",";
-      } else if ($id == "pend") {
-        $sql_pend.= $commar3.'"'.$taskStatusID.'"';
-        $commar3 = ",";
-      }
-    }
-    return array($sql_open,$sql_pend,$sql_clos);
-  }
 
-  public static function get_taskStatus_sql($status) {
-    if (!is_array($status)) {
-      $status = array($status);
-    }
-    foreach((array)$status as $s) {
-      $lengths[] = strlen($s);
-    }
-    return sprintf_implode("SUBSTRING(task.taskStatus,1,%d) = '%s'",$lengths,$status);
-  }
+      // If we're viewing the printer friendly view
+        if ($_GET["media"] == "print") {
+          // Parent Task label
+            $t = new task();
+            $t->set_id($this->get_value("parentTaskID"));
+            $t->select();
+            $TPL["parentTask"] = $t->get_display_value();
 
-  public static function get_list_filter($filter=array()) {
-    $current_user = &singleton("current_user");
+          // Task Type label
+            $TPL["taskType"] = $this->get_value("taskTypeID");
 
-    // If they want starred, load up the taskID filter element
-    if ($filter["starred"]) {
-      foreach ((array)$current_user->prefs["stars"]["task"] as $k=>$v) {
-        $filter["taskID"][] = $k;
-      }
-      is_array($filter["taskID"]) or $filter["taskID"][] = -1;
+          // Priority
+            $TPL["priority"] = $this->get_value("priority");
+
+          // Assignee label
+            $p = new person();
+            $p->set_id($this->get_value("personID"));
+            $p->select();
+            $TPL["person"] = $p->get_display_value();
+        }
     }
 
-    // Filter on taskID
-    $filter["taskID"] and $sql[] = sprintf_implode("task.taskID = %d",$filter["taskID"]);
-
-    // No point continuing if primary key specified, so return
-    if ($filter["taskID"]) {
-      return array($sql,"");
+    function get_task_comments_array()
+    {
+        $rows = comment::util_get_comments_array("task", $this->get_id());
+        $rows or $rows = array();
+        return $rows;
     }
 
-    // This takes care of projectID singular and plural
-    has("project") and $projectIDs = project::get_projectID_sql($filter);
-    $projectIDs and $sql["projectIDs"] = $projectIDs;
+    function get_task_link($_FORM = array())
+    {
+        $_FORM["return"] or $_FORM["return"] = "html";
+        $rtn = "<a href=\"".$this->get_url()."\">";
+        $rtn.= $this->get_name($_FORM);
+        $rtn.= "</a>";
+        return $rtn;
+    }
 
-    // project name or project nick name or project id
-    $filter["projectNameMatches"] and $sql[] = sprintf_implode("project.projectName LIKE '%%%s%%'
+    function get_task_image()
+    {
+        global $TPL;
+        return "<img class=\"taskType\" alt=\"".$this->get_value("taskTypeID")."\" title=\"".$this->get_value("taskTypeID")."\" src=\"".$TPL["url_alloc_images"]."taskType_".strtolower($this->get_value("taskTypeID")).".gif\">";
+    }
+
+    function get_name($_FORM = array())
+    {
+
+        $_FORM["prefixTaskID"] and $id = $this->get_id()." ";
+
+        if ($this->get_value("taskTypeID") == "Parent" && $_FORM["return"] == "html") {
+            $rtn = "<strong>".$id.$this->get_value("taskName", DST_HTML_DISPLAY)."</strong>";
+        } else if ($_FORM["return"] == "html") {
+            $rtn = $id.$this->get_value("taskName", DST_HTML_DISPLAY);
+        } else {
+            $rtn = $id.$this->get_value("taskName");
+        }
+        return $rtn;
+    }
+
+    function get_url($absolute = false, $id = false)
+    {
+        global $sess;
+        $sess or $sess = new session();
+        $id or $id = $this->get_id();
+        $url = "task/task.php?taskID=".$id;
+
+        if ($sess->Started() && !$absolute) {
+            $url = $sess->url(SCRIPT_PATH.$url);
+
+        // This for urls that are emailed
+        } else {
+            static $prefix;
+            $prefix or $prefix = config::get_config_item("allocURL");
+            $url = $prefix.$url;
+        }
+        return $url;
+    }
+
+    public static function get_task_statii_array($flat = false)
+    {
+      // This gets an array that is useful for building the two types of dropdown lists that taskStatus uses
+        $taskStatii = task::get_task_statii();
+        if ($flat) {
+            $m = new meta("taskStatus");
+            $taskStatii = $m->get_assoc_array();
+            foreach ($taskStatii as $status => $arr) {
+                $taskStatiiArray[$status] = task::get_task_status_thing("label", $status);
+            }
+        } else {
+            foreach ($taskStatii as $status => $sub) {
+                $taskStatiiArray[$status] = ucwords($status);
+                foreach ($sub as $subStatus => $arr) {
+                    $taskStatiiArray[$status."_".$subStatus] = "&nbsp;&nbsp;&nbsp;&nbsp;".$arr["label"];
+                }
+            }
+        }
+
+        return $taskStatiiArray;
+    }
+
+    function get_task_statii()
+    {
+      // looks like:
+      //$arr["open"]["notstarted"] = array("label"=>"Not Started","colour"=>"#ffffff");
+      //$arr["open"]["inprogress"] = array("label"=>"In Progress","colour"=>"#ffffff");
+      //etc
+        static $rows;
+        if (!$rows) {
+            $m = new meta("taskStatus");
+            $rows = $m->get_assoc_array();
+        }
+        foreach ($rows as $taskStatusID => $arr) {
+            list($s,$ss) = explode("_", $taskStatusID);
+            $rtn[$s][$ss] = array("label"=>$arr["taskStatusLabel"],"colour"=>$arr["taskStatusColour"]);
+        }
+        return $rtn;
+    }
+
+    function get_task_status($thing = "")
+    {
+        return task::get_task_status_thing($thing, $this->get_value("taskStatus"));
+    }
+
+    public static function get_task_status_thing($thing = "", $status = "")
+    {
+        list($taskStatus,$taskSubStatus) = explode("_", $status);
+        $arr = task::get_task_statii();
+        if ($thing && $arr[$taskStatus][$taskSubStatus][$thing]) {
+            return $arr[$taskStatus][$taskSubStatus][$thing];
+        }
+    }
+
+    public static function get_task_status_in_set_sql()
+    {
+        $m = new meta("taskStatus");
+        $arr = $m->get_assoc_array();
+        foreach ($arr as $taskStatusID => $r) {
+            $id = strtolower(substr($taskStatusID, 0, 4));
+            if ($id == "open") {
+                $sql_open.= $commar1.'"'.$taskStatusID.'"';
+                $commar1 = ",";
+            } else if ($id == "clos") {
+                $sql_clos.= $commar2.'"'.$taskStatusID.'"';
+                $commar2 = ",";
+            } else if ($id == "pend") {
+                $sql_pend.= $commar3.'"'.$taskStatusID.'"';
+                $commar3 = ",";
+            }
+        }
+        return array($sql_open,$sql_pend,$sql_clos);
+    }
+
+    public static function get_taskStatus_sql($status)
+    {
+        if (!is_array($status)) {
+            $status = array($status);
+        }
+        foreach ((array)$status as $s) {
+            $lengths[] = strlen($s);
+        }
+        return sprintf_implode("SUBSTRING(task.taskStatus,1,%d) = '%s'", $lengths, $status);
+    }
+
+    public static function get_list_filter($filter = array())
+    {
+        $current_user = &singleton("current_user");
+
+      // If they want starred, load up the taskID filter element
+        if ($filter["starred"]) {
+            foreach ((array)$current_user->prefs["stars"]["task"] as $k => $v) {
+                $filter["taskID"][] = $k;
+            }
+            is_array($filter["taskID"]) or $filter["taskID"][] = -1;
+        }
+
+      // Filter on taskID
+        $filter["taskID"] and $sql[] = sprintf_implode("task.taskID = %d", $filter["taskID"]);
+
+      // No point continuing if primary key specified, so return
+        if ($filter["taskID"]) {
+            return array($sql,"");
+        }
+
+      // This takes care of projectID singular and plural
+        has("project") and $projectIDs = project::get_projectID_sql($filter);
+        $projectIDs and $sql["projectIDs"] = $projectIDs;
+
+      // project name or project nick name or project id
+        $filter["projectNameMatches"] and $sql[] = sprintf_implode(
+            "project.projectName LIKE '%%%s%%'
                                                                OR project.projectShortName LIKE '%%%s%%'
-                                                               OR project.projectID = %d"
-                                                              ,$filter["projectNameMatches"]
-                                                              ,$filter["projectNameMatches"]
-                                                              ,$filter["projectNameMatches"]);
+                                                               OR project.projectID = %d",
+            $filter["projectNameMatches"],
+            $filter["projectNameMatches"],
+            $filter["projectNameMatches"]
+        );
 
-    list($ts_open,$ts_pending,$ts_closed) = task::get_task_status_in_set_sql();
+        list($ts_open,$ts_pending,$ts_closed) = task::get_task_status_in_set_sql();
 
-    // New Tasks
-    if ($filter["taskDate"] == "new") {
-      $past = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d") - 2, date("Y")))." 00:00:00";
-      date("D") == "Mon" and $past = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d") - 4, date("Y")))." 00:00:00";
-      $sql[] = prepare("(task.taskStatus NOT IN (".$ts_closed.") AND task.dateCreated >= '".$past."')");
+      // New Tasks
+        if ($filter["taskDate"] == "new") {
+            $past = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d") - 2, date("Y")))." 00:00:00";
+            date("D") == "Mon" and $past = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d") - 4, date("Y")))." 00:00:00";
+            $sql[] = prepare("(task.taskStatus NOT IN (".$ts_closed.") AND task.dateCreated >= '".$past."')");
 
-    // Due Today
-    } else if ($filter["taskDate"] == "due_today") {
-      $sql[] = "(task.taskStatus NOT IN (".$ts_closed.") AND task.dateTargetCompletion = '".date("Y-m-d")."')";
+        // Due Today
+        } else if ($filter["taskDate"] == "due_today") {
+            $sql[] = "(task.taskStatus NOT IN (".$ts_closed.") AND task.dateTargetCompletion = '".date("Y-m-d")."')";
 
-    // Overdue
-    } else if ($filter["taskDate"] == "overdue") {
-      $sql[] = "(task.taskStatus NOT IN (".$ts_closed.")
+        // Overdue
+        } else if ($filter["taskDate"] == "overdue") {
+            $sql[] = "(task.taskStatus NOT IN (".$ts_closed.")
                 AND 
                 (task.dateTargetCompletion IS NOT NULL AND task.dateTargetCompletion != '' AND '".date("Y-m-d")."' > task.dateTargetCompletion))";
   
-    // Date Created
-    } else if ($filter["taskDate"] == "d_created") {
-      $filter["dateOne"] and $sql[] = prepare("(task.dateCreated >= '%s')",$filter["dateOne"]);
-      $filter["dateTwo"] and $sql[] = prepare("(task.dateCreated <= '%s 23:59:59')",$filter["dateTwo"]);
+        // Date Created
+        } else if ($filter["taskDate"] == "d_created") {
+            $filter["dateOne"] and $sql[] = prepare("(task.dateCreated >= '%s')", $filter["dateOne"]);
+            $filter["dateTwo"] and $sql[] = prepare("(task.dateCreated <= '%s 23:59:59')", $filter["dateTwo"]);
 
-    // Date Assigned
-    } else if ($filter["taskDate"] == "d_assigned") {
-      $filter["dateOne"] and $sql[] = prepare("(task.dateAssigned >= '%s')",$filter["dateOne"]);
-      $filter["dateTwo"] and $sql[] = prepare("(task.dateAssigned <= '%s 23:59:59')",$filter["dateTwo"]);
+        // Date Assigned
+        } else if ($filter["taskDate"] == "d_assigned") {
+            $filter["dateOne"] and $sql[] = prepare("(task.dateAssigned >= '%s')", $filter["dateOne"]);
+            $filter["dateTwo"] and $sql[] = prepare("(task.dateAssigned <= '%s 23:59:59')", $filter["dateTwo"]);
 
-    // Date Target Start
-    } else if ($filter["taskDate"] == "d_targetStart") {
-      $filter["dateOne"] and $sql[] = prepare("(task.dateTargetStart >= '%s')",$filter["dateOne"]);
-      $filter["dateTwo"] and $sql[] = prepare("(task.dateTargetStart <= '%s')",$filter["dateTwo"]);
+        // Date Target Start
+        } else if ($filter["taskDate"] == "d_targetStart") {
+            $filter["dateOne"] and $sql[] = prepare("(task.dateTargetStart >= '%s')", $filter["dateOne"]);
+            $filter["dateTwo"] and $sql[] = prepare("(task.dateTargetStart <= '%s')", $filter["dateTwo"]);
 
-    // Date Target Completion
-    } else if ($filter["taskDate"] == "d_targetCompletion") {
-      $filter["dateOne"] and $sql[] = prepare("(task.dateTargetCompletion >= '%s')",$filter["dateOne"]);
-      $filter["dateTwo"] and $sql[] = prepare("(task.dateTargetCompletion <= '%s')",$filter["dateTwo"]);
+        // Date Target Completion
+        } else if ($filter["taskDate"] == "d_targetCompletion") {
+            $filter["dateOne"] and $sql[] = prepare("(task.dateTargetCompletion >= '%s')", $filter["dateOne"]);
+            $filter["dateTwo"] and $sql[] = prepare("(task.dateTargetCompletion <= '%s')", $filter["dateTwo"]);
 
-    // Date Actual Start
-    } else if ($filter["taskDate"] == "d_actualStart") {
-      $filter["dateOne"] and $sql[] = prepare("(task.dateActualStart >= '%s')",$filter["dateOne"]);
-      $filter["dateTwo"] and $sql[] = prepare("(task.dateActualStart <= '%s')",$filter["dateTwo"]);
+        // Date Actual Start
+        } else if ($filter["taskDate"] == "d_actualStart") {
+            $filter["dateOne"] and $sql[] = prepare("(task.dateActualStart >= '%s')", $filter["dateOne"]);
+            $filter["dateTwo"] and $sql[] = prepare("(task.dateActualStart <= '%s')", $filter["dateTwo"]);
 
-    // Date Actual Completion
-    } else if ($filter["taskDate"] == "d_actualCompletion") {
-      $filter["dateOne"] and $sql[] = prepare("(task.dateActualCompletion >= '%s')",$filter["dateOne"]);
-      $filter["dateTwo"] and $sql[] = prepare("(task.dateActualCompletion <= '%s')",$filter["dateTwo"]);
-    }
-
-    // Task status filtering
-    $filter["taskStatus"] and $sql[] = task::get_taskStatus_sql($filter["taskStatus"]);
-    $filter["taskTypeID"] and $sql[] = sprintf_implode("task.taskTypeID = '%s'",$filter["taskTypeID"]);
-
-    // Filter on %taskName%
-    $filter["taskName"] and $sql[] = sprintf_implode("task.taskName LIKE '%%%s%%'", $filter["taskName"]);
-
-    // If personID filter
-    $filter["personID"]  and $sql["personID"]  = sprintf_implode("IFNULL(task.personID,0) = %d", $filter["personID"]);
-    $filter["creatorID"] and $sql["creatorID"] = sprintf_implode("IFNULL(task.creatorID,0) = %d",$filter["creatorID"]);
-    $filter["managerID"] and $sql["managerID"] = sprintf_implode("IFNULL(task.managerID,0) = %d",$filter["managerID"]);
-
-    // If tags filter
-    if ($filter["tags"] && is_array($filter["tags"])) {
-      foreach ((array)$filter["tags"] as $k => $tag) { $tag and $tags[] = $tag; }
-      $tags and $sql[] = sprintf_implode("seltag.name = '%s'",$tags);
-      $having = prepare("HAVING count(DISTINCT seltag.name) = %d",count($tags));
-    }
-
-    // These filters are for the time sheet dropdown list
-    if ($filter["taskTimeSheetStatus"] == "open") {
-      unset($sql["personID"]);
-      $sql[] = prepare("(task.taskStatus NOT IN (".$ts_closed."))");
-
-    } else if ($filter["taskTimeSheetStatus"] == "mine"){ 
-      $current_user = &singleton("current_user");
-      unset($sql["personID"]);
-      $sql[] = prepare("((task.taskStatus NOT IN (".$ts_closed.")) AND task.personID = %d)",$current_user->get_id());
-
-    } else if ($filter["taskTimeSheetStatus"] == "not_assigned"){ 
-      unset($sql["personID"]);
-      $sql[] = prepare("((task.taskStatus NOT IN (".$ts_closed.")) AND task.personID != %d)",$filter["personID"]);
-
-    } else if ($filter["taskTimeSheetStatus"] == "recent_closed"){
-      unset($sql["personID"]);
-      $sql[] = prepare("(task.dateActualCompletion >= DATE_SUB(CURDATE(),INTERVAL 14 DAY))");
-
-    } else if ($filter["taskTimeSheetStatus"] == "all") {
-    }
-
-    $filter["parentTaskID"] and $sql["parentTaskID"] = sprintf_implode("IFNULL(task.parentTaskID,0) = %d",$filter["parentTaskID"]);
-    return array($sql,$having);
-  }
-
-  function get_recursive_child_tasks($taskID_of_parent, $rows=array(), $padding=0) {
-    $rtn = array();
-    $rows or $rows = array();
-    foreach($rows as $taskID => $v) {
-      $parentTaskID = $v["parentTaskID"];
-      $row = $v["row"];
-
-      if ($taskID_of_parent == $parentTaskID) {
-        $row["padding"] = $padding;
-        $rtn[$taskID]["row"] = $row;
-        unset($rows[$taskID]);
-        $padding+=1;
-        $children = task::get_recursive_child_tasks($taskID,$rows,$padding);
-        $padding-=1;
-
-        if (count($children)) {
-          $rtn[$taskID]["children"] = $children;
+        // Date Actual Completion
+        } else if ($filter["taskDate"] == "d_actualCompletion") {
+            $filter["dateOne"] and $sql[] = prepare("(task.dateActualCompletion >= '%s')", $filter["dateOne"]);
+            $filter["dateTwo"] and $sql[] = prepare("(task.dateActualCompletion <= '%s')", $filter["dateTwo"]);
         }
-      }
+
+      // Task status filtering
+        $filter["taskStatus"] and $sql[] = task::get_taskStatus_sql($filter["taskStatus"]);
+        $filter["taskTypeID"] and $sql[] = sprintf_implode("task.taskTypeID = '%s'", $filter["taskTypeID"]);
+
+      // Filter on %taskName%
+        $filter["taskName"] and $sql[] = sprintf_implode("task.taskName LIKE '%%%s%%'", $filter["taskName"]);
+
+      // If personID filter
+        $filter["personID"]  and $sql["personID"]  = sprintf_implode("IFNULL(task.personID,0) = %d", $filter["personID"]);
+        $filter["creatorID"] and $sql["creatorID"] = sprintf_implode("IFNULL(task.creatorID,0) = %d", $filter["creatorID"]);
+        $filter["managerID"] and $sql["managerID"] = sprintf_implode("IFNULL(task.managerID,0) = %d", $filter["managerID"]);
+
+      // If tags filter
+        if ($filter["tags"] && is_array($filter["tags"])) {
+            foreach ((array)$filter["tags"] as $k => $tag) {
+                $tag and $tags[] = $tag;
+            }
+            $tags and $sql[] = sprintf_implode("seltag.name = '%s'", $tags);
+            $having = prepare("HAVING count(DISTINCT seltag.name) = %d", count($tags));
+        }
+
+      // These filters are for the time sheet dropdown list
+        if ($filter["taskTimeSheetStatus"] == "open") {
+            unset($sql["personID"]);
+            $sql[] = prepare("(task.taskStatus NOT IN (".$ts_closed."))");
+        } else if ($filter["taskTimeSheetStatus"] == "mine") {
+            $current_user = &singleton("current_user");
+            unset($sql["personID"]);
+            $sql[] = prepare("((task.taskStatus NOT IN (".$ts_closed.")) AND task.personID = %d)", $current_user->get_id());
+        } else if ($filter["taskTimeSheetStatus"] == "not_assigned") {
+            unset($sql["personID"]);
+            $sql[] = prepare("((task.taskStatus NOT IN (".$ts_closed.")) AND task.personID != %d)", $filter["personID"]);
+        } else if ($filter["taskTimeSheetStatus"] == "recent_closed") {
+            unset($sql["personID"]);
+            $sql[] = prepare("(task.dateActualCompletion >= DATE_SUB(CURDATE(),INTERVAL 14 DAY))");
+        } else if ($filter["taskTimeSheetStatus"] == "all") {
+        }
+
+        $filter["parentTaskID"] and $sql["parentTaskID"] = sprintf_implode("IFNULL(task.parentTaskID,0) = %d", $filter["parentTaskID"]);
+        return array($sql,$having);
     }
-    return $rtn;
-  }
 
-  function build_recursive_task_list($t=array(),$_FORM=array()) {
-    $tasks or $tasks = array();
-    foreach ($t as $r) {
-      $row = $r["row"];
-      $done[$row["taskID"]] = true; // To track orphans
-      $tasks += array($row["taskID"]=>$row);
+    function get_recursive_child_tasks($taskID_of_parent, $rows = array(), $padding = 0)
+    {
+        $rtn = array();
+        $rows or $rows = array();
+        foreach ($rows as $taskID => $v) {
+            $parentTaskID = $v["parentTaskID"];
+            $row = $v["row"];
 
-      if ($r["children"]) {
-        list($t,$d) = task::build_recursive_task_list($r["children"],$_FORM);
-        $t and $tasks += $t;
-        $d and $done += $d;
-      }
+            if ($taskID_of_parent == $parentTaskID) {
+                $row["padding"] = $padding;
+                $rtn[$taskID]["row"] = $row;
+                unset($rows[$taskID]);
+                $padding+=1;
+                $children = task::get_recursive_child_tasks($taskID, $rows, $padding);
+                $padding-=1;
+
+                if (count($children)) {
+                    $rtn[$taskID]["children"] = $children;
+                }
+            }
+        }
+        return $rtn;
     }
-    return array($tasks,$done);
-  }
 
-  function get_overall_priority($projectPriority=0,$taskPriority=0,$dateTargetCompletion) {
-    $spread = sprintf("%d",config::get_config_item("taskPrioritySpread"));
-    $scale = sprintf("%d",config::get_config_item("taskPriorityScale"));
-    $scale_halved = sprintf("%d",config::get_config_item("taskPriorityScale")/2);
+    function build_recursive_task_list($t = array(), $_FORM = array())
+    {
+        $tasks or $tasks = array();
+        foreach ($t as $r) {
+            $row = $r["row"];
+            $done[$row["taskID"]] = true; // To track orphans
+            $tasks += array($row["taskID"]=>$row);
 
-    if ($dateTargetCompletion) {
-      $daysUntilDue = (format_date("U",$dateTargetCompletion) - mktime()) / 60 / 60 / 24;
-      $mult = atan($daysUntilDue / $spread) / 3.14 * $scale + $scale_halved;
-    } else {
-      $mult = 8;
+            if ($r["children"]) {
+                list($t,$d) = task::build_recursive_task_list($r["children"], $_FORM);
+                $t and $tasks += $t;
+                $d and $done += $d;
+            }
+        }
+        return array($tasks,$done);
     }
-    $daysUntilDue and $daysUntilDue = sprintf("%d",ceil($daysUntilDue));
-    return array(sprintf("%0.2f",($taskPriority * pow($projectPriority,2)) * $mult / 10), $daysUntilDue);
-  }
 
-  public static function get_list($_FORM) {
-    $current_user = &singleton("current_user");
+    function get_overall_priority($projectPriority = 0, $taskPriority = 0, $dateTargetCompletion)
+    {
+        $spread = sprintf("%d", config::get_config_item("taskPrioritySpread"));
+        $scale = sprintf("%d", config::get_config_item("taskPriorityScale"));
+        $scale_halved = sprintf("%d", config::get_config_item("taskPriorityScale")/2);
 
-    /*
-     * This is the definitive method of getting a list of tasks that need a sophisticated level of filtering
-     *
-     */
+        if ($dateTargetCompletion) {
+            $daysUntilDue = (format_date("U", $dateTargetCompletion) - mktime()) / 60 / 60 / 24;
+            $mult = atan($daysUntilDue / $spread) / 3.14 * $scale + $scale_halved;
+        } else {
+            $mult = 8;
+        }
+        $daysUntilDue and $daysUntilDue = sprintf("%d", ceil($daysUntilDue));
+        return array(sprintf("%0.2f", ($taskPriority * pow($projectPriority, 2)) * $mult / 10), $daysUntilDue);
+    }
+
+    public static function get_list($_FORM)
+    {
+        $current_user = &singleton("current_user");
+
+      /*
+       * This is the definitive method of getting a list of tasks that need a sophisticated level of filtering
+       *
+       */
  
-    list($filter, $having) = task::get_list_filter($_FORM);
+        list($filter, $having) = task::get_list_filter($_FORM);
 
-    $debug = $_FORM["debug"];
-    $debug and print "\n<pre>_FORM: ".print_r($_FORM,1)."</pre>";
-    $debug and print "\n<pre>filter: ".print_r($filter,1)."</pre>";
+        $debug = $_FORM["debug"];
+        $debug and print "\n<pre>_FORM: ".print_r($_FORM, 1)."</pre>";
+        $debug and print "\n<pre>filter: ".print_r($filter, 1)."</pre>";
 
-    $_FORM["taskView"] or $_FORM["taskView"] = 'prioritised';
+        $_FORM["taskView"] or $_FORM["taskView"] = 'prioritised';
 
-    // Zero is a valid limit
-    if ($_FORM["limit"] || $_FORM["limit"] === 0 || $_FORM["limit"] === "0") {
-      $limit = prepare("limit %d",$_FORM["limit"]); 
-    }
-    $_FORM["return"] or $_FORM["return"] = "html";
+      // Zero is a valid limit
+        if ($_FORM["limit"] || $_FORM["limit"] === 0 || $_FORM["limit"] === "0") {
+            $limit = prepare("limit %d", $_FORM["limit"]);
+        }
+        $_FORM["return"] or $_FORM["return"] = "html";
 
-    $_FORM["people_cache"] =& get_cached_table("person");
-    $_FORM["timeUnit_cache"] =& get_cached_table("timeUnit");
-    $_FORM["taskType_cache"] =& get_cached_table("taskType");
+        $_FORM["people_cache"] =& get_cached_table("person");
+        $_FORM["timeUnit_cache"] =& get_cached_table("timeUnit");
+        $_FORM["taskType_cache"] =& get_cached_table("taskType");
 
-    if ($_FORM["taskView"] == "prioritised") {
-      unset($filter["parentTaskID"]);
-      $order_limit = " ".$limit;
-    } else {
-      $order_limit = " ORDER BY projectName,taskName ".$limit;
-    }
+        if ($_FORM["taskView"] == "prioritised") {
+            unset($filter["parentTaskID"]);
+            $order_limit = " ".$limit;
+        } else {
+            $order_limit = " ORDER BY projectName,taskName ".$limit;
+        }
 
-    // Get a hierarchical list of tasks
-    if (is_array($filter) && count($filter)) {
-      $f = " WHERE ".implode(" AND ",$filter);
-    }
+      // Get a hierarchical list of tasks
+        if (is_array($filter) && count($filter)) {
+            $f = " WHERE ".implode(" AND ", $filter);
+        }
 
-    $uid = sprintf("%d",$current_user->get_id());
-    $spread = sprintf("%d",config::get_config_item("taskPrioritySpread"));
-    $scale = sprintf("%d",config::get_config_item("taskPriorityScale"));
-    $scale_halved = sprintf("%d",config::get_config_item("taskPriorityScale")/2);
+        $uid = sprintf("%d", $current_user->get_id());
+        $spread = sprintf("%d", config::get_config_item("taskPrioritySpread"));
+        $scale = sprintf("%d", config::get_config_item("taskPriorityScale"));
+        $scale_halved = sprintf("%d", config::get_config_item("taskPriorityScale")/2);
 
-    $q = "SELECT task.*
+        $q = "SELECT task.*
                 ,projectName
                 ,projectShortName
                 ,clientID
@@ -994,199 +1029,207 @@ class task extends db_entity {
                  ".$having."
                  ".$order_limit;
       
-    $debug and print "\n<br>QUERY: ".$q;
-    $_FORM["debug"] and print "\n<br>QUERY: ".$q;
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->next_record()) {
-      $task = new task();
-      $task->read_db_record($db);
-      $row["taskURL"] = $task->get_url();
-      $row["taskName"] = $task->get_name($_FORM);
-      $row["taskLink"] = $task->get_task_link($_FORM);
-      $row["project_name"] = $row["projectShortName"]  or  $row["project_name"] = $row["projectName"];
-      $row["projectPriority"] = $db->f("projectPriority");
-      has("project") and $row["projectPriorityLabel"] = project::get_priority_label($db->f("projectPriority"));
-      has("project") and list($row["priorityFactor"],$row["daysUntilDue"]) = $task->get_overall_priority($row["projectPriority"],$row["priority"],$row["dateTargetCompletion"]);
-      $row["taskTypeImage"] = $task->get_task_image();
-      $row["taskTypeSeq"] = $_FORM["taskType_cache"][$row["taskTypeID"]]["taskTypeSeq"];
-      $row["taskStatusLabel"] = $task->get_task_status("label");
-      $row["taskStatusColour"] = $task->get_task_status("colour");
-      $row["creator_name"] = $_FORM["people_cache"][$row["creatorID"]]["name"];
-      $row["manager_name"] = $_FORM["people_cache"][$row["managerID"]]["name"];
-      $row["assignee_name"] = $_FORM["people_cache"][$row["personID"]]["name"];
-      $row["closer_name"] = $_FORM["people_cache"][$row["closerID"]]["name"];
-      $row["estimator_name"] = $_FORM["people_cache"][$row["estimatorID"]]["name"];
-      $row["creator_username"] = $_FORM["people_cache"][$row["creatorID"]]["username"];
-      $row["manager_username"] = $_FORM["people_cache"][$row["managerID"]]["username"];
-      $row["assignee_username"] = $_FORM["people_cache"][$row["personID"]]["username"];
-      $row["closer_username"] = $_FORM["people_cache"][$row["closerID"]]["username"];
-      $row["estimator_username"] = $_FORM["people_cache"][$row["estimatorID"]]["username"];
-      $row["newSubTask"] = $task->get_new_subtask_link();
-      $_FORM["showPercent"] and $row["percentComplete"] = $task->get_percentComplete();
-      $_FORM["showTimes"] and $row["timeActual"] = $task->get_time_billed()/60/60;
-      $row["rate"] = page::money($row["currency"],$row["rate"],"%mo");
-      $row["rateUnit"] = $_FORM["timeUnit_cache"][$row["rateUnitID"]]["timeUnitName"];
-      $row["priorityLabel"] = $task->get_priority_label();
-      if (!$_FORM["skipObject"]) {
-        $_FORM["return"] == "array" and $row["object"] = $task;
-      }
-      $row["padding"] = $_FORM["padding"];
-      $row["taskID"] = $task->get_id();
-      $row["parentTaskID"] = $task->get_value("parentTaskID");
-      $row["parentTaskID_link"] = "<a href='".$task->get_url(false,$task->get_value("parentTaskID"))."'>".$task->get_value("parentTaskID")."</a>";
-      $row["timeLimitLabel"] = $row["timeBestLabel"] = $row["timeWorstLabel"] = $row["timeExpectedLabel"] = $row["timeActualLabel"] = "";
-      $row["timeLimit"] !== NULL    and $row["timeLimitLabel"]    = seconds_to_display_format($row["timeLimit"]*60*60);
-      $row["timeBest"] !== NULL     and $row["timeBestLabel"]     = seconds_to_display_format($row["timeBest"]*60*60);
-      $row["timeWorst"] !== NULL    and $row["timeWorstLabel"]    = seconds_to_display_format($row["timeWorst"]*60*60);
-      $row["timeExpected"] !== NULL and $row["timeExpectedLabel"] = seconds_to_display_format($row["timeExpected"]*60*60);
-      $row["timeActual"] !== NULL   and $row["timeActualLabel"]   = seconds_to_display_format($row["timeActual"]*60*60);
-      if ($_FORM["showComments"] && $comments = comment::util_get_comments("task",$row["taskID"])) {
-        $row["comments"] = $comments;
-      }
-      if ($_FORM["taskView"] == "byProject") {
-        $rows[$task->get_id()] = array("parentTaskID"=>$row["parentTaskID"],"row"=>$row);
-      } else if ($_FORM["taskView"] == "prioritised") {
-        $rows[$row["taskID"]] = $row;
-        if (is_array($rows) && count($rows)) {
-          uasort($rows, array("task", "priority_compare"));
+        $debug and print "\n<br>QUERY: ".$q;
+        $_FORM["debug"] and print "\n<br>QUERY: ".$q;
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->next_record()) {
+            $task = new task();
+            $task->read_db_record($db);
+            $row["taskURL"] = $task->get_url();
+            $row["taskName"] = $task->get_name($_FORM);
+            $row["taskLink"] = $task->get_task_link($_FORM);
+            $row["project_name"] = $row["projectShortName"]  or  $row["project_name"] = $row["projectName"];
+            $row["projectPriority"] = $db->f("projectPriority");
+            has("project") and $row["projectPriorityLabel"] = project::get_priority_label($db->f("projectPriority"));
+            has("project") and list($row["priorityFactor"],$row["daysUntilDue"]) = $task->get_overall_priority($row["projectPriority"], $row["priority"], $row["dateTargetCompletion"]);
+            $row["taskTypeImage"] = $task->get_task_image();
+            $row["taskTypeSeq"] = $_FORM["taskType_cache"][$row["taskTypeID"]]["taskTypeSeq"];
+            $row["taskStatusLabel"] = $task->get_task_status("label");
+            $row["taskStatusColour"] = $task->get_task_status("colour");
+            $row["creator_name"] = $_FORM["people_cache"][$row["creatorID"]]["name"];
+            $row["manager_name"] = $_FORM["people_cache"][$row["managerID"]]["name"];
+            $row["assignee_name"] = $_FORM["people_cache"][$row["personID"]]["name"];
+            $row["closer_name"] = $_FORM["people_cache"][$row["closerID"]]["name"];
+            $row["estimator_name"] = $_FORM["people_cache"][$row["estimatorID"]]["name"];
+            $row["creator_username"] = $_FORM["people_cache"][$row["creatorID"]]["username"];
+            $row["manager_username"] = $_FORM["people_cache"][$row["managerID"]]["username"];
+            $row["assignee_username"] = $_FORM["people_cache"][$row["personID"]]["username"];
+            $row["closer_username"] = $_FORM["people_cache"][$row["closerID"]]["username"];
+            $row["estimator_username"] = $_FORM["people_cache"][$row["estimatorID"]]["username"];
+            $row["newSubTask"] = $task->get_new_subtask_link();
+            $_FORM["showPercent"] and $row["percentComplete"] = $task->get_percentComplete();
+            $_FORM["showTimes"] and $row["timeActual"] = $task->get_time_billed()/60/60;
+            $row["rate"] = page::money($row["currency"], $row["rate"], "%mo");
+            $row["rateUnit"] = $_FORM["timeUnit_cache"][$row["rateUnitID"]]["timeUnitName"];
+            $row["priorityLabel"] = $task->get_priority_label();
+            if (!$_FORM["skipObject"]) {
+                $_FORM["return"] == "array" and $row["object"] = $task;
+            }
+            $row["padding"] = $_FORM["padding"];
+            $row["taskID"] = $task->get_id();
+            $row["parentTaskID"] = $task->get_value("parentTaskID");
+            $row["parentTaskID_link"] = "<a href='".$task->get_url(false, $task->get_value("parentTaskID"))."'>".$task->get_value("parentTaskID")."</a>";
+            $row["timeLimitLabel"] = $row["timeBestLabel"] = $row["timeWorstLabel"] = $row["timeExpectedLabel"] = $row["timeActualLabel"] = "";
+            $row["timeLimit"] !== null    and $row["timeLimitLabel"]    = seconds_to_display_format($row["timeLimit"]*60*60);
+            $row["timeBest"] !== null     and $row["timeBestLabel"]     = seconds_to_display_format($row["timeBest"]*60*60);
+            $row["timeWorst"] !== null    and $row["timeWorstLabel"]    = seconds_to_display_format($row["timeWorst"]*60*60);
+            $row["timeExpected"] !== null and $row["timeExpectedLabel"] = seconds_to_display_format($row["timeExpected"]*60*60);
+            $row["timeActual"] !== null   and $row["timeActualLabel"]   = seconds_to_display_format($row["timeActual"]*60*60);
+            if ($_FORM["showComments"] && $comments = comment::util_get_comments("task", $row["taskID"])) {
+                $row["comments"] = $comments;
+            }
+            if ($_FORM["taskView"] == "byProject") {
+                $rows[$task->get_id()] = array("parentTaskID"=>$row["parentTaskID"],"row"=>$row);
+            } else if ($_FORM["taskView"] == "prioritised") {
+                $rows[$row["taskID"]] = $row;
+                if (is_array($rows) && count($rows)) {
+                    uasort($rows, array("task", "priority_compare"));
+                }
+            }
         }
-      }
-    }
  
-    if ($_FORM["taskView"] == "byProject") {
-      $parentTaskID = $_FORM["parentTaskID"] or $parentTaskID = 0;
-      $t = task::get_recursive_child_tasks($parentTaskID,(array)$rows);
-      list($tasks,$done) = task::build_recursive_task_list($t,$_FORM);
+        if ($_FORM["taskView"] == "byProject") {
+            $parentTaskID = $_FORM["parentTaskID"] or $parentTaskID = 0;
+            $t = task::get_recursive_child_tasks($parentTaskID, (array)$rows);
+            list($tasks,$done) = task::build_recursive_task_list($t, $_FORM);
 
-      // This bit appends the orphan tasks onto the end..
-      foreach ((array)$rows as $taskID => $r) {
-        $row = $r["row"];
-        $row["padding"] = 0;
-        if (!$done[$taskID]) {
-          $tasks += array($taskID=>$row);
+          // This bit appends the orphan tasks onto the end..
+            foreach ((array)$rows as $taskID => $r) {
+                $row = $r["row"];
+                $row["padding"] = 0;
+                if (!$done[$taskID]) {
+                    $tasks += array($taskID=>$row);
+                }
+            }
+        } else if ($_FORM["taskView"] == "prioritised") {
+            $tasks = &$rows;
         }
-      }
-    } else if ($_FORM["taskView"] == "prioritised") {
-      $tasks = &$rows;
+
+        return (array)$tasks;
     }
 
-    return (array)$tasks;
-  }
-
-  function priority_compare($a, $b) {
-    return $a["priorityFactor"] > $b["priorityFactor"];
-  }
-
-  function get_list_html($tasks=array(),$ops=array()) {
-    global $TPL;
-    $TPL["taskListRows"] = $tasks;
-    $TPL["_FORM"] = $ops;
-    $TPL["taskPriorities"] = config::get_config_item("taskPriorities");
-    $TPL["projectPriorities"] =  config::get_config_item("projectPriorities");
-    include_template(dirname(__FILE__)."/../templates/taskListS.tpl");
-  }
-
-  function get_task_priority_dropdown($priority=false) {
-    $taskPriorities = config::get_config_item("taskPriorities") or $taskPriorities = array();
-    foreach ($taskPriorities as $k => $v) {
-      $tp[$k] = $v["label"];     
+    function priority_compare($a, $b)
+    {
+        return $a["priorityFactor"] > $b["priorityFactor"];
     }
-    return page::select_options($tp,$priority);
-  }
 
-  function get_new_subtask_link() {
-    global $TPL;
-    if (is_object($this) && $this->get_value("taskTypeID") == "Parent") {
-      return "<a class=\"noprint\" href=\"".$TPL["url_alloc_task"]."projectID=".$this->get_value("projectID")."&parentTaskID=".$this->get_id()."\">New Subtask</a>";
+    function get_list_html($tasks = array(), $ops = array())
+    {
+        global $TPL;
+        $TPL["taskListRows"] = $tasks;
+        $TPL["_FORM"] = $ops;
+        $TPL["taskPriorities"] = config::get_config_item("taskPriorities");
+        $TPL["projectPriorities"] =  config::get_config_item("projectPriorities");
+        include_template(dirname(__FILE__)."/../templates/taskListS.tpl");
     }
-  }
 
-  function get_time_billed($taskID="") {
-    static $results;
-    if (is_object($this) && !$taskID) {
-      $taskID = $this->get_id();
+    function get_task_priority_dropdown($priority = false)
+    {
+        $taskPriorities = config::get_config_item("taskPriorities") or $taskPriorities = array();
+        foreach ($taskPriorities as $k => $v) {
+            $tp[$k] = $v["label"];
+        }
+        return page::select_options($tp, $priority);
     }
-    if ($results[$taskID]) {
-      return $results[$taskID];
+
+    function get_new_subtask_link()
+    {
+        global $TPL;
+        if (is_object($this) && $this->get_value("taskTypeID") == "Parent") {
+            return "<a class=\"noprint\" href=\"".$TPL["url_alloc_task"]."projectID=".$this->get_value("projectID")."&parentTaskID=".$this->get_id()."\">New Subtask</a>";
+        }
     }
-    if ($taskID) {
-      $db = new db_alloc();
-      // Get tally from timeSheetItem table
-      $db->query("SELECT sum(timeSheetItemDuration*timeUnitSeconds) as sum_of_time
+
+    function get_time_billed($taskID = "")
+    {
+        static $results;
+        if (is_object($this) && !$taskID) {
+            $taskID = $this->get_id();
+        }
+        if ($results[$taskID]) {
+            return $results[$taskID];
+        }
+        if ($taskID) {
+            $db = new db_alloc();
+          // Get tally from timeSheetItem table
+            $db->query("SELECT sum(timeSheetItemDuration*timeUnitSeconds) as sum_of_time
                     FROM timeSheetItem 
                LEFT JOIN timeUnit ON timeSheetItemDurationUnitID = timeUnitID 
                    WHERE taskID = %d
-               GROUP BY taskID",$taskID);
-      while ($db->next_record()) {
-        $results[$taskID] = $db->f("sum_of_time");
-        return $db->f("sum_of_time");
-      }
-      return "";
+               GROUP BY taskID", $taskID);
+            while ($db->next_record()) {
+                  $results[$taskID] = $db->f("sum_of_time");
+                  return $db->f("sum_of_time");
+            }
+            return "";
+        }
     }
-  }
 
-  function get_percentComplete($get_num=false) {
+    function get_percentComplete($get_num = false)
+    {
 
-    $timeActual = sprintf("%0.2f",$this->get_time_billed());
-    $timeExpected = sprintf("%0.2f",$this->get_value("timeLimit")*60*60);
+        $timeActual = sprintf("%0.2f", $this->get_time_billed());
+        $timeExpected = sprintf("%0.2f", $this->get_value("timeLimit")*60*60);
 
-    if ($timeExpected>0 && is_object($this)) {
-
-      $percent = $timeActual / $timeExpected * 100;
-      $this->get_value("dateActualCompletion") and $closed_text = "<del>" and $closed_text_end = "</del> Closed";
+        if ($timeExpected>0 && is_object($this)) {
+            $percent = $timeActual / $timeExpected * 100;
+            $this->get_value("dateActualCompletion") and $closed_text = "<del>" and $closed_text_end = "</del> Closed";
  
-      // Return number
-      if ($get_num) {
-        $this->get_value("dateActualCompletion") || $percent>100 and $percent = 100;
-        return $percent;
+          // Return number
+            if ($get_num) {
+                $this->get_value("dateActualCompletion") || $percent>100 and $percent = 100;
+                return $percent;
        
-      // Else if task <= 100%
-      } else if ($percent <= 100) {
-        return $closed_text.sprintf("%d%%",$percent).$closed_text_end;
+              // Else if task <= 100%
+            } else if ($percent <= 100) {
+                return $closed_text.sprintf("%d%%", $percent).$closed_text_end;
                     
        
-      // Else if task > 100%
-      } else if ($percent > 100) {
-        return "<span class='bad'>".$closed_text.sprintf("%d%%",$percent).$closed_text_end."</span>";
-      }
-    }
-  }
-
-  function get_priority_label() {
-    static $taskPriorities;
-    $taskPriorities or $taskPriorities = config::get_config_item("taskPriorities");
-    return $taskPriorities[$this->get_value("priority")]["label"];
-  }
-
-  function get_forecast_completion() {
-    // Get the date the task is forecast to be completed given an actual start 
-    // date and percent complete
-    $date_actual_start = $this->get_value("dateActualStart");
-    $percent_complete = $this->get_percentComplete(true);
-
-    if (!($date_actual_start && $percent_complete)) {
-      // Can't calculate forecast date without date_actual_start and % complete
-      return 0;
+              // Else if task > 100%
+            } else if ($percent > 100) {
+                return "<span class='bad'>".$closed_text.sprintf("%d%%", $percent).$closed_text_end."</span>";
+            }
+        }
     }
 
-    $date_actual_start = format_date("U",$date_actual_start);
-    $time_spent = mktime() - $date_actual_start;
-    $time_per_percent = $time_spent / $percent_complete;
-    $percent_left = 100 - $percent_complete;
-    $time_left = $percent_left * $time_per_percent;
-    $date_forecast_completion = mktime() + $time_left;
-    return $date_forecast_completion;
-  }
-
-  function get_list_vars() {
-    $taskStatii = task::get_task_statii_array(true);
-    foreach($taskStatii as $k => $v) {
-      $taskStatiiStr.= $pipe.$k;
-      $pipe = " | ";
+    function get_priority_label()
+    {
+        static $taskPriorities;
+        $taskPriorities or $taskPriorities = config::get_config_item("taskPriorities");
+        return $taskPriorities[$this->get_value("priority")]["label"];
     }
 
-    return array("taskView"             => "[MANDATORY] eg: byProject | prioritised"
+    function get_forecast_completion()
+    {
+      // Get the date the task is forecast to be completed given an actual start
+      // date and percent complete
+        $date_actual_start = $this->get_value("dateActualStart");
+        $percent_complete = $this->get_percentComplete(true);
+
+        if (!($date_actual_start && $percent_complete)) {
+          // Can't calculate forecast date without date_actual_start and % complete
+            return 0;
+        }
+
+        $date_actual_start = format_date("U", $date_actual_start);
+        $time_spent = mktime() - $date_actual_start;
+        $time_per_percent = $time_spent / $percent_complete;
+        $percent_left = 100 - $percent_complete;
+        $time_left = $percent_left * $time_per_percent;
+        $date_forecast_completion = mktime() + $time_left;
+        return $date_forecast_completion;
+    }
+
+    function get_list_vars()
+    {
+        $taskStatii = task::get_task_statii_array(true);
+        foreach ($taskStatii as $k => $v) {
+            $taskStatiiStr.= $pipe.$k;
+            $pipe = " | ";
+        }
+
+        return array("taskView"             => "[MANDATORY] eg: byProject | prioritised"
                 ,"return"               => "[MANDATORY] eg: html | array"
                 ,"limit"                => "Appends an SQL limit (only for prioritised and objects views)"
                 ,"projectIDs"           => "An array of projectIDs"
@@ -1238,104 +1281,105 @@ class task extends db_entity {
                 ,"showEdit"             => "Display the html edit controls to allow en masse task editing"
                 ,"showTotals"           => "Display the totals of certain columns in the html view"
                 );
-  }
+    }
 
-  public static function load_form_data($defaults=array()) {
-    $current_user = &singleton("current_user");
+    public static function load_form_data($defaults = array())
+    {
+        $current_user = &singleton("current_user");
   
-    $page_vars = array_keys(task::get_list_vars());
+        $page_vars = array_keys(task::get_list_vars());
 
-    $_FORM = get_all_form_data($page_vars,$defaults);
+        $_FORM = get_all_form_data($page_vars, $defaults);
 
-    if ($_FORM["projectID"] && !is_array($_FORM["projectID"])) {
-      $p = $_FORM["projectID"];
-      unset($_FORM["projectID"]);
-      $_FORM["projectID"][] = $p;
+        if ($_FORM["projectID"] && !is_array($_FORM["projectID"])) {
+            $p = $_FORM["projectID"];
+            unset($_FORM["projectID"]);
+            $_FORM["projectID"][] = $p;
+        } else if (!$_FORM["projectType"]) {
+            $_FORM["projectType"] = "mine";
+        }
 
-    } else if (!$_FORM["projectType"]){
-      $_FORM["projectType"] = "mine";
+        if ($_FORM["showDates"]) {
+            $_FORM["showDate1"] = true;
+            $_FORM["showDate2"] = true;
+            $_FORM["showDate3"] = true;
+            $_FORM["showDate4"] = true;
+            $_FORM["showDate5"] = true;
+        }
+
+        if ($_FORM["applyFilter"] && is_object($current_user)) {
+          // we have a new filter configuration from the user, and must save it
+            if (!$_FORM["dontSave"]) {
+                $url = $_FORM["url_form_action"];
+                unset($_FORM["url_form_action"]);
+                $current_user->prefs[$_FORM["form_name"]] = $_FORM;
+                $_FORM["url_form_action"] = $url;
+            }
+        } else {
+          // we haven't been given a filter configuration, so load it from user preferences
+            $_FORM = $current_user->prefs[$_FORM["form_name"]];
+            if (!isset($current_user->prefs[$_FORM["form_name"]])) {
+                $_FORM["projectType"] = "mine";
+                $_FORM["taskStatus"] = "open";
+                $_FORM["personID"] = $current_user->get_id();
+            }
+        }
+
+      // If have check Show Description checkbox then display the Long Description and the Comments
+        if ($_FORM["showDescription"]) {
+            $_FORM["showComments"] = true;
+        } else {
+            unset($_FORM["showComments"]);
+        }
+        $_FORM["taskView"] or $_FORM["taskView"] = "byProject";
+        return $_FORM;
     }
 
-    if ($_FORM["showDates"]) {
-      $_FORM["showDate1"] = true;
-      $_FORM["showDate2"] = true;
-      $_FORM["showDate3"] = true;
-      $_FORM["showDate4"] = true;
-      $_FORM["showDate5"] = true;
-    }
+    function load_task_filter($_FORM)
+    {
+        $current_user = &singleton("current_user");
 
-    if ($_FORM["applyFilter"] && is_object($current_user)) {
-      // we have a new filter configuration from the user, and must save it
-      if(!$_FORM["dontSave"]) {
-        $url = $_FORM["url_form_action"];
-        unset($_FORM["url_form_action"]);
-        $current_user->prefs[$_FORM["form_name"]] = $_FORM;
-        $_FORM["url_form_action"] = $url;
-      }
-    } else {
-      // we haven't been given a filter configuration, so load it from user preferences
-      $_FORM = $current_user->prefs[$_FORM["form_name"]];
-      if (!isset($current_user->prefs[$_FORM["form_name"]])) {
-        $_FORM["projectType"] = "mine";
-        $_FORM["taskStatus"] = "open";
-        $_FORM["personID"] = $current_user->get_id();
-      }
-    }
+        $db = new db_alloc();
 
-    // If have check Show Description checkbox then display the Long Description and the Comments
-    if ($_FORM["showDescription"]) {
-      $_FORM["showComments"] = true;
-    } else {
-      unset($_FORM["showComments"]);
-    }
-    $_FORM["taskView"] or $_FORM["taskView"] = "byProject";
-    return $_FORM;
-  }
+      // Load up the forms action url
+        $rtn["url_form_action"] = $_FORM["url_form_action"];
+        $rtn["hide_field_options"] = $_FORM["hide_field_options"];
 
-  function load_task_filter($_FORM) {
-    $current_user = &singleton("current_user");
+      //time Load up the filter bits
+        has("project") and $rtn["projectOptions"] = project::get_list_dropdown($_FORM["projectType"], $_FORM["projectID"]);
 
-    $db = new db_alloc();
+        $_FORM["projectType"] and $rtn["projectType_checked"][$_FORM["projectType"]] = " checked";
+        $ops = array("0"=>"Nobody");
+        $rtn["personOptions"] = page::select_options($ops+person::get_username_list($_FORM["personID"]), $_FORM["personID"]);
+        $rtn["managerPersonOptions"] = page::select_options($ops+person::get_username_list($_FORM["managerID"]), $_FORM["managerID"]);
+        $rtn["creatorPersonOptions"] = page::select_options(person::get_username_list($_FORM["creatorID"]), $_FORM["creatorID"]);
+        $rtn["all_tags"] = task::get_tags(true);
+        $rtn["tags"] = $_FORM["tags"];
 
-    // Load up the forms action url
-    $rtn["url_form_action"] = $_FORM["url_form_action"];
-    $rtn["hide_field_options"] = $_FORM["hide_field_options"];
+        $taskType = new meta("taskType");
+        $taskType_array = $taskType->get_assoc_array("taskTypeID", "taskTypeID");
+        $rtn["taskTypeOptions"] = page::select_options($taskType_array, $_FORM["taskTypeID"]);
 
-    //time Load up the filter bits
-    has("project") and $rtn["projectOptions"] = project::get_list_dropdown($_FORM["projectType"],$_FORM["projectID"]);
+        $_FORM["taskView"] and $rtn["taskView_checked_".$_FORM["taskView"]] = " checked";
 
-    $_FORM["projectType"] and $rtn["projectType_checked"][$_FORM["projectType"]] = " checked"; 
-    $ops = array("0"=>"Nobody");
-    $rtn["personOptions"] = page::select_options($ops+person::get_username_list($_FORM["personID"]), $_FORM["personID"]);
-    $rtn["managerPersonOptions"] = page::select_options($ops+person::get_username_list($_FORM["managerID"]), $_FORM["managerID"]);
-    $rtn["creatorPersonOptions"] = page::select_options(person::get_username_list($_FORM["creatorID"]), $_FORM["creatorID"]);
-    $rtn["all_tags"] = task::get_tags(true);
-    $rtn["tags"] = $_FORM["tags"];
+        $taskStatii = task::get_task_statii_array();
+        $rtn["taskStatusOptions"] = page::select_options($taskStatii, $_FORM["taskStatus"]);
 
-    $taskType = new meta("taskType");
-    $taskType_array = $taskType->get_assoc_array("taskTypeID","taskTypeID");
-    $rtn["taskTypeOptions"] = page::select_options($taskType_array,$_FORM["taskTypeID"]);
-
-    $_FORM["taskView"] and $rtn["taskView_checked_".$_FORM["taskView"]] = " checked";
-
-    $taskStatii = task::get_task_statii_array();
-    $rtn["taskStatusOptions"] = page::select_options($taskStatii, $_FORM["taskStatus"]);
-
-    $_FORM["showDescription"] and $rtn["showDescription_checked"] = " checked";
-    $_FORM["showDates"]       and $rtn["showDates_checked"]       = " checked";
-    $_FORM["showCreator"]     and $rtn["showCreator_checked"]     = " checked";
-    $_FORM["showAssigned"]    and $rtn["showAssigned_checked"]    = " checked";
-    $_FORM["showTimes"]       and $rtn["showTimes_checked"]       = " checked";
-    $_FORM["showPercent"]     and $rtn["showPercent_checked"]     = " checked";
-    $_FORM["showPriority"]    and $rtn["showPriority_checked"]    = " checked";
-    $_FORM["showTaskID"]      and $rtn["showTaskID_checked"]      = " checked";
-    $_FORM["showManager"]     and $rtn["showManager_checked"]     = " checked";
-    $_FORM["showProject"]     and $rtn["showProject_checked"]     = " checked";
-    $_FORM["showTags"]        and $rtn["showTags_checked"]        = " checked";
-    $_FORM["showParentID"]    and $rtn["showParentID_checked"]    = " checked";
+        $_FORM["showDescription"] and $rtn["showDescription_checked"] = " checked";
+        $_FORM["showDates"]       and $rtn["showDates_checked"]       = " checked";
+        $_FORM["showCreator"]     and $rtn["showCreator_checked"]     = " checked";
+        $_FORM["showAssigned"]    and $rtn["showAssigned_checked"]    = " checked";
+        $_FORM["showTimes"]       and $rtn["showTimes_checked"]       = " checked";
+        $_FORM["showPercent"]     and $rtn["showPercent_checked"]     = " checked";
+        $_FORM["showPriority"]    and $rtn["showPriority_checked"]    = " checked";
+        $_FORM["showTaskID"]      and $rtn["showTaskID_checked"]      = " checked";
+        $_FORM["showManager"]     and $rtn["showManager_checked"]     = " checked";
+        $_FORM["showProject"]     and $rtn["showProject_checked"]     = " checked";
+        $_FORM["showTags"]        and $rtn["showTags_checked"]        = " checked";
+        $_FORM["showParentID"]    and $rtn["showParentID_checked"]    = " checked";
     
-    $arrow = " --&gt;";
-    $taskDateOps = array(""                   => ""
+        $arrow = " --&gt;";
+        $taskDateOps = array(""                   => ""
                         ,"new"                => "New Tasks"
                         ,"due_today"          => "Due Today"
                         ,"overdue"            => "Overdue"
@@ -1346,14 +1390,14 @@ class task extends db_entity {
                         ,"d_actualStart"      => "Date Started".$arrow
                         ,"d_actualCompletion" => "Date Completed".$arrow
                         );
-    $rtn["taskDateOptions"] = page::select_options($taskDateOps, $_FORM["taskDate"], 45, false);
+        $rtn["taskDateOptions"] = page::select_options($taskDateOps, $_FORM["taskDate"], 45, false);
 
-    if (!in_array($_FORM["taskDate"],array("new","due_today","overdue"))) {
-      $rtn["dateOne"] = $_FORM["dateOne"];
-      $rtn["dateTwo"] = $_FORM["dateTwo"];
-    }
+        if (!in_array($_FORM["taskDate"], array("new","due_today","overdue"))) {
+            $rtn["dateOne"] = $_FORM["dateOne"];
+            $rtn["dateTwo"] = $_FORM["dateTwo"];
+        }
 
-    $task_num_ops = array("" => "All results"
+        $task_num_ops = array("" => "All results"
                          ,1     => "1 result"
                          ,2     => "2 results"
                          ,3     => "3 results"
@@ -1378,266 +1422,286 @@ class task extends db_entity {
                          ,5000  => "5000 results"
                          ,10000 => "10000 results"
                          );
-    $rtn["limitOptions"] = page::select_options($task_num_ops, $_FORM["limit"]);
+        $rtn["limitOptions"] = page::select_options($task_num_ops, $_FORM["limit"]);
 
 
-    // unset vars that aren't necessary
-    foreach ((array)$_FORM as $k => $v) {
-      if (!$v) {
-        unset($_FORM[$k]);
-      }
+      // unset vars that aren't necessary
+        foreach ((array)$_FORM as $k => $v) {
+            if (!$v) {
+                unset($_FORM[$k]);
+            }
+        }
+
+      // Get
+        $rtn["FORM"] = "FORM=".urlencode(serialize($_FORM));
+
+        return $rtn;
     }
 
-    // Get
-    $rtn["FORM"] = "FORM=".urlencode(serialize($_FORM));
+    function get_changes_list()
+    {
+      // This function returns HTML rows for the changes that have been made to this task
+        $rows = array();
 
-    return $rtn;
-  }
+        $people_cache =& get_cached_table("person");
 
-  function get_changes_list() {
-    // This function returns HTML rows for the changes that have been made to this task
-    $rows = array();
+        $options = array("taskID" => $this->get_id());
+        $changes = audit::get_list($options);
 
-    $people_cache =& get_cached_table("person");
+        foreach ($changes as $audit) {
+            $changeDescription = "";
+            $newValue = $audit['value'];
+            switch ($audit['field']) {
+                case 'created':
+                    $changeDescription = $newValue;
+                    break;
+                case 'dip':
+                    $changeDescription = "Default parties set to ".interestedParty::abbreviate($newValue);
+                    break;
+                case 'taskName':
+                    $changeDescription = "Task name set to '$newValue'.";
+                    break;
+                case 'taskDescription':
+                    $changeDescription = "Task description set to <a class=\"magic\" href=\"#x\" onclick=\"$('#audit" . $audit["auditID"] . "').slideToggle('fast');\">Show</a> <div class=\"hidden\" id=\"audit" . $audit["auditID"] . "\"><div>" .$newValue. "</div></div>";
+                    break;
+                case 'priority':
+                    $priorities = config::get_config_item("taskPriorities");
+                    $changeDescription = sprintf('Task priority set to <span style="color: %s;">%s</span>.', $priorities[$newValue]["colour"], $priorities[$newValue]["label"]);
+                    break;
+                case 'projectID':
+                    task::load_entity("project", $newValue, $newProject);
+                    is_object($newProject) and $newProjectLink = $newProject->get_project_link();
+                    $newProjectLink or $newProjectLink = "&lt;empty&gt;";
+                    $changeDescription = "Project changed set to ".$newProjectLink.".";
+                    break;
+                case 'parentTaskID':
+                    task::load_entity("task", $newValue, $newTask);
+                    if ($newValue) {
+                        $changeDescription = sprintf("Task set to a child of %d %s.", $newTask->get_id(), $newTask->get_task_link());
+                    } else {
+                        $changeDescription = "Task no longer a child task.";
+                    }
+                    break;
+                case 'duplicateTaskID':
+                    task::load_entity("task", $newValue, $newTask);
+                    if ($newValue) {
+                        $changeDescription = "Task set to a duplicate of " . $newTask->get_task_link();
+                    } else {
+                        $changeDescription = "Task is no longer a duplicate.";
+                    }
+                    break;
+                case 'personID':
+                    $changeDescription = "Task assigned to " . $people_cache[$newValue]["name"] . ".";
+                    break;
+                case 'managerID':
+                    $changeDescription = "Task manager set to " . $people_cache[$newValue]["name"] . ".";
+                    break;
+                case 'estimatorID':
+                    $changeDescription = "Task estimator set to " . $people_cache[$newValue]["name"] . ".";
+                    break;
+                case 'taskTypeID':
+                    $changeDescription = "Task type set to " . $newValue . ".";
+                    break;
+                case 'taskStatus':
+                    $changeDescription = sprintf(
+                        'Task status set to <span style="background-color:%s">%s</span>.',
+                        task::get_task_status_thing("colour", $newValue),
+                        task::get_task_status_thing("label", $newValue)
+                    );
+                    break;
+                case 'dateActualCompletion':
+                case 'dateActualStart':
+                case 'dateTargetStart':
+                case 'dateTargetCompletion':
+                case 'timeLimit':
+                case 'timeBest':
+                case 'timeWorst':
+                case 'timeExpected':
+                  // these cases are more or less identical
+                    switch ($audit['field']) {
+                        case 'dateActualCompletion':
+                            $fieldDesc = "actual completion date";
+                            break;
+                        case 'dateActualStart':
+                            $fieldDesc = "actual start date";
+                            break;
+                        case 'dateTargetStart':
+                            $fieldDesc = "estimate/target start date";
+                            break;
+                        case 'dateTargetCompletion':
+                                  $fieldDesc = "estimate/target completion date";
+                            break;
+                        case 'timeLimit':
+                                  $fieldDesc = "hours worked limit";
+                            break;
+                        case 'timeBest':
+                                  $fieldDesc = "best estimate";
+                            break;
+                        case 'timeWorst':
+                                  $fieldDesc = "worst estimate";
+                            break;
+                        case 'timeExpected':
+                                  $fieldDesc = "expected estimate";
+                    }
+                    if ($newValue) {
+                        $changeDescription = "The $fieldDesc was set to $newValue.";
+                    } else {
+                        $changeDescription = "The $fieldDesc was removed.";
+                    }
+                    break;
+            }
+            $rows[] = "<tr><td class=\"nobr\">" . $audit["dateChanged"] . "</td><td>$changeDescription</td><td>" . page::htmlentities($people_cache[$audit["personID"]]["name"]) . "</td></tr>";
+        }
 
-    $options = array("taskID" => $this->get_id());
-    $changes = audit::get_list($options);
-
-    foreach($changes as $audit) {
-      $changeDescription = "";
-      $newValue = $audit['value'];
-      switch($audit['field']) {
-        case 'created':
-          $changeDescription = $newValue;
-          break;
-        case 'dip':
-          $changeDescription = "Default parties set to ".interestedParty::abbreviate($newValue);
-          break;
-        case 'taskName':
-          $changeDescription = "Task name set to '$newValue'.";
-          break;
-        case 'taskDescription':
-          $changeDescription = "Task description set to <a class=\"magic\" href=\"#x\" onclick=\"$('#audit" . $audit["auditID"] . "').slideToggle('fast');\">Show</a> <div class=\"hidden\" id=\"audit" . $audit["auditID"] . "\"><div>" .$newValue. "</div></div>";
-          break;
-        case 'priority':
-          $priorities = config::get_config_item("taskPriorities");
-          $changeDescription = sprintf('Task priority set to <span style="color: %s;">%s</span>.', $priorities[$newValue]["colour"], $priorities[$newValue]["label"]);
-        break;
-        case 'projectID':
-          task::load_entity("project", $newValue, $newProject);
-          is_object($newProject) and $newProjectLink = $newProject->get_project_link();
-          $newProjectLink or $newProjectLink = "&lt;empty&gt;";
-          $changeDescription = "Project changed set to ".$newProjectLink.".";
-        break;
-        case 'parentTaskID':
-          task::load_entity("task", $newValue, $newTask);
-          if ($newValue) {
-            $changeDescription = sprintf("Task set to a child of %d %s.", $newTask->get_id(), $newTask->get_task_link());
-          } else {
-            $changeDescription = "Task no longer a child task.";
-          }
-        break;
-        case 'duplicateTaskID':
-          task::load_entity("task", $newValue, $newTask);
-          if($newValue) {
-            $changeDescription = "Task set to a duplicate of " . $newTask->get_task_link();
-          } else {
-            $changeDescription = "Task is no longer a duplicate.";
-          }
-        break;
-        case 'personID':
-          $changeDescription = "Task assigned to " . $people_cache[$newValue]["name"] . ".";
-        break;
-        case 'managerID':
-          $changeDescription = "Task manager set to " . $people_cache[$newValue]["name"] . ".";
-        break;
-        case 'estimatorID':
-          $changeDescription = "Task estimator set to " . $people_cache[$newValue]["name"] . ".";
-        break;
-        case 'taskTypeID':
-          $changeDescription = "Task type set to " . $newValue . ".";
-        break;
-        case 'taskStatus':
-          $changeDescription = sprintf('Task status set to <span style="background-color:%s">%s</span>.'
-                                      ,task::get_task_status_thing("colour",$newValue)
-                                      ,task::get_task_status_thing("label",$newValue)
-                                      );
-        break;
-        case 'dateActualCompletion':
-        case 'dateActualStart':
-        case 'dateTargetStart':
-        case 'dateTargetCompletion':
-        case 'timeLimit':
-        case 'timeBest':
-        case 'timeWorst':
-        case 'timeExpected':
-          // these cases are more or less identical
-          switch($audit['field']) {
-            case 'dateActualCompletion': $fieldDesc = "actual completion date"; break;
-            case 'dateActualStart': $fieldDesc = "actual start date"; break;
-            case 'dateTargetStart': $fieldDesc = "estimate/target start date"; break;
-            case 'dateTargetCompletion': $fieldDesc = "estimate/target completion date"; break;
-            case 'timeLimit': $fieldDesc = "hours worked limit"; break;
-            case 'timeBest': $fieldDesc = "best estimate"; break;
-            case 'timeWorst': $fieldDesc = "worst estimate"; break;
-            case 'timeExpected': $fieldDesc = "expected estimate";
-          }
-          if($newValue) {
-            $changeDescription = "The $fieldDesc was set to $newValue.";
-          } else {
-            $changeDescription = "The $fieldDesc was removed.";
-          }
-        break;
-      }
-      $rows[] = "<tr><td class=\"nobr\">" . $audit["dateChanged"] . "</td><td>$changeDescription</td><td>" . page::htmlentities($people_cache[$audit["personID"]]["name"]) . "</td></tr>";
+        return implode("\n", $rows);
     }
 
-    return implode("\n", $rows);
-  }
-
-  function load_entity($type, $id, &$entity) {
-    // helper function to cut down on code duplication in the above function
-    if($id) {
-      $entity = new $type;
-      $entity->set_id($id);
-      $entity->select();
-    }
-  }
-
-  function update_search_index_doc(&$index) {
-    $p =& get_cached_table("person");
-    $creatorID = $this->get_value("creatorID");
-    $creator_field = $creatorID." ".$p[$creatorID]["username"]." ".$p[$creatorID]["name"];
-    $closerID = $this->get_value("closerID");
-    $closer_field = $closerID." ".$p[$closerID]["username"]." ".$p[$closerID]["name"];
-    $personID = $this->get_value("personID");
-    $person_field = $personID." ".$p[$personID]["username"]." ".$p[$personID]["name"];
-    $managerID = $this->get_value("managerID");
-    $manager_field = $managerID." ".$p[$managerID]["username"]." ".$p[$managerID]["name"];
-    $taskModifiedUser = $this->get_value("taskModifiedUser");
-    $taskModifiedUser_field = $taskModifiedUser." ".$p[$taskModifiedUser]["username"]." ".$p[$taskModifiedUser]["name"];
-    $status = $this->get_value("taskStatus");
-
-    if ($this->get_value("projectID")) {
-      $project = new project();
-      $project->set_id($this->get_value("projectID"));
-      $project->select();
-      $projectName = $project->get_name();
-      $projectShortName = $project->get_name(array("showShortProjectLink"=>true));
-      $projectShortName && $projectShortName != $projectName and $projectName.= " ".$projectShortName;
+    function load_entity($type, $id, &$entity)
+    {
+      // helper function to cut down on code duplication in the above function
+        if ($id) {
+            $entity = new $type;
+            $entity->set_id($id);
+            $entity->select();
+        }
     }
 
-    $doc = new Zend_Search_Lucene_Document();
-    $doc->addField(Zend_Search_Lucene_Field::Keyword('id'   ,$this->get_id()));
-    $doc->addField(Zend_Search_Lucene_Field::Text('name'    ,$this->get_value("taskName"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('project' ,$projectName,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('pid'     ,$this->get_value("projectID"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('creator' ,$creator_field,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('closer'  ,$closer_field,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('assignee',$person_field,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('manager' ,$manager_field,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('modifier',$taskModifiedUser_field,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('desc'    ,$this->get_value("taskDescription"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('priority',$this->get_value("priority"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('limit'   ,$this->get_value("timeLimit"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('best'    ,$this->get_value("timeBest"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('worst'   ,$this->get_value("timeWorst"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('expected',$this->get_value("timeExpected"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('type',$this->get_value("taskTypeID"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('status',$status,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateCreated',str_replace("-","",$this->get_value("dateCreated")),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateAssigned',str_replace("-","",$this->get_value("dateAssigned")),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateClosed',str_replace("-","",$this->get_value("dateClosed")),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateTargetStart',str_replace("-","",$this->get_value("dateTargetStart")),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateTargetCompletion',str_replace("-","",$this->get_value("dateTargetCompletion")),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateStart',str_replace("-","",$this->get_value("dateActualStart")),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateCompletion',str_replace("-","",$this->get_value("dateActualCompletion")),"utf-8"));
-    $index->addDocument($doc);
-  }
+    function update_search_index_doc(&$index)
+    {
+        $p =& get_cached_table("person");
+        $creatorID = $this->get_value("creatorID");
+        $creator_field = $creatorID." ".$p[$creatorID]["username"]." ".$p[$creatorID]["name"];
+        $closerID = $this->get_value("closerID");
+        $closer_field = $closerID." ".$p[$closerID]["username"]." ".$p[$closerID]["name"];
+        $personID = $this->get_value("personID");
+        $person_field = $personID." ".$p[$personID]["username"]." ".$p[$personID]["name"];
+        $managerID = $this->get_value("managerID");
+        $manager_field = $managerID." ".$p[$managerID]["username"]." ".$p[$managerID]["name"];
+        $taskModifiedUser = $this->get_value("taskModifiedUser");
+        $taskModifiedUser_field = $taskModifiedUser." ".$p[$taskModifiedUser]["username"]." ".$p[$taskModifiedUser]["name"];
+        $status = $this->get_value("taskStatus");
 
-  function add_comment_from_email($email_receive,$ignorethis) {
-    return comment::add_comment_from_email($email_receive,$this);
-  }
+        if ($this->get_value("projectID")) {
+            $project = new project();
+            $project->set_id($this->get_value("projectID"));
+            $project->select();
+            $projectName = $project->get_name();
+            $projectShortName = $project->get_name(array("showShortProjectLink"=>true));
+            $projectShortName && $projectShortName != $projectName and $projectName.= " ".$projectShortName;
+        }
 
-  function get_project_id() {
-    return $this->get_value("projectID");
-  }
-
-  function can_be_deleted() {
-    if (is_object($this) && $this->get_id()) {
-      $db = new db_alloc();
-      $q = prepare("SELECT can_delete_task(%d) as rtn",$this->get_id());
-      $db->query($q);
-      $row = $db->row();
-      return $row['rtn'];
+        $doc = new Zend_Search_Lucene_Document();
+        $doc->addField(Zend_Search_Lucene_Field::Keyword('id', $this->get_id()));
+        $doc->addField(Zend_Search_Lucene_Field::Text('name', $this->get_value("taskName"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('project', $projectName, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('pid', $this->get_value("projectID"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('creator', $creator_field, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('closer', $closer_field, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('assignee', $person_field, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('manager', $manager_field, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('modifier', $taskModifiedUser_field, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('desc', $this->get_value("taskDescription"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('priority', $this->get_value("priority"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('limit', $this->get_value("timeLimit"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('best', $this->get_value("timeBest"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('worst', $this->get_value("timeWorst"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('expected', $this->get_value("timeExpected"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('type', $this->get_value("taskTypeID"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('status', $status, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateCreated', str_replace("-", "", $this->get_value("dateCreated")), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateAssigned', str_replace("-", "", $this->get_value("dateAssigned")), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateClosed', str_replace("-", "", $this->get_value("dateClosed")), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateTargetStart', str_replace("-", "", $this->get_value("dateTargetStart")), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateTargetCompletion', str_replace("-", "", $this->get_value("dateTargetCompletion")), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateStart', str_replace("-", "", $this->get_value("dateActualStart")), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateCompletion', str_replace("-", "", $this->get_value("dateActualCompletion")), "utf-8"));
+        $index->addDocument($doc);
     }
-  }
 
-  function moved_from_pending_to_open() {
-    if (is_object($this) && $this->get_id()) {
-      $this->select();
-      if (substr($this->get_value("taskStatus"),0,4) == 'open') {
-        $db = new db_alloc();
-        $q = prepare("SELECT *
+    function add_comment_from_email($email_receive, $ignorethis)
+    {
+        return comment::add_comment_from_email($email_receive, $this);
+    }
+
+    function get_project_id()
+    {
+        return $this->get_value("projectID");
+    }
+
+    function can_be_deleted()
+    {
+        if (is_object($this) && $this->get_id()) {
+            $db = new db_alloc();
+            $q = prepare("SELECT can_delete_task(%d) as rtn", $this->get_id());
+            $db->query($q);
+            $row = $db->row();
+            return $row['rtn'];
+        }
+    }
+
+    function moved_from_pending_to_open()
+    {
+        if (is_object($this) && $this->get_id()) {
+            $this->select();
+            if (substr($this->get_value("taskStatus"), 0, 4) == 'open') {
+                $db = new db_alloc();
+                $q = prepare("SELECT *
                         FROM audit
                        WHERE taskID = %d
                          AND field = 'taskStatus'
                     ORDER BY dateChanged DESC
-                       LIMIT 2,1",$this->get_id());
-        $row = $db->qr($q);
-        return substr($row["value"],0,7) == "pending";
-      }
-    }
-  }
-
-  function reopen_pending_task() {
-    if (is_object($this) && $this->get_id()) {
-      $this->select();
-      if (substr($this->get_value("taskStatus"),0,4) == 'pend') {
-        $db = new db_alloc();
-        $db->query("call change_task_status(%d,'%s')",$this->get_id(),"open_inprogress");
-        return true;
-      }
-    }
-  }
-
-  function add_notification($tokenActionID,$maxUsed,$name,$desc,$recipients,$datetime=false) {
-    $current_user = &singleton("current_user");
-    $token = new token();
-    $token->set_value("tokenEntity","task");
-    $token->set_value("tokenEntityID",$this->get_id());
-    $token->set_value("tokenActionID",$tokenActionID);
-    $token->set_value("tokenActive",1);
-    $token->set_value("tokenMaxUsed",$maxUsed);
-    $token->set_value("tokenCreatedBy",$current_user->get_id());
-    $token->set_value("tokenCreatedDate",date("Y-m-d H:i:s"));
-    $hash = $token->generate_hash();
-    $token->set_value("tokenHash",$hash);
-    $token->save();
-    if ($token->get_id()) {
-      $reminder = new reminder();
-      $reminder->set_value("reminderType","task");
-      $reminder->set_value("reminderLinkID",$this->get_id());
-      $reminder->set_value("reminderHash",$hash);
-      $reminder->set_value("reminderSubject",$name);
-      $reminder->set_value("reminderContent",$desc);
-      if ($datetime) {
-        $reminder->set_value("reminderTime",$datetime);
-      } 
-      $reminder->save();
-      if ($reminder->get_id()) {
-        foreach ($recipients as $row) {
-          $reminderRecipient = new reminderRecipient();
-          $reminderRecipient->set_value("reminderID",$reminder->get_id());
-          $reminderRecipient->set_value($row["field"],$row["who"]);
-          $reminderRecipient->save();
+                       LIMIT 2,1", $this->get_id());
+                $row = $db->qr($q);
+                return substr($row["value"], 0, 7) == "pending";
+            }
         }
-      }
     }
-  }
 
+    function reopen_pending_task()
+    {
+        if (is_object($this) && $this->get_id()) {
+            $this->select();
+            if (substr($this->get_value("taskStatus"), 0, 4) == 'pend') {
+                $db = new db_alloc();
+                $db->query("call change_task_status(%d,'%s')", $this->get_id(), "open_inprogress");
+                return true;
+            }
+        }
+    }
 
+    function add_notification($tokenActionID, $maxUsed, $name, $desc, $recipients, $datetime = false)
+    {
+        $current_user = &singleton("current_user");
+        $token = new token();
+        $token->set_value("tokenEntity", "task");
+        $token->set_value("tokenEntityID", $this->get_id());
+        $token->set_value("tokenActionID", $tokenActionID);
+        $token->set_value("tokenActive", 1);
+        $token->set_value("tokenMaxUsed", $maxUsed);
+        $token->set_value("tokenCreatedBy", $current_user->get_id());
+        $token->set_value("tokenCreatedDate", date("Y-m-d H:i:s"));
+        $hash = $token->generate_hash();
+        $token->set_value("tokenHash", $hash);
+        $token->save();
+        if ($token->get_id()) {
+            $reminder = new reminder();
+            $reminder->set_value("reminderType", "task");
+            $reminder->set_value("reminderLinkID", $this->get_id());
+            $reminder->set_value("reminderHash", $hash);
+            $reminder->set_value("reminderSubject", $name);
+            $reminder->set_value("reminderContent", $desc);
+            if ($datetime) {
+                $reminder->set_value("reminderTime", $datetime);
+            }
+            $reminder->save();
+            if ($reminder->get_id()) {
+                foreach ($recipients as $row) {
+                    $reminderRecipient = new reminderRecipient();
+                    $reminderRecipient->set_value("reminderID", $reminder->get_id());
+                    $reminderRecipient->set_value($row["field"], $row["who"]);
+                    $reminderRecipient->save();
+                }
+            }
+        }
+    }
 }
-
-
-?>

--- a/task/lib/taskListPrint.inc.php
+++ b/task/lib/taskListPrint.inc.php
@@ -3,152 +3,149 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("DEFAULT_SEP","\n");
+define("DEFAULT_SEP", "\n");
 
-class taskListPrint {
+class taskListPrint
+{
 
-  function get_printable_file($_FORM=array()) {
-    global $TPL;
+    function get_printable_file($_FORM = array())
+    {
+        global $TPL;
   
-    $db = new db_alloc();
+        $db = new db_alloc();
 
-    $TPL["companyName"] = config::get_config_item("companyName");
-    $TPL["companyNos1"] = config::get_config_item("companyACN");
-    $TPL["companyNos2"] = config::get_config_item("companyABN");
-    $TPL["img"] = config::get_config_item("companyImage");
-    $TPL["companyContactAddress"] = config::get_config_item("companyContactAddress");
-    $TPL["companyContactAddress2"] = config::get_config_item("companyContactAddress2");
-    $TPL["companyContactAddress3"] = config::get_config_item("companyContactAddress3");
-    $email = config::get_config_item("companyContactEmail");
-    $email and $TPL["companyContactEmail"] = "Email: ".$email;
-    $web = config::get_config_item("companyContactHomePage");
-    $web and $TPL["companyContactHomePage"] = "Web: ".$web;
-    $phone = config::get_config_item("companyContactPhone");
-    $fax = config::get_config_item("companyContactFax");
-    $phone and $TPL["phone"] = "Ph: ".$phone;
-    $fax and $TPL["fax"] = "Fax: ".$fax;
+        $TPL["companyName"] = config::get_config_item("companyName");
+        $TPL["companyNos1"] = config::get_config_item("companyACN");
+        $TPL["companyNos2"] = config::get_config_item("companyABN");
+        $TPL["img"] = config::get_config_item("companyImage");
+        $TPL["companyContactAddress"] = config::get_config_item("companyContactAddress");
+        $TPL["companyContactAddress2"] = config::get_config_item("companyContactAddress2");
+        $TPL["companyContactAddress3"] = config::get_config_item("companyContactAddress3");
+        $email = config::get_config_item("companyContactEmail");
+        $email and $TPL["companyContactEmail"] = "Email: ".$email;
+        $web = config::get_config_item("companyContactHomePage");
+        $web and $TPL["companyContactHomePage"] = "Web: ".$web;
+        $phone = config::get_config_item("companyContactPhone");
+        $fax = config::get_config_item("companyContactFax");
+        $phone and $TPL["phone"] = "Ph: ".$phone;
+        $fax and $TPL["fax"] = "Fax: ".$fax;
 
 
-    $taskPriorities = config::get_config_item("taskPriorities");
-    $projectPriorities = config::get_config_item("projectPriorities");
+        $taskPriorities = config::get_config_item("taskPriorities");
+        $projectPriorities = config::get_config_item("projectPriorities");
 
-    // Add requested fields to pdf
-    $_FORM["showEdit"] = false;
+      // Add requested fields to pdf
+        $_FORM["showEdit"] = false;
                                   $fields["taskID"]               = "ID";
                                   $fields["taskName"]             = "Task";
-    $_FORM["showProject"]     and $fields["projectName"]          = "Project";
-    $_FORM["showPriority"] || $_FORM["showPriorityFactor"]
+        $_FORM["showProject"]     and $fields["projectName"]          = "Project";
+        $_FORM["showPriority"] || $_FORM["showPriorityFactor"]
                               and $fields["priorityFactor"]       = "Pri";
-    $_FORM["showPriority"]    and $fields["taskPriority"]         = "Task Pri";
-    $_FORM["showPriority"]    and $fields["projectPriority"]      = "Proj Pri";
-    $_FORM["showCreator"]     and $fields["creator_name"]         = "Creator";
-    $_FORM["showManager"]     and $fields["manager_name"]         = "Manager";
-    $_FORM["showAssigned"]    and $fields["assignee_name"]        = "Assigned To";
-    $_FORM["showDate1"]       and $fields["dateTargetStart"]      = "Targ Start";
-    $_FORM["showDate2"]       and $fields["dateTargetCompletion"] = "Targ Compl";
-    $_FORM["showDate3"]       and $fields["dateActualStart"]      = "Start";
-    $_FORM["showDate4"]       and $fields["dateActualCompletion"] = "Compl";
-    $_FORM["showDate5"]       and $fields["dateCreated"]          = "Created";
-    $_FORM["showTimes"]       and $fields["timeBestLabel"]        = "Best";
-    $_FORM["showTimes"]       and $fields["timeExpectedLabel"]    = "Likely";
-    $_FORM["showTimes"]       and $fields["timeWorstLabel"]       = "Worst";
-    $_FORM["showTimes"]       and $fields["timeActualLabel"]      = "Actual";
-    $_FORM["showTimes"]       and $fields["timeLimitLabel"]       = "Limit"; 
-    $_FORM["showPercent"]     and $fields["percentComplete"]      = "%";
-    $_FORM["showStatus"]      and $fields["taskStatusLabel"]      = "Status";
+        $_FORM["showPriority"]    and $fields["taskPriority"]         = "Task Pri";
+        $_FORM["showPriority"]    and $fields["projectPriority"]      = "Proj Pri";
+        $_FORM["showCreator"]     and $fields["creator_name"]         = "Creator";
+        $_FORM["showManager"]     and $fields["manager_name"]         = "Manager";
+        $_FORM["showAssigned"]    and $fields["assignee_name"]        = "Assigned To";
+        $_FORM["showDate1"]       and $fields["dateTargetStart"]      = "Targ Start";
+        $_FORM["showDate2"]       and $fields["dateTargetCompletion"] = "Targ Compl";
+        $_FORM["showDate3"]       and $fields["dateActualStart"]      = "Start";
+        $_FORM["showDate4"]       and $fields["dateActualCompletion"] = "Compl";
+        $_FORM["showDate5"]       and $fields["dateCreated"]          = "Created";
+        $_FORM["showTimes"]       and $fields["timeBestLabel"]        = "Best";
+        $_FORM["showTimes"]       and $fields["timeExpectedLabel"]    = "Likely";
+        $_FORM["showTimes"]       and $fields["timeWorstLabel"]       = "Worst";
+        $_FORM["showTimes"]       and $fields["timeActualLabel"]      = "Actual";
+        $_FORM["showTimes"]       and $fields["timeLimitLabel"]       = "Limit";
+        $_FORM["showPercent"]     and $fields["percentComplete"]      = "%";
+        $_FORM["showStatus"]      and $fields["taskStatusLabel"]      = "Status";
 
-    $rows = task::get_list($_FORM);
-    $taskListRows = array();
-    foreach ((array)$rows as $row) {
-      $row["taskPriority"] = $taskPriorities[$row["priority"]]["label"];
-      $row["projectPriority"] = $projectPriorities[$row["projectPriority"]]["label"];
-      $row["taskDateStatus"] = strip_tags($row["taskDateStatus"]);
-      $row["percentComplete"] = strip_tags($row["percentComplete"]);
-      $taskListRows[] = $row;
-    }
+        $rows = task::get_list($_FORM);
+        $taskListRows = array();
+        foreach ((array)$rows as $row) {
+            $row["taskPriority"] = $taskPriorities[$row["priority"]]["label"];
+            $row["projectPriority"] = $projectPriorities[$row["projectPriority"]]["label"];
+            $row["taskDateStatus"] = strip_tags($row["taskDateStatus"]);
+            $row["percentComplete"] = strip_tags($row["percentComplete"]);
+            $taskListRows[] = $row;
+        }
 
 
-    if ($_FORM["format"] != "html" && $_FORM["format"] != "html_plus") {
+        if ($_FORM["format"] != "html" && $_FORM["format"] != "html_plus") {
+          // Build PDF document
+            $font1 = ALLOC_MOD_DIR."util/fonts/Helvetica.afm";
+            $font2 = ALLOC_MOD_DIR."util/fonts/Helvetica-Oblique.afm";
 
-      // Build PDF document
-      $font1 = ALLOC_MOD_DIR."util/fonts/Helvetica.afm";
-      $font2 = ALLOC_MOD_DIR."util/fonts/Helvetica-Oblique.afm";
-
-      $pdf_table_options = array("showLines"=>0,"shaded"=>0,"showHeadings"=>0,"xPos"=>"left"
+            $pdf_table_options = array("showLines"=>0,"shaded"=>0,"showHeadings"=>0,"xPos"=>"left"
                                 ,"xOrientation"=>"right","fontSize"=>10,"rowGap"=>0,"fontSize"=>10);
-      $pdf_table_options3 = array("showLines"=>2,"shaded"=>0,"width"=>750, "xPos"=>"center","fontSize"=>10
+            $pdf_table_options3 = array("showLines"=>2,"shaded"=>0,"width"=>750, "xPos"=>"center","fontSize"=>10
                                  ,"lineCol"=>array(0.8, 0.8, 0.8),"splitRows"=>1,"protectRows"=>0);
 
-      $pdf = new Cezpdf(null,'landscape');
-      $pdf->ezSetMargins(40,40,40,40);
-      $pdf->selectFont($font1);
-      $pdf->ezStartPageNumbers(436,30,10,'center','Page {PAGENUM} of {TOTALPAGENUM}');
-      $pdf->ezSetY(560);
+            $pdf = new Cezpdf(null, 'landscape');
+            $pdf->ezSetMargins(40, 40, 40, 40);
+            $pdf->selectFont($font1);
+            $pdf->ezStartPageNumbers(436, 30, 10, 'center', 'Page {PAGENUM} of {TOTALPAGENUM}');
+            $pdf->ezSetY(560);
 
-      $TPL["companyContactAddress"]  and $contact_info[] = array($TPL["companyContactAddress"]);
-      $TPL["companyContactAddress2"] and $contact_info[] = array($TPL["companyContactAddress2"]);
-      $TPL["companyContactAddress3"] and $contact_info[] = array($TPL["companyContactAddress3"]);
-      $TPL["companyContactEmail"]    and $contact_info[] = array($TPL["companyContactEmail"]);
-      $TPL["companyContactHomePage"] and $contact_info[] = array($TPL["companyContactHomePage"]);
-      $TPL["phone"]                  and $contact_info[] = array($TPL["phone"]);
-      $TPL["fax"]                    and $contact_info[] = array($TPL["fax"]);
+            $TPL["companyContactAddress"]  and $contact_info[] = array($TPL["companyContactAddress"]);
+            $TPL["companyContactAddress2"] and $contact_info[] = array($TPL["companyContactAddress2"]);
+            $TPL["companyContactAddress3"] and $contact_info[] = array($TPL["companyContactAddress3"]);
+            $TPL["companyContactEmail"]    and $contact_info[] = array($TPL["companyContactEmail"]);
+            $TPL["companyContactHomePage"] and $contact_info[] = array($TPL["companyContactHomePage"]);
+            $TPL["phone"]                  and $contact_info[] = array($TPL["phone"]);
+            $TPL["fax"]                    and $contact_info[] = array($TPL["fax"]);
 
-      $pdf->selectFont($font2);
-      $y = $pdf->ezTable($contact_info,false,"",$pdf_table_options);
-      $pdf->selectFont($font1);
+            $pdf->selectFont($font2);
+            $y = $pdf->ezTable($contact_info, false, "", $pdf_table_options);
+            $pdf->selectFont($font1);
 
-      $line_y = $y-10;
-      $pdf->setLineStyle(1,"round");
-      $pdf->line(40,$line_y,801,$line_y);
+            $line_y = $y-10;
+            $pdf->setLineStyle(1, "round");
+            $pdf->line(40, $line_y, 801, $line_y);
 
-      $pdf->ezSetY(570);
+            $pdf->ezSetY(570);
 
-      $image_jpg = ALLOC_LOGO;
-      if (file_exists($image_jpg)) {
-        $pdf->ezImage($image_jpg,0,sprintf("%d",config::get_config_item("logoScaleX")),'none');
-        $y = 700;
-      } else {
-        $y = $pdf->ezText($TPL["companyName"],27,array("justification"=>"right"));
-      }
-      $nos_y = $line_y + 22;
-      $TPL["companyNos2"] and $nos_y = $line_y + 34;
-      $pdf->ezSetY($nos_y);
-      $TPL["companyNos1"] and $y = $pdf->ezText($TPL["companyNos1"],10, array("justification"=>"right"));
-      $TPL["companyNos2"] and $y = $pdf->ezText($TPL["companyNos2"],10, array("justification"=>"right"));
+            $image_jpg = ALLOC_LOGO;
+            if (file_exists($image_jpg)) {
+                  $pdf->ezImage($image_jpg, 0, sprintf("%d", config::get_config_item("logoScaleX")), 'none');
+                  $y = 700;
+            } else {
+                $y = $pdf->ezText($TPL["companyName"], 27, array("justification"=>"right"));
+            }
+            $nos_y = $line_y + 22;
+            $TPL["companyNos2"] and $nos_y = $line_y + 34;
+            $pdf->ezSetY($nos_y);
+            $TPL["companyNos1"] and $y = $pdf->ezText($TPL["companyNos1"], 10, array("justification"=>"right"));
+            $TPL["companyNos2"] and $y = $pdf->ezText($TPL["companyNos2"], 10, array("justification"=>"right"));
 
-      $pdf->ezSetY($line_y -10);
-      $y = $pdf->ezText("Task List",20,array("justification"=>"center"));
-      $pdf->ezSetY($y -20);
+            $pdf->ezSetY($line_y -10);
+            $y = $pdf->ezText("Task List", 20, array("justification"=>"center"));
+            $pdf->ezSetY($y -20);
 
-      $y = $pdf->ezTable($taskListRows,$fields,"",$pdf_table_options3);
+            $y = $pdf->ezTable($taskListRows, $fields, "", $pdf_table_options3);
 
-      $pdf->ezSetY($y -20);
-      $pdf->ezStream();
+            $pdf->ezSetY($y -20);
+            $pdf->ezStream();
 
-    // Else HTML format
-    } else {
-      echo task::get_list_html($taskListRows,$_FORM);
+        // Else HTML format
+        } else {
+            echo task::get_list_html($taskListRows, $_FORM);
+        }
     }
-
-  }
-
 }
-
-?>

--- a/task/lib/task_list_home_item.inc.php
+++ b/task/lib/task_list_home_item.inc.php
@@ -3,47 +3,51 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class task_list_home_item extends home_item {
-  var $date;
+class task_list_home_item extends home_item
+{
+    var $date;
 
-  function __construct() {
-    $this->has_config = true;
-    parent::__construct("top_ten_tasks", "Tasks", "task", "taskListH.tpl","standard",20);
-  }
-
-  function visible() {
-    $current_user = &singleton("current_user");
-
-    if (!isset($current_user->prefs["showTaskListHome"])) {
-      $current_user->prefs["showTaskListHome"] = 1;
+    function __construct()
+    {
+        $this->has_config = true;
+        parent::__construct("top_ten_tasks", "Tasks", "task", "taskListH.tpl", "standard", 20);
     }
 
-    if ($current_user->prefs["showTaskListHome"]) {
-      return true;
+    function visible()
+    {
+        $current_user = &singleton("current_user");
+
+        if (!isset($current_user->prefs["showTaskListHome"])) {
+            $current_user->prefs["showTaskListHome"] = 1;
+        }
+
+        if ($current_user->prefs["showTaskListHome"]) {
+            return true;
+        }
     }
-  }
 
-  function render() {
-    global $TPL;
+    function render()
+    {
+        global $TPL;
 
-    $defaults = array("showHeader"=>true
+        $defaults = array("showHeader"=>true
                      ,"showTaskID"=>true
                      ,"taskView" => "prioritised"
                      ,"showStatus" => "true"
@@ -51,24 +55,20 @@ class task_list_home_item extends home_item {
                      ,"form_name"=>"taskListHome_filter"
                      );
 
-    $current_user = &singleton("current_user");
-    if (!$current_user->prefs["taskListHome_filter"]) {
-      $defaults["taskStatus"] = "open"; 
-      $defaults["personID"] = $current_user->get_id(); 
-      $defaults["showStatus"] = true;
-      $defaults["showProject"] = true;
-      $defaults["limit"] = 10;
-      $defaults["applyFilter"] = true;
+        $current_user = &singleton("current_user");
+        if (!$current_user->prefs["taskListHome_filter"]) {
+            $defaults["taskStatus"] = "open";
+            $defaults["personID"] = $current_user->get_id();
+            $defaults["showStatus"] = true;
+            $defaults["showProject"] = true;
+            $defaults["limit"] = 10;
+            $defaults["applyFilter"] = true;
+        }
+
+        $_FORM = task::load_form_data($defaults);
+        $TPL["taskListRows"] = task::get_list($_FORM);
+        $TPL["_FORM"] = $_FORM;
+
+        return true;
     }
-
-    $_FORM = task::load_form_data($defaults);
-    $TPL["taskListRows"] = task::get_list($_FORM);
-    $TPL["_FORM"] = $_FORM;
-
-    return true;
-  }
 }
-
-
-
-?>

--- a/task/lib/task_message_list_home_item.inc.php
+++ b/task/lib/task_message_list_home_item.inc.php
@@ -3,63 +3,64 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class task_message_list_home_item extends home_item {
-  var $date;
+class task_message_list_home_item extends home_item
+{
+    var $date;
 
-  function __construct() {
-    parent::__construct("task_message_list_home_item", "Messages For You", "task", "taskMessageListH.tpl", "narrow", 19);
-  }
+    function __construct()
+    {
+        parent::__construct("task_message_list_home_item", "Messages For You", "task", "taskMessageListH.tpl", "narrow", 19);
+    }
 
-  function visible() {
-    $current_user = &singleton("current_user");
-    return $current_user->has_messages();
-  }
+    function visible()
+    {
+        $current_user = &singleton("current_user");
+        return $current_user->has_messages();
+    }
 
-  function render() {
-    return true;
-  } 
+    function render()
+    {
+        return true;
+    }
 
-  function show_tasks() {
-    $current_user = &singleton("current_user");
-    global $tasks_date;
+    function show_tasks()
+    {
+        $current_user = &singleton("current_user");
+        global $tasks_date;
     
-    list($ts_open,$ts_pending,$ts_closed) = task::get_task_status_in_set_sql();
-    $q = prepare("SELECT * 
+        list($ts_open,$ts_pending,$ts_closed) = task::get_task_status_in_set_sql();
+        $q = prepare("SELECT * 
                   FROM task 
                   WHERE (task.taskStatus NOT IN (".$ts_closed.") AND task.taskTypeID = 'Message') 
                   AND (personID = %d) 
                   ORDER BY priority
-                 ",$current_user->get_id());
+                 ", $current_user->get_id());
 
-    $db = new db_alloc();
-    $db->query($q);
+        $db = new db_alloc();
+        $db->query($q);
 
-    while ($db->next_record()) {
-      $task = new task();
-      $task->read_db_record($db);
-      echo $br.$task->get_task_image().$task->get_task_link(array("return"=>"html"));
-      $br = "<br>";
+        while ($db->next_record()) {
+            $task = new task();
+            $task->read_db_record($db);
+            echo $br.$task->get_task_image().$task->get_task_link(array("return"=>"html"));
+            $br = "<br>";
+        }
     }
-  }
 }
-
-
-
-?>

--- a/task/rss.php
+++ b/task/rss.php
@@ -11,20 +11,22 @@ $show_project = config::get_config_item('rssShowProject');
 $db = new db_alloc();
 $events = array();
 
-//create an artifical sort key. Creation/audit date is not unique, and creation should 
+//create an artifical sort key. Creation/audit date is not unique, and creation should
 //come before any status changes.
-function gen_key($prefix = 0) {
-  static $subidx = 0;
+function gen_key($prefix = 0)
+{
+    static $subidx = 0;
   //this falls apart if the feed runs to more than 9999 items
-  return '!' . $prefix . sprintf("%04d", $subidx++);
+    return '!' . $prefix . sprintf("%04d", $subidx++);
 }
 
-// a single '&' can't be inserted into the XML stream because it's used to 
-// create a character (&amp;, &lt;, etc). SimpleXML doesn't escape it, probably 
-// for that reason. There should be no HTML in task titles so this should be 
+// a single '&' can't be inserted into the XML stream because it's used to
+// create a character (&amp;, &lt;, etc). SimpleXML doesn't escape it, probably
+// for that reason. There should be no HTML in task titles so this should be
 // safe.
-function escape_xml($string) {
-  return str_replace('&', '&amp;', $string);
+function escape_xml($string)
+{
+    return str_replace('&', '&amp;', $string);
 }
 
 
@@ -48,49 +50,49 @@ $query = prepare("SELECT audit.taskID, field, dateChanged, value, taskName, task
                    LIMIT %d", $max_events);
 $db->query($query);
 while ($row = $db->next_record()) {
-  $key = $row['dateChanged'] . gen_key(1);
-  $el = array("date" => $row['dateChanged']);
+    $key = $row['dateChanged'] . gen_key(1);
+    $el = array("date" => $row['dateChanged']);
 
   //overwrite the new data (taskStatus, personID) with the correct (historical) data
-  if ($trace[$row['taskID']]) {
-    $row = array_merge($row, $trace[$row['taskID']]);
-  }
+    if ($trace[$row['taskID']]) {
+        $row = array_merge($row, $trace[$row['taskID']]);
+    }
   
-  if (!$row['personID']) {
-    $name = "Unassigned";
-  } else {
-    $name = $people[$row['personID']]['username'];
-  }
-
-  if ($row['field'] != "taskStatus" || array_search($row['taskStatus'], $status_types) !== FALSE) {
-    $taskName = escape_xml($row['taskName']);
-    $project = null;
-    if ($show_project) {
-      $project = new project();
-      $project->set_id($row['projectID']);
-      $project->select();
-    }
-    if ($summary) {
-      if ($show_project) {
-        $projectName = $project->get_value('projectShortName');
-      }
-      $el['desc'] = sprintf('%s: %d %s "%s" %s', $name, $row['taskID'], $projectName, $taskName, $row['taskStatus']);
+    if (!$row['personID']) {
+        $name = "Unassigned";
     } else {
-      if ($show_project) {
-        $projectName = "(".$project->get_value("projectName").")";
-      }
-      if ($row['field'] == "taskStatus") {
-        $el['desc'] = sprintf('Task #%d "%s" %s status changed to %s', $row['taskID'], $taskName, $projectName, $row['taskStatus']);
-      } else if ($row['field'] == "personID") {
-        $el['desc'] = sprintf('Task #%d "%s" %s assigned to %s', $row['taskID'], $taskName, $projectName, $name);
-      } else {
-        $el['desc'] = "error!";
-      }
+        $name = $people[$row['personID']]['username'];
     }
-    $events[$key] = $el;
-  }
-  //record the history 
-  $trace[$db->f('taskID')][$db->f('field')] = $db->f('value');
+
+    if ($row['field'] != "taskStatus" || array_search($row['taskStatus'], $status_types) !== false) {
+        $taskName = escape_xml($row['taskName']);
+        $project = null;
+        if ($show_project) {
+            $project = new project();
+            $project->set_id($row['projectID']);
+            $project->select();
+        }
+        if ($summary) {
+            if ($show_project) {
+                $projectName = $project->get_value('projectShortName');
+            }
+            $el['desc'] = sprintf('%s: %d %s "%s" %s', $name, $row['taskID'], $projectName, $taskName, $row['taskStatus']);
+        } else {
+            if ($show_project) {
+                $projectName = "(".$project->get_value("projectName").")";
+            }
+            if ($row['field'] == "taskStatus") {
+                $el['desc'] = sprintf('Task #%d "%s" %s status changed to %s', $row['taskID'], $taskName, $projectName, $row['taskStatus']);
+            } else if ($row['field'] == "personID") {
+                $el['desc'] = sprintf('Task #%d "%s" %s assigned to %s', $row['taskID'], $taskName, $projectName, $name);
+            } else {
+                $el['desc'] = "error!";
+            }
+        }
+        $events[$key] = $el;
+    }
+  //record the history
+    $trace[$db->f('taskID')][$db->f('field')] = $db->f('value');
 }
 
 // generate the actual feed
@@ -105,16 +107,15 @@ $channel->addChild("description", "Alloc task event feed.");
 $keys = array_keys($events);
 rsort($keys);
 
-// There are 20 events in the list, but older task creation events could show 
-// the wrong status. This would result in a change in the RSS feed, so readers 
+// There are 20 events in the list, but older task creation events could show
+// the wrong status. This would result in a change in the RSS feed, so readers
 // may show it as a new event. Therefore, trim the list.
-for ($i = 0;$i < $max_events;$i++) {
-  $event = $events[$keys[$i]];
-  $item = $channel->addChild("item");
-  $item->addChild("title", $event['desc']);
-  $date = strtotime($event['date']);
-  $item->addChild("pubDate", strftime ("%a, %d %b %Y %H:%M:%S %z", $date));
+for ($i = 0; $i < $max_events; $i++) {
+    $event = $events[$keys[$i]];
+    $item = $channel->addChild("item");
+    $item->addChild("title", $event['desc']);
+    $date = strtotime($event['date']);
+    $item->addChild("pubDate", strftime("%a, %d %b %Y %H:%M:%S %z", $date));
 }
 
 echo $rss->asXML();
-?>

--- a/task/task.php
+++ b/task/task.php
@@ -3,123 +3,131 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
-define("PAGE_IS_PRINTABLE",1);
+define("PAGE_IS_PRINTABLE", 1);
 
-  function show_task_children($template) {
+function show_task_children($template)
+{
     global $TPL;
     global $task;
     if ($task->get_value("taskTypeID") == "Parent") {
-      $options["parentTaskID"] = $task->get_id();
-      $options["taskView"] = "byProject";
-      $task->get_value("projectID") and $options["projectIDs"][] = $task->get_value("projectID");
-      $options["showDates"] = true;
+        $options["parentTaskID"] = $task->get_id();
+        $options["taskView"] = "byProject";
+        $task->get_value("projectID") and $options["projectIDs"][] = $task->get_value("projectID");
+        $options["showDates"] = true;
       #$options["showCreator"] = true;
-      $options["showAssigned"] = true;
-      $options["showPercent"] = true;
-      $options["showHeader"] = true;
-      $options["showTimes"] = true;
-      $options["showTaskID"] = true;
-      $options["showTotals"] = true;
-      $options["showStatus"] = true;
-      $options["showEdit"] = true;
-      $options["showPriorityFactor"] = true;
-      $options["returnURL"] = $TPL["url_alloc_task"]."taskID=".$task->get_id();
+        $options["showAssigned"] = true;
+        $options["showPercent"] = true;
+        $options["showHeader"] = true;
+        $options["showTimes"] = true;
+        $options["showTaskID"] = true;
+        $options["showTotals"] = true;
+        $options["showStatus"] = true;
+        $options["showEdit"] = true;
+        $options["showPriorityFactor"] = true;
+        $options["returnURL"] = $TPL["url_alloc_task"]."taskID=".$task->get_id();
 
-      $_GET["media"] == "print" and $options["showDescription"] = true;
-      $_GET["media"] == "print" and $options["showComments"] = true;
-      $TPL["taskListRows"] = task::get_list($options);
-      $TPL["taskListOptions"] = $options;
+        $_GET["media"] == "print" and $options["showDescription"] = true;
+        $_GET["media"] == "print" and $options["showComments"] = true;
+        $TPL["taskListRows"] = task::get_list($options);
+        $TPL["taskListOptions"] = $options;
 
-      include_template($template);
+        include_template($template);
     }
-  }
+}
 
-  function get_parent_taskIDs($taskID) {
-    $q = prepare("SELECT taskID,taskName,parentTaskID 
+function get_parent_taskIDs($taskID)
+{
+    $q = prepare(
+        "SELECT taskID,taskName,parentTaskID 
                     FROM task 
                    WHERE taskID = %d 
-                     AND (taskID != parentTaskID OR parentTaskID IS NULL)"
-                ,$taskID);
+                     AND (taskID != parentTaskID OR parentTaskID IS NULL)",
+        $taskID
+    );
     $db = new db_alloc();
     $db->query($q);
     
-    while($db->next_record()) {
-      $rtn[$db->f("taskName")] = $db->f("taskID"); 
-      $arr = get_parent_taskIDs($db->f("parentTaskID"));
-      if (is_array($arr)) {
-        $rtn = array_merge($rtn, $arr);
-      }
+    while ($db->next_record()) {
+        $rtn[$db->f("taskName")] = $db->f("taskID");
+        $arr = get_parent_taskIDs($db->f("parentTaskID"));
+        if (is_array($arr)) {
+            $rtn = array_merge($rtn, $arr);
+        }
     }
     return $rtn;
-  }
+}
 
-  function show_attachments() {
+function show_attachments()
+{
     global $taskID;
-    util_show_attachments("task",$taskID);
-  }
+    util_show_attachments("task", $taskID);
+}
 
-  function show_comments() {
+function show_comments()
+{
     global $taskID;
     global $TPL;
     global $task;
 
     if ($_REQUEST["commentSummary"]) {
-      $_REQUEST["showTaskHeader"] = true;
-      $_REQUEST["clients"] = true;
-      $TPL["commentsR"] = comment::get_list_summary($_REQUEST);
-      $TPL["extra_page_links"] = '<a href="'.$TPL["url_alloc_task"].'taskID='.$TPL["task_taskID"].'&sbs_link=comments">Full</a>';
+        $_REQUEST["showTaskHeader"] = true;
+        $_REQUEST["clients"] = true;
+        $TPL["commentsR"] = comment::get_list_summary($_REQUEST);
+        $TPL["extra_page_links"] = '<a href="'.$TPL["url_alloc_task"].'taskID='.$TPL["task_taskID"].'&sbs_link=comments">Full</a>';
     } else {
-      $TPL["commentsR"] = comment::util_get_comments("task",$taskID);
-      $TPL["extra_page_links"] = '<a href="'.$TPL["url_alloc_task"].'taskID='.$TPL["task_taskID"];
-      $TPL["extra_page_links"].= '&sbs_link=comments&commentSummary=true&maxCommentLength=50000000">Summary</a>';
+        $TPL["commentsR"] = comment::util_get_comments("task", $taskID);
+        $TPL["extra_page_links"] = '<a href="'.$TPL["url_alloc_task"].'taskID='.$TPL["task_taskID"];
+        $TPL["extra_page_links"].= '&sbs_link=comments&commentSummary=true&maxCommentLength=50000000">Summary</a>';
     }
     $TPL["commentsR"] and $TPL["class_new_comment"] = "hidden";
     $TPL["allParties"] = $task->get_all_parties($task->get_value("projectID")) or $TPL["allParties"] = array();
     $TPL["entity"] = "task";
     $TPL["entityID"] = $task->get_id();
     if (has("project")) {
-      $project = $task->get_foreign_object("project");
-      $TPL["clientID"] = $project->get_value("clientID");
+        $project = $task->get_foreign_object("project");
+        $TPL["clientID"] = $project->get_value("clientID");
     }
 
     $commentTemplate = new commentTemplate();
-    $ops = $commentTemplate->get_assoc_array("commentTemplateID","commentTemplateName","",array("commentTemplateType"=>"task"));
+    $ops = $commentTemplate->get_assoc_array("commentTemplateID", "commentTemplateName", "", array("commentTemplateType"=>"task"));
     $TPL["commentTemplateOptions"] = "<option value=\"\">Comment Templates</option>".page::select_options($ops);
 
     include_template("../comment/templates/commentM.tpl");
-  }
+}
 
-  function show_taskCommentsPrinter() {
+function show_taskCommentsPrinter()
+{
     global $taskID;
     global $TPL;
-    $TPL["commentsR"] = comment::util_get_comments("task",$taskID,$options);
+    $TPL["commentsR"] = comment::util_get_comments("task", $taskID, $options);
     include_template("../comment/templates/commentP.tpl");
-  }
+}
 
-  function show_taskHistory() {
+function show_taskHistory()
+{
     global $task;
     global $TPL;
     $TPL["changeHistory"] = $task->get_changes_list();
     include_template("templates/taskHistoryM.tpl");
-  }
+}
 
 
 global $timeSheetID;
@@ -133,95 +141,94 @@ $taskID = $_POST["taskID"] or $taskID = $_GET["taskID"];
 
 if (isset($taskID)) {
   // Displaying a record
-  $task->set_id($taskID);
-  $task->select();
+    $task->set_id($taskID);
+    $task->select();
 
 // Creating a new record
 } else {
-  $_POST["dateCreated"] = date("Y-m-d H:i:s");
-  $task->read_globals();
-  $taskID = $task->get_id();
-  if (has("project") && $task->get_value("projectID")) {
-    $project = $task->get_foreign_object("project");
-  }
+    $_POST["dateCreated"] = date("Y-m-d H:i:s");
+    $task->read_globals();
+    $taskID = $task->get_id();
+    if (has("project") && $task->get_value("projectID")) {
+        $project = $task->get_foreign_object("project");
+    }
 }
 
 // if someone uploads an attachment
 if ($_POST["save_attachment"]) {
-  move_attachment("task",$taskID);
-  alloc_redirect($TPL["url_alloc_task"]."taskID=".$taskID."&sbs_link=attachments");
-} 
+    move_attachment("task", $taskID);
+    alloc_redirect($TPL["url_alloc_task"]."taskID=".$taskID."&sbs_link=attachments");
+}
   
 
 // If saving a record
 if ($_POST["save"] || $_POST["save_and_back"] || $_POST["save_and_new"] || $_POST["save_and_summary"] || $_POST["timeSheet_save"] || $_POST["close_task"]) {
+    $task->read_globals();
 
-  $task->read_globals();
-
-  if ($_POST["close_task"]) {
-    $task->set_value("taskStatus","closed_complete");
-  }
+    if ($_POST["close_task"]) {
+        $task->set_value("taskStatus", "closed_complete");
+    }
 
   // If we're auto-nuking the pending tasks, we need to do that before the call to task->save()
-  if ($task->get_id() && !$_POST["pendingTasksIDs"]) {
-    $task->add_pending_tasks($_POST["pendingTasksIDs"]);
-  }
+    if ($task->get_id() && !$_POST["pendingTasksIDs"]) {
+        $task->add_pending_tasks($_POST["pendingTasksIDs"]);
+    }
 
   // Moved all validation over into task.inc.php save()
-  $success = $task->save();
+    $success = $task->save();
 
-  count($msg) and $msg = "&message_good=".urlencode(implode("<br>",$msg));
+    count($msg) and $msg = "&message_good=".urlencode(implode("<br>", $msg));
 
-  if ($success) {
-    interestedParty::make_interested_parties("task",$task->get_id(),$_POST["interestedParty"]);
+    if ($success) {
+        interestedParty::make_interested_parties("task", $task->get_id(), $_POST["interestedParty"]);
 
-    // A task can only have a pending task or pending reopen date - pending task is fixed up in JS, but check here too
-    if ($task->get_value("taskStatus") != "pending_tasks") {
-      $_POST['pendingTaskIDs'] = '';
-    }
-    $task->add_pending_tasks($_POST["pendingTasksIDs"]);
-    $task->add_tags($_POST["tags"]);
+      // A task can only have a pending task or pending reopen date - pending task is fixed up in JS, but check here too
+        if ($task->get_value("taskStatus") != "pending_tasks") {
+            $_POST['pendingTaskIDs'] = '';
+        }
+        $task->add_pending_tasks($_POST["pendingTasksIDs"]);
+        $task->add_tags($_POST["tags"]);
 
-    // This is only valid on pending_, but not on pending_task (because it has a different field)
-    if (strpos($task->get_value("taskStatus"), "pending_") !== 0 || $task->get_value("taskStatus") == "pending_tasks") {
-      $_POST['reopen_task'] = '';
-    }
-    $task->add_reopen_reminder($_POST["reopen_task"]);
+      // This is only valid on pending_, but not on pending_task (because it has a different field)
+        if (strpos($task->get_value("taskStatus"), "pending_") !== 0 || $task->get_value("taskStatus") == "pending_tasks") {
+            $_POST['reopen_task'] = '';
+        }
+        $task->add_reopen_reminder($_POST["reopen_task"]);
 
-    // Create reminders if necessary
-    if($_POST["createTaskReminder"] == true) {
-      $task->create_task_reminder();
-    }
+      // Create reminders if necessary
+        if ($_POST["createTaskReminder"] == true) {
+            $task->create_task_reminder();
+        }
   
-    if ($_POST["save"] && $_POST["view"] == "brief") {
-      #$url = $TPL["url_alloc_taskList"];
-      $url = $TPL["url_alloc_task"]."taskID=".$task->get_id();
-    } else if ($_POST["save"] || $_POST["close_task"]) {
-      $url = $TPL["url_alloc_task"]."taskID=".$task->get_id();
-    } else if ($_POST["save_and_back"]) {
-      $url = $TPL["url_alloc_project"]."projectID=".$task->get_value("projectID");
-    } else if ($_POST["save_and_summary"]) {
-      $url = $TPL["url_alloc_taskList"];
-    } else if ($_POST["save_and_new"]) {
-      $url = $TPL["url_alloc_task"]."projectID=".$task->get_value("projectID")."&parentTaskID=".$task->get_value("parentTaskID");
-    } else if ($_POST["timeSheet_save"]) {
-      $url = $TPL["url_alloc_timeSheet"]."timeSheetID=".$_POST["timeSheetID"]."&taskID=".$task->get_id();
-    } else {
-      alloc_error("Unexpected save button");
+        if ($_POST["save"] && $_POST["view"] == "brief") {
+          #$url = $TPL["url_alloc_taskList"];
+            $url = $TPL["url_alloc_task"]."taskID=".$task->get_id();
+        } else if ($_POST["save"] || $_POST["close_task"]) {
+            $url = $TPL["url_alloc_task"]."taskID=".$task->get_id();
+        } else if ($_POST["save_and_back"]) {
+            $url = $TPL["url_alloc_project"]."projectID=".$task->get_value("projectID");
+        } else if ($_POST["save_and_summary"]) {
+            $url = $TPL["url_alloc_taskList"];
+        } else if ($_POST["save_and_new"]) {
+            $url = $TPL["url_alloc_task"]."projectID=".$task->get_value("projectID")."&parentTaskID=".$task->get_value("parentTaskID");
+        } else if ($_POST["timeSheet_save"]) {
+            $url = $TPL["url_alloc_timeSheet"]."timeSheetID=".$_POST["timeSheetID"]."&taskID=".$task->get_id();
+        } else {
+            alloc_error("Unexpected save button");
+        }
+        alloc_redirect($url.$msg);
+        exit();
     }
-    alloc_redirect($url.$msg);
-    exit();
-  }
 
 // If deleting a record
 } else if ($_POST["delete"]) {
-  if ($task->can_be_deleted()) {
-    $task->read_globals();
-    $task->delete();
-    alloc_redirect($TPL["url_alloc_taskList"]);
-  } else {
-    alloc_error("This task cannot be deleted. You either don't have permission, or this task has history items.");
-  }
+    if ($task->can_be_deleted()) {
+        $task->read_globals();
+        $task->delete();
+        alloc_redirect($TPL["url_alloc_taskList"]);
+    } else {
+        alloc_error("This task cannot be deleted. You either don't have permission, or this task has history items.");
+    }
 }
 
 // Start stuff here
@@ -234,8 +241,8 @@ $TPL["task_createdBy"] = $person->get_name();
 $TPL["task_createdBy_personID"] = $person->get_id();
 
 if ($task->get_value("closerID") && $task->get_value("dateClosed")) {
-  $TPL["task_closed_by"] = person::get_fullname($task->get_value("closerID"));
-  $TPL["task_closed_when"] = $task->get_value("dateClosed");
+    $TPL["task_closed_by"] = person::get_fullname($task->get_value("closerID"));
+    $TPL["task_closed_when"] = $task->get_value("dateClosed");
 }
 
 $person = new person();
@@ -260,13 +267,13 @@ $TPL["estimator_username_personID"] = $estimator->get_id();
 
 // If we've been sent here by a "New Message" or "New Fault" option in the Quick List dropdown
 if (!$taskID && $_GET["tasktype"]) {
-  $task->set_value("taskTypeID", $_GET["tasktype"]);
+    $task->set_value("taskTypeID", $_GET["tasktype"]);
 }
 
 // If we've been sent here by a "New Task" link from the calendar
 if (!$taskID && $_GET["dateTargetStart"]) {
-  $TPL["task_dateTargetStart"] = $_GET["dateTargetStart"];
-  $task->set_value("personID", $_GET["personID"]);
+    $TPL["task_dateTargetStart"] = $_GET["dateTargetStart"];
+    $task->set_value("personID", $_GET["personID"]);
 }
 
 
@@ -276,8 +283,8 @@ $task->set_option_tpl_values();
 $time_billed = $task->get_time_billed(false);
 $time_billed_label = seconds_to_display_format($time_billed);
 if ($time_billed != "") {
-  $TPL["time_billed_link"] = "<a href=\"".$TPL["url_alloc_timeSheetList"]."taskID=".$task->get_id()."&dontSave=true&applyFilter=true\">".$time_billed_label."</a>";
-} 
+    $TPL["time_billed_link"] = "<a href=\"".$TPL["url_alloc_timeSheetList"]."taskID=".$task->get_id()."&dontSave=true&applyFilter=true\">".$time_billed_label."</a>";
+}
 
 $TPL["task_timeLimit"]    or $TPL["task_timeLimit"] = "";
 $TPL["task_timeBest"]     or $TPL["task_timeBest"] = "";
@@ -288,13 +295,13 @@ $TPL["percentComplete"] = $task->get_percentComplete();
 
 // Generate navigation links
 if (has("project") && $task->get_id()) {
-  $project = $task->get_foreign_object("project");
-  $project->set_values("project_");
-  if ($project->get_id()) {
-    $ops["taskID"] = $task->get_id();
-    $ops["showProject"] = true;
-    $TPL["navigation_links"] = $project->get_navigation_links($ops);
-  }
+    $project = $task->get_foreign_object("project");
+    $project->set_values("project_");
+    if ($project->get_id()) {
+        $ops["taskID"] = $task->get_id();
+        $ops["showProject"] = true;
+        $TPL["navigation_links"] = $project->get_navigation_links($ops);
+    }
 }
 
 $parent_task = $task->get_foreign_object("task", "parentTaskID");
@@ -302,154 +309,150 @@ $parent_task->set_values("parentTask_");
 
 $TPL["taskType_taskTypeID"] = $task->get_value("taskTypeID");
 
-$q = prepare("SELECT clientID FROM project LEFT JOIN task ON task.projectID = project.projectID WHERE taskID = %d",$task->get_id());
+$q = prepare("SELECT clientID FROM project LEFT JOIN task ON task.projectID = project.projectID WHERE taskID = %d", $task->get_id());
 $db->query($q);
 $db->next_record();
 if ($db->f("clientID")) {
-  $TPL["new_client_contact_link"] = "<br><br><a href=\"".$TPL["url_alloc_client"]."clientID=".$db->f("clientID")."\">";
-  $TPL["new_client_contact_link"].= "New Client Contact</a>";
-  $TPL["task_clientID"] = $db->f("clientID");
+    $TPL["new_client_contact_link"] = "<br><br><a href=\"".$TPL["url_alloc_client"]."clientID=".$db->f("clientID")."\">";
+    $TPL["new_client_contact_link"].= "New Client Contact</a>";
+    $TPL["task_clientID"] = $db->f("clientID");
 }
 
 
 $parentTaskIDs = get_parent_taskIDs($task->get_value("parentTaskID"));
 if (is_array($parentTaskIDs)) {
-  $parentTaskIDs = array_reverse($parentTaskIDs,1);
+    $parentTaskIDs = array_reverse($parentTaskIDs, 1);
 
-  foreach ($parentTaskIDs as $tName => $tID) {
-    $TPL["hierarchy_links"] .= $br.$spaces."<a href=\"".$TPL["url_alloc_task"]."taskID=".$tID."\">".$tID." ".page::htmlentities($tName)."</a>";
-    $spaces.="&nbsp;&nbsp;&nbsp;&nbsp;";
-    $br = "<br>";
-  }
+    foreach ($parentTaskIDs as $tName => $tID) {
+        $TPL["hierarchy_links"] .= $br.$spaces."<a href=\"".$TPL["url_alloc_task"]."taskID=".$tID."\">".$tID." ".page::htmlentities($tName)."</a>";
+        $spaces.="&nbsp;&nbsp;&nbsp;&nbsp;";
+        $br = "<br>";
+    }
 }
 
 // Link off to the source task, if this task is just a duplicate
 $dupeID = $task->get_value("duplicateTaskID");
 if ($dupeID) {
-  $realtask = new task();
-  $realtask->set_id($dupeID);
-  $realtask->select();
-  $TPL["taskDuplicateLink"] = $realtask->get_task_link(array("prefixTaskID"=>1,"return"=>"html"));
-  $mesg = "This task is a duplicate of ".$TPL["taskDuplicateLink"];
-  $TPL["message_help_no_esc"][] = $mesg;
-  $TPL["editing_disabled"] = true;
+    $realtask = new task();
+    $realtask->set_id($dupeID);
+    $realtask->select();
+    $TPL["taskDuplicateLink"] = $realtask->get_task_link(array("prefixTaskID"=>1,"return"=>"html"));
+    $mesg = "This task is a duplicate of ".$TPL["taskDuplicateLink"];
+    $TPL["message_help_no_esc"][] = $mesg;
+    $TPL["editing_disabled"] = true;
 }
 
 // Link off to the duplicate tasks, if this task is the source task
-$q = prepare("SELECT taskID FROM task WHERE duplicateTaskID = %d",$task->get_id());
+$q = prepare("SELECT taskID FROM task WHERE duplicateTaskID = %d", $task->get_id());
 $db->query($q);
 while ($row = $db->row()) {
-  $realtask = new task();
-  $realtask->set_id($row["taskID"]);
-  $realtask->select();
-  $duds.= "<br>".$realtask->get_task_link(array("prefixTaskID"=>1,"return"=>"html"));
-} 
+    $realtask = new task();
+    $realtask->set_id($row["taskID"]);
+    $realtask->select();
+    $duds.= "<br>".$realtask->get_task_link(array("prefixTaskID"=>1,"return"=>"html"));
+}
 $duds and $TPL["message_help_no_esc"][] = "The following tasks have been marked as a duplicate of this task: ".$duds;
 
 
 $rows = $task->get_pending_tasks();
 foreach ((array)$rows as $pendingTaskID) {
-  $realtask = new task();
-  $realtask->set_id($pendingTaskID);
-  $realtask->select();
-  unset($st1,$st2);
-  if (substr($realtask->get_value("taskStatus"),0,6) == "closed") {
-    $st1 = "<strike>";
-    $st2 = "</strike>";
-  } else {
-    $wasopen = true;
-  }
-  $pendingTaskLinks[] = $st1.$realtask->get_task_link(array("prefixTaskID"=>1,"return"=>"html")).$st2;
+    $realtask = new task();
+    $realtask->set_id($pendingTaskID);
+    $realtask->select();
+    unset($st1, $st2);
+    if (substr($realtask->get_value("taskStatus"), 0, 6) == "closed") {
+        $st1 = "<strike>";
+        $st2 = "</strike>";
+    } else {
+        $wasopen = true;
+    }
+    $pendingTaskLinks[] = $st1.$realtask->get_task_link(array("prefixTaskID"=>1,"return"=>"html")).$st2;
 }
 $is = "was";
 $wasopen and $is = "is";
-$pendingTaskLinks and $TPL["message_help_no_esc"][] = "This task ".$is." pending the completion of:<br>".implode("<br>",$pendingTaskLinks);
+$pendingTaskLinks and $TPL["message_help_no_esc"][] = "This task ".$is." pending the completion of:<br>".implode("<br>", $pendingTaskLinks);
 
 $rows = $task->get_pending_tasks(true);
 foreach ((array)$rows as $tID) {
-  $realtask = new task();
-  $realtask->set_id($tID);
-  $realtask->select();
-  unset($st1,$st2);
-  if (substr($realtask->get_value("taskStatus"),0,6) == "closed") {
-    $st1 = "<strike>";
-    $st2 = "</strike>";
-  } else {
-    $wasopen = true;
-  }
-  $blockTaskLinks[] = $st1.$realtask->get_task_link(array("prefixTaskID"=>1,"return"=>"html")).$st2;
+    $realtask = new task();
+    $realtask->set_id($tID);
+    $realtask->select();
+    unset($st1, $st2);
+    if (substr($realtask->get_value("taskStatus"), 0, 6) == "closed") {
+        $st1 = "<strike>";
+        $st2 = "</strike>";
+    } else {
+        $wasopen = true;
+    }
+    $blockTaskLinks[] = $st1.$realtask->get_task_link(array("prefixTaskID"=>1,"return"=>"html")).$st2;
 }
 $is = "was";
 $wasopen and $is = "is";
-$blockTaskLinks and $TPL["message_help_no_esc"][] = "This task ".$is." blocking the start of:<br>".implode("<br>",$blockTaskLinks);
+$blockTaskLinks and $TPL["message_help_no_esc"][] = "This task ".$is." blocking the start of:<br>".implode("<br>", $blockTaskLinks);
 
 
-if (in_str("pending_",$task->get_value("taskStatus"))) {
-  $rows = $task->get_reopen_reminders();
-  foreach ($rows as $r) {
-    $TPL["message_help_no_esc"][] = 'This task is set to
+if (in_str("pending_", $task->get_value("taskStatus"))) {
+    $rows = $task->get_reopen_reminders();
+    foreach ($rows as $r) {
+        $TPL["message_help_no_esc"][] = 'This task is set to
                                     <a href="'.$TPL["url_alloc_reminder"].'step=3&reminderID='.$r["rID"].'&returnToParent=task">
 				    automatically reopen at '.$r["reminderTime"].'</a>';
-    // Which date gets plugged in is arbitrary, but it would be unusual for there to be more than one
-    $TPL['reopen_task'] = strftime("%Y-%m-%d", strtotime($r['reminderTime']));
-  }
+      // Which date gets plugged in is arbitrary, but it would be unusual for there to be more than one
+        $TPL['reopen_task'] = strftime("%Y-%m-%d", strtotime($r['reminderTime']));
+    }
 }
 
 
 
 if ($task->get_id()) {
- $TPL["task_taskType"] = $task->get_value("taskTypeID");
+    $TPL["task_taskType"] = $task->get_value("taskTypeID");
 } else {
-  $TPL["task_children_summary"] = "";
-  $TPL["task_taskType"] = "Task";
+    $TPL["task_children_summary"] = "";
+    $TPL["task_taskType"] = "Task";
 }
 
 
 if ($taskID) {
-  $TPL["taskTypeImage"] = $task->get_task_image();
-  $TPL["taskSelfLink"] = "<a href=\"".$task->get_url()."\">".$task->get_id()." ".$task->get_name(array("return"=>"html"))."</a>";
-  $TPL["main_alloc_title"] = "Task " . $task->get_id() . ": " . $task->get_name()." - ".APPLICATION_NAME;
-  $TPL["task_exists"] = true;
+    $TPL["taskTypeImage"] = $task->get_task_image();
+    $TPL["taskSelfLink"] = "<a href=\"".$task->get_url()."\">".$task->get_id()." ".$task->get_name(array("return"=>"html"))."</a>";
+    $TPL["main_alloc_title"] = "Task " . $task->get_id() . ": " . $task->get_name()." - ".APPLICATION_NAME;
+    $TPL["task_exists"] = true;
 
-  $q = prepare("SELECT GROUP_CONCAT(pendingTaskID) as pendingTaskIDs FROM pendingTask WHERE taskID = %d",$task->get_id());
-  $db->query($q);
-  $row = $db->row();
-  $TPL["task_pendingTaskIDs"] = $row["pendingTaskIDs"];
-  $TPL["task_tags"] = implode(", ",$task->get_tags());
-
+    $q = prepare("SELECT GROUP_CONCAT(pendingTaskID) as pendingTaskIDs FROM pendingTask WHERE taskID = %d", $task->get_id());
+    $db->query($q);
+    $row = $db->row();
+    $TPL["task_pendingTaskIDs"] = $row["pendingTaskIDs"];
+    $TPL["task_tags"] = implode(", ", $task->get_tags());
 } else {
-  $TPL["taskSelfLink"] = "New Task";
-  $TPL["main_alloc_title"] = "New Task - ".APPLICATION_NAME;
+    $TPL["taskSelfLink"] = "New Task";
+    $TPL["main_alloc_title"] = "New Task - ".APPLICATION_NAME;
 }
 
-$TPL["tagOptions"] = page::select_options($task->get_tags(true),$task->get_tags(),300);
+$TPL["tagOptions"] = page::select_options($task->get_tags(true), $task->get_tags(), 300);
 
 if (!$task->get_id()) {
-  $TPL["message_help"][] = "Enter a Task Name and click the Save button to create a new Task.";
-  $TPL["task_dateTargetStart"] or $TPL["task_dateTargetStart"] = date("Y-m-d");
+    $TPL["message_help"][] = "Enter a Task Name and click the Save button to create a new Task.";
+    $TPL["task_dateTargetStart"] or $TPL["task_dateTargetStart"] = date("Y-m-d");
 }
 
 $TPL["task"] = $task;
 
 // Printer friendly view
 if ($_GET["media"] == "print") {
-  if (has("client")) {
-    $client = new client();
-    $client->set_id($project->get_value("clientID"));
-    $client->select();
-    $client->set_values("client_");
-  }
-  if (has("project") && has("client")) {
-    $project = $task->get_foreign_object("project");
-    $clientContact = new clientContact();
-    $clientContact->set_id($project->get_value("clientContactID"));
-    $clientContact->select();
-    $clientContact->set_values("clientContact_");
-  }
-  include_template("templates/taskPrinterM.tpl");
+    if (has("client")) {
+        $client = new client();
+        $client->set_id($project->get_value("clientID"));
+        $client->select();
+        $client->set_values("client_");
+    }
+    if (has("project") && has("client")) {
+        $project = $task->get_foreign_object("project");
+        $clientContact = new clientContact();
+        $clientContact->set_id($project->get_value("clientContactID"));
+        $clientContact->select();
+        $clientContact->set_values("clientContact_");
+    }
+    include_template("templates/taskPrinterM.tpl");
 } else {
-  include_template("templates/taskM.tpl");
+    include_template("templates/taskM.tpl");
 }
-
-
-?>

--- a/task/taskListCSV.php
+++ b/task/taskListCSV.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -45,7 +45,7 @@ $_FORM["showTimes"]       and $fields["timeBestLabel"]        = "Best";
 $_FORM["showTimes"]       and $fields["timeExpectedLabel"]    = "Likely";
 $_FORM["showTimes"]       and $fields["timeWorstLabel"]       = "Worst";
 $_FORM["showTimes"]       and $fields["timeActualLabel"]      = "Actual";
-$_FORM["showTimes"]       and $fields["timeLimitLabel"]       = "Limit"; 
+$_FORM["showTimes"]       and $fields["timeLimitLabel"]       = "Limit";
 $_FORM["showPercent"]     and $fields["percentComplete"]      = "%";
 $_FORM["showStatus"]      and $fields["taskStatusLabel"]      = "Status";
 
@@ -55,27 +55,24 @@ $projectPriorities = config::get_config_item("projectPriorities");
 $rows = task::get_list($_FORM);
 $taskListRows = array();
 foreach ((array)$rows as $row) {
-  $row["taskPriority"] = $taskPriorities[$row["priority"]]["label"];
-  $row["projectPriority"] = $projectPriorities[$row["projectPriority"]]["label"];
-  $row["taskDateStatus"] = strip_tags($row["taskDateStatus"]);
-  $row["percentComplete"] = strip_tags($row["percentComplete"]);
-  $taskListRows[] = $row;
+    $row["taskPriority"] = $taskPriorities[$row["priority"]]["label"];
+    $row["projectPriority"] = $projectPriorities[$row["projectPriority"]]["label"];
+    $row["taskDateStatus"] = strip_tags($row["taskDateStatus"]);
+    $row["percentComplete"] = strip_tags($row["percentComplete"]);
+    $taskListRows[] = $row;
 }
 
 if ($taskListRows) {
-  header('Content-Type: text/csv');
-  header('Content-Disposition: attachment;filename=tasklist'.time().'.csv');
-  $fp = fopen('php://output', 'w');
+    header('Content-Type: text/csv');
+    header('Content-Disposition: attachment;filename=tasklist'.time().'.csv');
+    $fp = fopen('php://output', 'w');
 
   // header row
-  fputcsv($fp, array_keys(current($taskListRows)));
+    fputcsv($fp, array_keys(current($taskListRows)));
 
-  foreach ($taskListRows as $row) {
-    fputcsv($fp, $row);
-  }
+    foreach ($taskListRows as $row) {
+        fputcsv($fp, $row);
+    }
 
-  fclose($fp);
+    fclose($fp);
 }
-
-
-?>

--- a/task/taskListPrint.php
+++ b/task/taskListPrint.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -25,5 +25,3 @@ require_once("../alloc.php");
 
 $t = new taskListPrint();
 $t->get_printable_file($_GET);
-
-?>

--- a/task/updateEstimatorPersonList.php
+++ b/task/updateEstimatorPersonList.php
@@ -3,25 +3,25 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 
@@ -29,10 +29,8 @@ usleep(500000);
 
 $task = new task();
 if ($_GET["taskID"]) {
-  $task->set_id($_GET["taskID"]);
-  $task->select();
+    $task->set_id($_GET["taskID"]);
+    $task->select();
 }
 
-echo "<select name=\"estimatorID\"><option value=\"\">".$task->get_personList_dropdown($_GET["projectID"],"estimatorID",$_GET["selected"])."</select>";
-
-?>
+echo "<select name=\"estimatorID\"><option value=\"\">".$task->get_personList_dropdown($_GET["projectID"], "estimatorID", $_GET["selected"])."</select>";

--- a/task/updateInterestedParties.php
+++ b/task/updateInterestedParties.php
@@ -3,40 +3,37 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 #if ($_GET["projectID"]) {
   usleep(500000);
   
-  if ($_GET["taskID"]) {
+if ($_GET["taskID"]) {
     $task = new task();
     $task->set_id($_GET["taskID"]);
     $task->select();
     echo $task->get_task_cc_list_select($_GET["projectID"]);
-  } else {
+} else {
     echo task::get_task_cc_list_select($_GET["projectID"]);
-  }
+}
 
 #}
-
-
-?>

--- a/task/updateManagerPersonList.php
+++ b/task/updateManagerPersonList.php
@@ -3,25 +3,25 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 
@@ -29,11 +29,8 @@ usleep(500000);
 
 $task = new task();
 if ($_GET["taskID"]) {
-  $task->set_id($_GET["taskID"]);
-  $task->select();
+    $task->set_id($_GET["taskID"]);
+    $task->select();
 }
 
-echo "<select name=\"managerID\"><option value=\"\">".$task->get_personList_dropdown($_GET["projectID"],"managerID",$_GET["selected"])."</select>";
-
-
-?>
+echo "<select name=\"managerID\"><option value=\"\">".$task->get_personList_dropdown($_GET["projectID"], "managerID", $_GET["selected"])."</select>";

--- a/task/updateParentTasks.php
+++ b/task/updateParentTasks.php
@@ -3,25 +3,25 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 
@@ -30,7 +30,3 @@ require_once("../alloc.php");
   usleep(50000);
   echo task::get_parent_task_select($_GET["projectID"]);
 #}
-
-
-
-?>

--- a/task/updatePersonList.php
+++ b/task/updatePersonList.php
@@ -3,25 +3,25 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 
@@ -29,10 +29,7 @@ usleep(600000);
 
 $task = new task();
 if ($_GET["taskID"]) {
-  $task->set_id($_GET["taskID"]);
-  $task->select();
+    $task->set_id($_GET["taskID"]);
+    $task->select();
 }
-echo "<select name=\"personID\"><option value=\"\">".$task->get_personList_dropdown($_GET["projectID"],"personID",$_GET["selected"])."</select>";
-
-
-?>
+echo "<select name=\"personID\"><option value=\"\">".$task->get_personList_dropdown($_GET["projectID"], "personID", $_GET["selected"])."</select>";

--- a/task/updateProjectList.php
+++ b/task/updateProjectList.php
@@ -3,30 +3,26 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 usleep(400000);
 echo project::get_list_dropdown($_GET["projectType"]);
-
-
-
-?>

--- a/task/updateTaskDupes.php
+++ b/task/updateTaskDupes.php
@@ -3,25 +3,25 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 $index = new Zend_Search_Lucene(ATTACHMENTS_DIR.'search/task');
@@ -31,15 +31,12 @@ $query = Zend_Search_Lucene_Search_QueryParser::parse($needle);
 $hits = $index->find($needle);
 
 foreach ($hits as $hit) {
-  $d = $hit->getDocument();
-  $str.= "<div style='padding-bottom:3px'>";
-  $str.= "<a href=\"".$TPL["url_alloc_task"]."taskID=".$d->getFieldValue('id')."\">".$d->getFieldValue('id')." ".$d->getFieldValue('name')."</a>";
-  $str.= "</div>";
+    $d = $hit->getDocument();
+    $str.= "<div style='padding-bottom:3px'>";
+    $str.= "<a href=\"".$TPL["url_alloc_task"]."taskID=".$d->getFieldValue('id')."\">".$d->getFieldValue('id')." ".$d->getFieldValue('name')."</a>";
+    $str.= "</div>";
 }
 
 if ($str) {
-  echo $str;
+    echo $str;
 }
-
-
-?>

--- a/task/updateTaskName.php
+++ b/task/updateTaskName.php
@@ -3,36 +3,32 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 
 
 if ($_REQUEST["taskID"]) {
-  $q = prepare("SELECT taskID, taskName FROM task WHERE taskID = %d",$_REQUEST["taskID"]);
-  $db = new db_alloc();
-  $row = $db->qr($q);
-  echo page::htmlentities($row["taskID"]." ".$row["taskName"]);
+    $q = prepare("SELECT taskID, taskName FROM task WHERE taskID = %d", $_REQUEST["taskID"]);
+    $db = new db_alloc();
+    $row = $db->qr($q);
+    echo page::htmlentities($row["taskID"]." ".$row["taskName"]);
 }
-
-
-
-?>

--- a/time/lib/init.php
+++ b/time/lib/init.php
@@ -3,27 +3,27 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class time_module extends module {
-  var $module = "time";
-  var $db_entities = array("timeSheet", "timeSheetItem","timeUnit");
-  var $home_items = array("timeSheetHomeItem","tsiHintHomeItem","timeSheetListHomeItem","pendingApprovalTimeSheetListHomeItem","timeSheetStatusHomeItem","pendingAdminApprovalTimeSheetListHomeItem");
+class time_module extends module
+{
+    var $module = "time";
+    var $db_entities = array("timeSheet", "timeSheetItem","timeUnit");
+    var $home_items = array("timeSheetHomeItem","tsiHintHomeItem","timeSheetListHomeItem","pendingApprovalTimeSheetListHomeItem","timeSheetStatusHomeItem","pendingAdminApprovalTimeSheetListHomeItem");
 }
-?>

--- a/time/lib/pendingAdminApprovalTimeSheetListHomeItem.inc.php
+++ b/time/lib/pendingAdminApprovalTimeSheetListHomeItem.inc.php
@@ -3,47 +3,50 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class pendingAdminApprovalTimeSheetListHomeItem extends home_item {
+class pendingAdminApprovalTimeSheetListHomeItem extends home_item
+{
 
-  function __construct() {
-    parent::__construct("pending_admin_time_list", "Time Sheets Pending Admin Approval", "time", "pendingAdminApprovalTimeSheetHomeM.tpl", "narrow", 22);
-  }
-
-  function visible() {
-    $current_user = &singleton("current_user");
-    if (isset($current_user) && $current_user->is_employee()) {
-      $timeSheetAdminPersonIDs = config::get_config_item("defaultTimeSheetAdminList");
-      if (in_array($current_user->get_id(), $timeSheetAdminPersonIDs) && has_pending_admin_timesheet()) {
-        return true;
-      }
+    function __construct()
+    {
+        parent::__construct("pending_admin_time_list", "Time Sheets Pending Admin Approval", "time", "pendingAdminApprovalTimeSheetHomeM.tpl", "narrow", 22);
     }
-  }
 
-  function render() {
-    return true;
-  }
+    function visible()
+    {
+        $current_user = &singleton("current_user");
+        if (isset($current_user) && $current_user->is_employee()) {
+            $timeSheetAdminPersonIDs = config::get_config_item("defaultTimeSheetAdminList");
+            if (in_array($current_user->get_id(), $timeSheetAdminPersonIDs) && has_pending_admin_timesheet()) {
+                return true;
+            }
+        }
+    }
 
-  function show_pending_time_sheets($template_name,$doAdmin=false) {
-    show_time_sheets_list_for_classes($template_name,$doAdmin);
-  }
+    function render()
+    {
+        return true;
+    }
+
+    function show_pending_time_sheets($template_name, $doAdmin = false)
+    {
+        show_time_sheets_list_for_classes($template_name, $doAdmin);
+    }
 }
-
-?>

--- a/time/lib/pendingApprovalTimeSheetListHomeItem.inc.php
+++ b/time/lib/pendingApprovalTimeSheetListHomeItem.inc.php
@@ -3,83 +3,90 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class pendingApprovalTimeSheetListHomeItem extends home_item {
+class pendingApprovalTimeSheetListHomeItem extends home_item
+{
 
-  function __construct() {
-    parent::__construct("pending_time_list", "Time Sheets Pending Manager", "time", "pendingApprovalTimeSheetHomeM.tpl", "narrow", 23);
-  }
-
-  function visible() {
-    $current_user = &singleton("current_user");
-    return (isset($current_user) && $current_user->is_employee() && has_pending_timesheet());
-  }
-  
-  function render() {
-    return true;
-  }
-
-  function show_pending_time_sheets($template_name,$doAdmin=false) {
-    show_time_sheets_list_for_classes($template_name,$doAdmin);
-  }
-}
-
-function show_time_sheets_list_for_classes($template_name,$doAdmin=false) {
-  $current_user = &singleton("current_user");
-  global $TPL;
-
-  if ($doAdmin) {
-    $db = get_pending_admin_timesheet_db();
-  } else {
-    $db = get_pending_timesheet_db();
-  }
-
-  $people =& get_cached_table("person");
-
-  while ($db->next_record()) {
-    $timeSheet = new timeSheet();
-    $timeSheet->read_db_record($db);
-    $timeSheet->set_values();
-
-    unset($date); 
-    if ($timeSheet->get_value("status") == "manager") {
-      $date = $timeSheet->get_value("dateSubmittedToManager");
-    } else if ($timeSheet->get_value("status") == "admin") {
-      $date = $timeSheet->get_value("dateSubmittedToAdmin");
+    function __construct()
+    {
+        parent::__construct("pending_time_list", "Time Sheets Pending Manager", "time", "pendingApprovalTimeSheetHomeM.tpl", "narrow", 23);
     }
-    unset($TPL["warning"]);
 
-    // older than $current_user->prefs["timeSheetDaysWarn"] days 
-    if ($date && imp($current_user->prefs["timeSheetDaysWarn"]) && (mktime()-format_date("U",$date))/60/60/24 > $current_user->prefs["timeSheetDaysWarn"]) {
-      $TPL["warning"] = page::help("This time sheet was submitted to you over ".$current_user->prefs["timeSheetDaysWarn"]." days ago.",page::warn());
-    } 
-    
-    $TPL["date"] = "<a href=\"".$TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheet->get_id()."\">".$date."</a>";
-    $TPL["user"] = $people[$timeSheet->get_value("personID")]["name"];
-    $TPL["projectName"] = $db->f("projectName");
+    function visible()
+    {
+        $current_user = &singleton("current_user");
+        return (isset($current_user) && $current_user->is_employee() && has_pending_timesheet());
+    }
+  
+    function render()
+    {
+        return true;
+    }
 
-    include_template("../time/templates/".$template_name);
-  }
+    function show_pending_time_sheets($template_name, $doAdmin = false)
+    {
+        show_time_sheets_list_for_classes($template_name, $doAdmin);
+    }
 }
 
-function get_pending_timesheet_db() {
+function show_time_sheets_list_for_classes($template_name, $doAdmin = false)
+{
+    $current_user = &singleton("current_user");
+    global $TPL;
+
+    if ($doAdmin) {
+        $db = get_pending_admin_timesheet_db();
+    } else {
+        $db = get_pending_timesheet_db();
+    }
+
+    $people =& get_cached_table("person");
+
+    while ($db->next_record()) {
+        $timeSheet = new timeSheet();
+        $timeSheet->read_db_record($db);
+        $timeSheet->set_values();
+
+        unset($date);
+        if ($timeSheet->get_value("status") == "manager") {
+            $date = $timeSheet->get_value("dateSubmittedToManager");
+        } else if ($timeSheet->get_value("status") == "admin") {
+            $date = $timeSheet->get_value("dateSubmittedToAdmin");
+        }
+        unset($TPL["warning"]);
+
+      // older than $current_user->prefs["timeSheetDaysWarn"] days
+        if ($date && imp($current_user->prefs["timeSheetDaysWarn"]) && (mktime()-format_date("U", $date))/60/60/24 > $current_user->prefs["timeSheetDaysWarn"]) {
+            $TPL["warning"] = page::help("This time sheet was submitted to you over ".$current_user->prefs["timeSheetDaysWarn"]." days ago.", page::warn());
+        }
+    
+        $TPL["date"] = "<a href=\"".$TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheet->get_id()."\">".$date."</a>";
+        $TPL["user"] = $people[$timeSheet->get_value("personID")]["name"];
+        $TPL["projectName"] = $db->f("projectName");
+
+        include_template("../time/templates/".$template_name);
+    }
+}
+
+function get_pending_timesheet_db()
+{
   /*
    -----------     -----------------     --------
    | project |  <  | projectPerson |  <  | role |
@@ -94,14 +101,13 @@ function get_pending_timesheet_db() {
    -----------------
   */
 
-  $current_user = &singleton("current_user");
-  $db = new db_alloc();
+    $current_user = &singleton("current_user");
+    $db = new db_alloc();
 
   // Get all the time sheets that are in status manager, and are the responsibility of only the default manager
-  if (in_array($current_user->get_id(), config::get_config_item("defaultTimeSheetManagerList"))) {
-
-    // First get the blacklist of projects that we don't want to include below
-    $query = prepare("SELECT timeSheet.*, sum(timeSheetItem.timeSheetItemDuration * timeSheetItem.rate) as total_dollars
+    if (in_array($current_user->get_id(), config::get_config_item("defaultTimeSheetManagerList"))) {
+      // First get the blacklist of projects that we don't want to include below
+        $query = prepare("SELECT timeSheet.*, sum(timeSheetItem.timeSheetItemDuration * timeSheetItem.rate) as total_dollars
                            , COALESCE(projectShortName, projectName) as projectName
                         FROM timeSheet
                              LEFT JOIN timeSheetItem ON timeSheet.timeSheetID = timeSheetItem.timeSheetID
@@ -111,12 +117,12 @@ function get_pending_timesheet_db() {
                                (SELECT projectID FROM projectPerson WHERE personID != %d AND roleID = 3)
                     GROUP BY timeSheet.timeSheetID 
                     ORDER BY timeSheet.dateSubmittedToManager
-                     ",$current_user->get_id());
+                     ", $current_user->get_id());
 
-  // Get all the time sheets that are in status manager, where the currently logged in user is the manager
-  } else {
- 
-    $query = prepare("SELECT timeSheet.*, sum(timeSheetItem.timeSheetItemDuration * timeSheetItem.rate) as total_dollars
+    // Get all the time sheets that are in status manager, where the currently logged in user is the manager
+    } else {
+        $query = prepare(
+            "SELECT timeSheet.*, sum(timeSheetItem.timeSheetItemDuration * timeSheetItem.rate) as total_dollars
                            , COALESCE(projectShortName, projectName) as projectName
                         FROM timeSheet
                              LEFT JOIN timeSheetItem ON timeSheet.timeSheetID = timeSheetItem.timeSheetID
@@ -125,54 +131,49 @@ function get_pending_timesheet_db() {
                              LEFT JOIN role on projectPerson.roleID = role.roleID
                        WHERE projectPerson.personID = %d AND role.roleHandle = 'timeSheetRecipient' AND timeSheet.status='manager'
                     GROUP BY timeSheet.timeSheetID 
-                    ORDER BY timeSheet.dateSubmittedToManager"
-                     , $current_user->get_id()
-                    );
+                    ORDER BY timeSheet.dateSubmittedToManager",
+            $current_user->get_id()
+        );
+    }
 
-  }
-
-  $db->query($query);
-  return $db;
+    $db->query($query);
+    return $db;
 }
 
-function get_pending_admin_timesheet_db() {
-  $current_user = &singleton("current_user");
-  $db = new db_alloc();
+function get_pending_admin_timesheet_db()
+{
+    $current_user = &singleton("current_user");
+    $db = new db_alloc();
  
-  $timeSheetAdminPersonIDs = config::get_config_item("defaultTimeSheetAdminList");
+    $timeSheetAdminPersonIDs = config::get_config_item("defaultTimeSheetAdminList");
 
-  if (in_array($current_user->get_id(), $timeSheetAdminPersonIDs)) {
-    $query = "SELECT timeSheet.*, sum(timeSheetItem.timeSheetItemDuration * timeSheetItem.rate) as total_dollars, COALESCE(projectShortName, projectName) as projectName
+    if (in_array($current_user->get_id(), $timeSheetAdminPersonIDs)) {
+        $query = "SELECT timeSheet.*, sum(timeSheetItem.timeSheetItemDuration * timeSheetItem.rate) as total_dollars, COALESCE(projectShortName, projectName) as projectName
                 FROM timeSheet
            LEFT JOIN timeSheetItem ON timeSheet.timeSheetID = timeSheetItem.timeSheetID
            LEFT JOIN project on project.projectID = timeSheet.projectID
                WHERE timeSheet.status='admin'
             GROUP BY timeSheet.timeSheetID 
             ORDER BY timeSheet.dateSubmittedToAdmin";
-
-  } 
-  $db->query($query);
-  return $db;
-
+    }
+    $db->query($query);
+    return $db;
 }
 
-function has_pending_admin_timesheet() {
-  $db = get_pending_admin_timesheet_db();
-  if ($db->next_record()) {
-    return true;
-  }
-  return false;
+function has_pending_admin_timesheet()
+{
+    $db = get_pending_admin_timesheet_db();
+    if ($db->next_record()) {
+        return true;
+    }
+    return false;
 }
 
-function has_pending_timesheet() {
-  $db = get_pending_timesheet_db();
-  if ($db->next_record()) {
-    return true;
-  }
-  return false;
+function has_pending_timesheet()
+{
+    $db = get_pending_timesheet_db();
+    if ($db->next_record()) {
+        return true;
+    }
+    return false;
 }
-
-
-
-
-?>

--- a/time/lib/timeSheet.inc.php
+++ b/time/lib/timeSheet.inc.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,12 +23,13 @@
 define("PERM_TIME_APPROVE_TIMESHEETS", 256);
 define("PERM_TIME_INVOICE_TIMESHEETS", 512);
 
-class timeSheet extends db_entity {
-  public $classname = "timeSheet";
-  public $data_table = "timeSheet";
-  public $display_field_name = "projectID";
-  public $key_field = "timeSheetID";
-  public $data_fields = array("projectID"
+class timeSheet extends db_entity
+{
+    public $classname = "timeSheet";
+    public $data_table = "timeSheet";
+    public $display_field_name = "projectID";
+    public $key_field = "timeSheetID";
+    public $data_fields = array("projectID"
                              ,"dateFrom"
                              ,"dateTo"
                              ,"status"
@@ -43,151 +44,159 @@ class timeSheet extends db_entity {
                              ,"customerBilledDollars" => array("type"=>"money")
                              ,"currencyTypeID"
                              );
-  public $permissions = array(PERM_TIME_APPROVE_TIMESHEETS => "approve"
+    public $permissions = array(PERM_TIME_APPROVE_TIMESHEETS => "approve"
                              ,PERM_TIME_INVOICE_TIMESHEETS => "invoice");
 
-  function is_owner() {
-    $current_user = &singleton("current_user");
+    function is_owner()
+    {
+        $current_user = &singleton("current_user");
 
-    if (!$this->get_id()) {
-      return true;
-    }
-
-    if ($this->get_value("personID") == $current_user->get_id()) {
-      return true;
-    } 
-
-    $project = $this->get_foreign_object("project");
-    $managers = $project->get_timeSheetRecipients() or $managers = array();
-    if (in_array($current_user->get_id(), $managers)) {
-      return true;
-    }
-
-    if ($current_user->have_role("admin")) {
-      return true;
-    }
-
-    // This allows people with transactions on this time sheet who may not
-    // actually be this time sheets owner to view this time sheet.
-    if ($this->get_value("status") != "edit") { 
-      $current_user_tfIDs = $current_user->get_tfIDs();
-      $q = prepare("SELECT * FROM transaction WHERE timeSheetID = %d",$this->get_id());
-      $db = new db_alloc();
-      $db->query($q);
-      while ($db->next_record()) {
-        if (is_array($current_user_tfIDs) && (in_array($db->f("tfID"),$current_user_tfIDs) || in_array($db->f("fromTfID"),$current_user_tfIDs))) {
-          return true;
+        if (!$this->get_id()) {
+            return true;
         }
-      }
-    }
-  }
 
-  function save() {
-    $rtn = parent::save();
-    $this->update_related_invoices();
-    return $rtn;
-  }
-
-  function update_related_invoices() {
-    if ($rows = invoiceEntity::get("timeSheet",$this->get_id())) {
-      foreach ($rows as $row) {
-        if ($row["useItems"]) {
-          invoiceEntity::save_invoice_timeSheetItems($row["invoiceID"],$this->get_id());
-        } else {
-          invoiceEntity::save_invoice_timeSheet($row["invoiceID"],$this->get_id());
+        if ($this->get_value("personID") == $current_user->get_id()) {
+            return true;
         }
-      }
-    }
-  }
 
-  public static function get_timeSheet_statii() {
-    return array("edit"      => "Add Time"
+        $project = $this->get_foreign_object("project");
+        $managers = $project->get_timeSheetRecipients() or $managers = array();
+        if (in_array($current_user->get_id(), $managers)) {
+            return true;
+        }
+
+        if ($current_user->have_role("admin")) {
+            return true;
+        }
+
+      // This allows people with transactions on this time sheet who may not
+      // actually be this time sheets owner to view this time sheet.
+        if ($this->get_value("status") != "edit") {
+            $current_user_tfIDs = $current_user->get_tfIDs();
+            $q = prepare("SELECT * FROM transaction WHERE timeSheetID = %d", $this->get_id());
+            $db = new db_alloc();
+            $db->query($q);
+            while ($db->next_record()) {
+                if (is_array($current_user_tfIDs) && (in_array($db->f("tfID"), $current_user_tfIDs) || in_array($db->f("fromTfID"), $current_user_tfIDs))) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    function save()
+    {
+        $rtn = parent::save();
+        $this->update_related_invoices();
+        return $rtn;
+    }
+
+    function update_related_invoices()
+    {
+        if ($rows = invoiceEntity::get("timeSheet", $this->get_id())) {
+            foreach ($rows as $row) {
+                if ($row["useItems"]) {
+                    invoiceEntity::save_invoice_timeSheetItems($row["invoiceID"], $this->get_id());
+                } else {
+                    invoiceEntity::save_invoice_timeSheet($row["invoiceID"], $this->get_id());
+                }
+            }
+        }
+    }
+
+    public static function get_timeSheet_statii()
+    {
+        return array("edit"      => "Add Time"
                 ,"manager"   => "Manager"
                 ,"admin"     => "Administrator"
                 ,"invoiced"  => "Invoice"
                 ,"finished"  => "Completed"
                 ,"rejected"  => "Rejected"
                 );
-  } 
-
-  function get_timeSheet_status() {
-    $statii = timeSheet::get_timeSheet_statii();
-    return $statii[$this->get_value("status")];
-  }
-
-  function load_pay_info() {
-
-    /***************************************************************************
-     *                                                                         *
-     * load_pay_info() loads these vars:                                       *
-     * $this->pay_info["project_rate"];	    according to projectPerson table   *
-     * $this->pay_info["project_rate_orig"];before the currency transform      *
-     * $this->pay_info["timeSheetItem_rate"];according to timeSheetItem table  *
-     * $this->pay_info["customerBilledDollars"];                               *
-     * $this->pay_info["project_rateUnitID"];	according to projectPerson table *
-     * $this->pay_info["duration"][time sheet ITEM ID];                        *
-     * $this->pay_info["total_duration"]; of a timesheet                       *
-     * $this->pay_info["total_dollars"];  of a timesheet                       *
-     * $this->pay_info["total_customerBilledDollars"]                          *
-     * $this->pay_info["total_dollars_minus_gst"]                              *
-     * $this->pay_info["total_customerBilledDollars_minus_gst"]                *
-     * $this->pay_info["unit"]                                                 *
-     * $this->pay_info["summary_unit_totals"]                                  *
-     * $this->pay_info["total_dollars_not_null"] tot_custbilled/tot_dollars    *
-     * $this->pay_info["currency"]; according to timeSheet table               *
-     *                                                                         *
-     ***************************************************************************/
-
-    static $rates;
-    unset($this->pay_info);
-    $db = new db_alloc();
-
-    if (!$this->get_value("projectID") || !$this->get_value("personID")) {
-      return false;
     }
-    $currency = $this->get_value("currencyTypeID");
+
+    function get_timeSheet_status()
+    {
+        $statii = timeSheet::get_timeSheet_statii();
+        return $statii[$this->get_value("status")];
+    }
+
+    function load_pay_info()
+    {
+
+      /***************************************************************************
+       *                                                                         *
+       * load_pay_info() loads these vars:                                       *
+       * $this->pay_info["project_rate"];     according to projectPerson table   *
+       * $this->pay_info["project_rate_orig"];before the currency transform      *
+       * $this->pay_info["timeSheetItem_rate"];according to timeSheetItem table  *
+       * $this->pay_info["customerBilledDollars"];                               *
+       * $this->pay_info["project_rateUnitID"];   according to projectPerson table *
+       * $this->pay_info["duration"][time sheet ITEM ID];                        *
+       * $this->pay_info["total_duration"]; of a timesheet                       *
+       * $this->pay_info["total_dollars"];  of a timesheet                       *
+       * $this->pay_info["total_customerBilledDollars"]                          *
+       * $this->pay_info["total_dollars_minus_gst"]                              *
+       * $this->pay_info["total_customerBilledDollars_minus_gst"]                *
+       * $this->pay_info["unit"]                                                 *
+       * $this->pay_info["summary_unit_totals"]                                  *
+       * $this->pay_info["total_dollars_not_null"] tot_custbilled/tot_dollars    *
+       * $this->pay_info["currency"]; according to timeSheet table               *
+       *                                                                         *
+       ***************************************************************************/
+
+        static $rates;
+        unset($this->pay_info);
+        $db = new db_alloc();
+
+        if (!$this->get_value("projectID") || !$this->get_value("personID")) {
+            return false;
+        }
+        $currency = $this->get_value("currencyTypeID");
     
-    // The unit labels
-    $timeUnit = new timeUnit();
-    $units = array_reverse($timeUnit->get_assoc_array("timeUnitID","timeUnitLabelA"),true);
+      // The unit labels
+        $timeUnit = new timeUnit();
+        $units = array_reverse($timeUnit->get_assoc_array("timeUnitID", "timeUnitLabelA"), true);
 
-    if ($rates[$this->get_value("projectID")][$this->get_value("personID")]) {
-      list($this->pay_info["project_rate"],$this->pay_info["project_rateUnitID"]) = $rates[$this->get_value("projectID")][$this->get_value("personID")];
-    } else {
-
-      // Get rate for person for this particular project
-      $db->query("SELECT rate, rateUnitID, project.currencyTypeID
+        if ($rates[$this->get_value("projectID")][$this->get_value("personID")]) {
+            list($this->pay_info["project_rate"],$this->pay_info["project_rateUnitID"]) = $rates[$this->get_value("projectID")][$this->get_value("personID")];
+        } else {
+          // Get rate for person for this particular project
+            $db->query(
+                "SELECT rate, rateUnitID, project.currencyTypeID
                     FROM projectPerson
                LEFT JOIN project on projectPerson.projectID = project.projectID
                    WHERE projectPerson.projectID = %d
-                     AND projectPerson.personID = %d"
-                 ,$this->get_value("projectID")
-                 ,$this->get_value("personID"));
+                     AND projectPerson.personID = %d",
+                $this->get_value("projectID"),
+                $this->get_value("personID")
+            );
 
-      $db->next_record();
-      $this->pay_info["project_rate"] = page::money($db->f("currencyTypeID"),$db->f("rate"),"%mo");
-      $this->pay_info["project_rateUnitID"] = $db->f("rateUnitID");
-      $rates[$this->get_value("projectID")][$this->get_value("personID")] = array($this->pay_info["project_rate"],$this->pay_info["project_rateUnitID"]);
-    }
+            $db->next_record();
+            $this->pay_info["project_rate"] = page::money($db->f("currencyTypeID"), $db->f("rate"), "%mo");
+            $this->pay_info["project_rateUnitID"] = $db->f("rateUnitID");
+            $rates[$this->get_value("projectID")][$this->get_value("personID")] = array($this->pay_info["project_rate"],$this->pay_info["project_rateUnitID"]);
+        }
 
-    // Get external rate, only load up customerBilledDollars if the field is actually set
-    if (imp($this->get_value("customerBilledDollars"))) {
-      $this->pay_info["customerBilledDollars"] = page::money($currency,$this->get_value("customerBilledDollars"),"%mo");
-    }
+      // Get external rate, only load up customerBilledDollars if the field is actually set
+        if (imp($this->get_value("customerBilledDollars"))) {
+            $this->pay_info["customerBilledDollars"] = page::money($currency, $this->get_value("customerBilledDollars"), "%mo");
+        }
 
-    $q = "SELECT * FROM timeUnit ORDER BY timeUnitSequence DESC";
-    $db->query($q);
-    while ($row = $db->row()) { 
-      if ($row["timeUnitSeconds"]) {
-        $extra_sql[] = "SUM(IF(timeUnit.timeUnitLabelA = '".$row["timeUnitLabelA"]."',multiplier * timeSheetItemDuration * timeUnit.timeUnitSeconds,0)) /".$row["timeUnitSeconds"]." as ".$row["timeUnitLabelA"];
-      }
-      $timeUnitRows[] = $row;
-    }
+        $q = "SELECT * FROM timeUnit ORDER BY timeUnitSequence DESC";
+        $db->query($q);
+        while ($row = $db->row()) {
+            if ($row["timeUnitSeconds"]) {
+                $extra_sql[] = "SUM(IF(timeUnit.timeUnitLabelA = '".$row["timeUnitLabelA"]."',multiplier * timeSheetItemDuration * timeUnit.timeUnitSeconds,0)) /".$row["timeUnitSeconds"]." as ".$row["timeUnitLabelA"];
+            }
+            $timeUnitRows[] = $row;
+        }
 
-    $extra_sql and $sql = ",".implode("\n,",$extra_sql);
+        $extra_sql and $sql = ",".implode("\n,", $extra_sql);
 
-    // Get duration for this timesheet/timeSheetItems
-    $db->query(prepare("SELECT SUM(timeSheetItemDuration) AS total_duration, 
+      // Get duration for this timesheet/timeSheetItems
+        $db->query(prepare(
+            "SELECT SUM(timeSheetItemDuration) AS total_duration, 
                                SUM((timeSheetItemDuration * timeUnit.timeUnitSeconds) / 3600) AS total_duration_hours,
                                SUM((rate * pow(10,-currencyType.numberToBasic)) * timeSheetItemDuration * multiplier) AS total_dollars,
                                SUM((IFNULL(timeSheet.customerBilledDollars,0) * pow(10,-currencyType.numberToBasic)) * timeSheetItemDuration * multiplier) AS total_customerBilledDollars
@@ -196,325 +205,330 @@ class timeSheet extends db_entity {
                      LEFT JOIN timeUnit ON timeUnit.timeUnitID = timeSheetItem.timeSheetItemDurationUnitID
                      LEFT JOIN timeSheet on timeSheet.timeSheetID = timeSheetItem.timeSheetID
                      LEFT JOIN currencyType on currencyType.currencyTypeID = timeSheet.currencyTypeID
-                         WHERE timeSheetItem.timeSheetID = %d"
-                       ,$this->get_id()));
+                         WHERE timeSheetItem.timeSheetID = %d",
+            $this->get_id()
+        ));
 
-    $row = $db->row();
-    $this->pay_info = array_merge((array)$this->pay_info, (array)$row);
-    $this->pay_info["total_customerBilledDollars"] = page::money($currency,$this->pay_info["total_customerBilledDollars"],"%m");
-    $this->pay_info["total_dollars"] = page::money($currency,$this->pay_info["total_dollars"],"%m");
+        $row = $db->row();
+        $this->pay_info = array_merge((array)$this->pay_info, (array)$row);
+        $this->pay_info["total_customerBilledDollars"] = page::money($currency, $this->pay_info["total_customerBilledDollars"], "%m");
+        $this->pay_info["total_dollars"] = page::money($currency, $this->pay_info["total_dollars"], "%m");
 
-    unset($commar);
-    foreach((array)$timeUnitRows as $r) {
-      if ($row[$r["timeUnitLabelA"]]!=0) {
-        $this->pay_info["summary_unit_totals"].= $commar.($row[$r["timeUnitLabelA"]] + 0)." ".$r["timeUnitLabelA"];
-        $commar = ", ";
-      }
-    }
-
-    if (!isset($this->pay_info["total_dollars"])) {
-      $this->pay_info["total_dollars"] = 0;
-    }
-    if (!isset($this->pay_info["total_duration"])) {
-      $this->pay_info["total_duration"] = 0;
-    }
-    if (!isset($this->pay_info["total_duration_hours"])) {
-      $this->pay_info["total_duration_hours"] = 0;
-    }
-    $taxPercent = config::get_config_item("taxPercent");
-    $taxPercentDivisor = ($taxPercent/100) + 1;
-    $this->pay_info["total_dollars_minus_gst"] =               page::money($currency,$this->pay_info["total_dollars"] / $taxPercentDivisor,"%m");
-    $this->pay_info["total_customerBilledDollars_minus_gst"] = page::money($currency,$this->pay_info["total_customerBilledDollars"] / $taxPercentDivisor,"%m");
-    $this->pay_info["total_dollars_not_null"] = $this->pay_info["total_customerBilledDollars"] or $this->pay_info["total_dollars_not_null"] = $this->pay_info["total_dollars"];
-    $this->pay_info["currency"] = page::money($currency,'',"%S");
-  }
-
-  function destroyTransactions() {
-    $db = new db_alloc();
-    $query = prepare("DELETE FROM transaction WHERE timeSheetID = %d AND transactionType != 'invoice'", $this->get_id());
-    $db->query($query);
-    $db->next_record();
-  }
-
-  function createTransactions($status="pending") {
-
-    // So this will only create transaction if:
-    // - The timesheet status is admin
-    // - There is a recipient_tfID - that is the money is going to a TF
-    $db = new db_alloc();
-    $project = $this->get_foreign_object("project");
-    $projectName = $project->get_value("projectName");
-    $personName = person::get_fullname($this->get_value("personID"));
-    $company_tfID = config::get_config_item("mainTfID");
-    $cost_centre = $project->get_value("cost_centre_tfID") or $cost_centre = $company_tfID;
-    $this->fromTfID = $cost_centre;
-    $this->load_pay_info();
-
-    if ($this->get_value("status") != "invoiced") {
-      return "ERROR: Status of the timesheet must be 'invoiced' to Create Transactions.
-              The status is currently: ".$this->get_value("status");
-
-    } else if ($this->get_value("recipient_tfID") == "") {
-      return "ERROR: There is no recipient Tagged Fund to credit for this timesheet.
-              Go to Tools -> New Tagged Fund, add a new TF and add the owner. Then go
-              to People -> Select the user and set their Preferred Payment TF.";
-
-    } else if (!$cost_centre || $cost_centre == 0) {
-      return "ERROR: There is no cost centre associated with the project.";
-    }
-
-    $taxName = config::get_config_item("taxName");
-    $taxPercent = config::get_config_item("taxPercent");
-    $taxTfID = config::get_config_item("taxTfID");
-    $taxPercentDivisor = ($taxPercent/100) + 1;
-    $recipient_tfID = $this->get_value("recipient_tfID");
-    $timeSheetRecipients = $project->get_timeSheetRecipients();
-    
-    $rtn = array();
-
-    // This is just for internal transactions
-    if ($_POST["create_transactions_default"] && $this->pay_info["total_customerBilledDollars"] == 0) {
-      $this->pay_info["total_customerBilledDollars_minus_gst"] = $this->pay_info["total_dollars"];
-
-      // 1. Credit Employee TF
-      $product = "Timesheet #".$this->get_id()." for ".$projectName." (".$this->pay_info["summary_unit_totals"].")";
-      $rtn[$product] = $this->createTransaction($product, $this->pay_info["total_dollars"], $recipient_tfID, "timesheet", $status);
-
-      // 2. Payment Insurance
-      // removed
-      
-
-    } else if ($_POST["create_transactions_default"]) {
-      /*  This was previously named "Simple" transactions. Ho ho.
-          On the Project page we care about these following variables:
-           - Client Billed At $amount eg: $121
-           - The projectPersons rate for this project eg: $50;
-
-          $121 after gst == $110
-          cyber get 28.5% of $110 
-          djk get $50
-          commissions 
-          whatever is left of the $110 goes to the 0% commissions
-      */
-      
-      // 1. Credit TAX/GST Cost Centre
-      $product = $taxName." ".$taxPercent."% for timesheet #".$this->get_id();
-      $rtn[$product] = $this->createTransaction($product, ($this->pay_info["total_customerBilledDollars"]-$this->pay_info["total_customerBilledDollars_minus_gst"]), $taxTfID, "tax", $status);
-
-      // 3. Credit Employee TF
-      $product = "Timesheet #".$this->get_id()." for ".$projectName." (".$this->pay_info["summary_unit_totals"].")";
-      $rtn[$product] = $this->createTransaction($product, $this->pay_info["total_dollars"], $recipient_tfID, "timesheet", $status);
-
-      // 4. Credit Project Commissions
-      $db->query("SELECT * FROM projectCommissionPerson where projectID = %d ORDER BY commissionPercent DESC"
-                 ,$this->get_value("projectID"));
-
-      while ($db->next_record()) {
-        if ($db->f("commissionPercent") > 0) { 
-          $product = "Commission ".$db->f("commissionPercent")."% of ".$this->pay_info["currency"].$this->pay_info["total_customerBilledDollars_minus_gst"];
-          $product.= " from timesheet #".$this->get_id().".  Project: ".$projectName;
-          $amount = $this->pay_info["total_customerBilledDollars_minus_gst"]*($db->f("commissionPercent")/100);
-          $rtn[$product] = $this->createTransaction($product, $amount, $db->f("tfID"), "commission",$status);
-
-        // Suck up the rest of funds if it is a special zero % commission
-        } else if ($db->f("commissionPercent") == 0) { 
-          $amount = $this->pay_info["total_customerBilledDollars_minus_gst"] - $this->get_amount_so_far();
-          $amount < 0 and $amount = 0;
-
-          // If the 0% commission is for the company tf, dump it in the company tf
-          if ($db->f("tfID") == $company_tfID) {
-            $product = "Commission Remaining from timesheet #".$this->get_id().".  Project: ".$projectName;
-            $rtn[$product] = $this->createTransaction($product, $amount, $db->f("tfID"), "commission");
-          } else {
-
-            // If it's cyber do a 50/50 split with the commission tf and the company
-            if (config::for_cyber()) {
-              $amount = $amount/2;
-              $product = "Commission Remaining from timesheet #".$this->get_id().".  Project: ".$projectName;
-              $rtn[$product] = $this->createTransaction($product, $amount, $db->f("tfID"), "commission");
-              $rtn[$product] = $this->createTransaction($product, $amount, $company_tfID, "commission",$status); // 50/50
-            } else {
-              $product = "Commission Remaining from timesheet #".$this->get_id().".  Project: ".$projectName;
-              $rtn[$product] = $this->createTransaction($product, $amount, $db->f("tfID"), "commission");
+        unset($commar);
+        foreach ((array)$timeUnitRows as $r) {
+            if ($row[$r["timeUnitLabelA"]]!=0) {
+                $this->pay_info["summary_unit_totals"].= $commar.($row[$r["timeUnitLabelA"]] + 0)." ".$r["timeUnitLabelA"];
+                $commar = ", ";
             }
-
-          }
-
         }
 
-      }
+        if (!isset($this->pay_info["total_dollars"])) {
+            $this->pay_info["total_dollars"] = 0;
+        }
+        if (!isset($this->pay_info["total_duration"])) {
+            $this->pay_info["total_duration"] = 0;
+        }
+        if (!isset($this->pay_info["total_duration_hours"])) {
+            $this->pay_info["total_duration_hours"] = 0;
+        }
+        $taxPercent = config::get_config_item("taxPercent");
+        $taxPercentDivisor = ($taxPercent/100) + 1;
+        $this->pay_info["total_dollars_minus_gst"] =               page::money($currency, $this->pay_info["total_dollars"] / $taxPercentDivisor, "%m");
+        $this->pay_info["total_customerBilledDollars_minus_gst"] = page::money($currency, $this->pay_info["total_customerBilledDollars"] / $taxPercentDivisor, "%m");
+        $this->pay_info["total_dollars_not_null"] = $this->pay_info["total_customerBilledDollars"] or $this->pay_info["total_dollars_not_null"] = $this->pay_info["total_dollars"];
+        $this->pay_info["currency"] = page::money($currency, '', "%S");
     }
 
-    foreach($rtn as $error=>$v) {
-      $v != 1 and $errmsg.= "<br>FAILED: ".$error;
+    function destroyTransactions()
+    {
+        $db = new db_alloc();
+        $query = prepare("DELETE FROM transaction WHERE timeSheetID = %d AND transactionType != 'invoice'", $this->get_id());
+        $db->query($query);
+        $db->next_record();
     }
-    if ($errmsg) {
-      $this->destroyTransactions();
-      $rtnmsg.= "<br>Failed to create transactions... ".$errmsg;
-    }
-    return $rtnmsg;
-  }
 
-  function get_amount_so_far($include_tax = false) {
-    $q = prepare("SELECT SUM(amount * pow(10,-currencyType.numberToBasic) * exchangeRate) AS balance
+    function createTransactions($status = "pending")
+    {
+
+      // So this will only create transaction if:
+      // - The timesheet status is admin
+      // - There is a recipient_tfID - that is the money is going to a TF
+        $db = new db_alloc();
+        $project = $this->get_foreign_object("project");
+        $projectName = $project->get_value("projectName");
+        $personName = person::get_fullname($this->get_value("personID"));
+        $company_tfID = config::get_config_item("mainTfID");
+        $cost_centre = $project->get_value("cost_centre_tfID") or $cost_centre = $company_tfID;
+        $this->fromTfID = $cost_centre;
+        $this->load_pay_info();
+
+        if ($this->get_value("status") != "invoiced") {
+            return "ERROR: Status of the timesheet must be 'invoiced' to Create Transactions.
+              The status is currently: ".$this->get_value("status");
+        } else if ($this->get_value("recipient_tfID") == "") {
+            return "ERROR: There is no recipient Tagged Fund to credit for this timesheet.
+              Go to Tools -> New Tagged Fund, add a new TF and add the owner. Then go
+              to People -> Select the user and set their Preferred Payment TF.";
+        } else if (!$cost_centre || $cost_centre == 0) {
+            return "ERROR: There is no cost centre associated with the project.";
+        }
+
+        $taxName = config::get_config_item("taxName");
+        $taxPercent = config::get_config_item("taxPercent");
+        $taxTfID = config::get_config_item("taxTfID");
+        $taxPercentDivisor = ($taxPercent/100) + 1;
+        $recipient_tfID = $this->get_value("recipient_tfID");
+        $timeSheetRecipients = $project->get_timeSheetRecipients();
+    
+        $rtn = array();
+
+      // This is just for internal transactions
+        if ($_POST["create_transactions_default"] && $this->pay_info["total_customerBilledDollars"] == 0) {
+            $this->pay_info["total_customerBilledDollars_minus_gst"] = $this->pay_info["total_dollars"];
+
+          // 1. Credit Employee TF
+            $product = "Timesheet #".$this->get_id()." for ".$projectName." (".$this->pay_info["summary_unit_totals"].")";
+            $rtn[$product] = $this->createTransaction($product, $this->pay_info["total_dollars"], $recipient_tfID, "timesheet", $status);
+
+          // 2. Payment Insurance
+          // removed
+        } else if ($_POST["create_transactions_default"]) {
+          /*  This was previously named "Simple" transactions. Ho ho.
+            On the Project page we care about these following variables:
+             - Client Billed At $amount eg: $121
+             - The projectPersons rate for this project eg: $50;
+
+            $121 after gst == $110
+            cyber get 28.5% of $110
+            djk get $50
+            commissions
+            whatever is left of the $110 goes to the 0% commissions
+          */
+      
+          // 1. Credit TAX/GST Cost Centre
+            $product = $taxName." ".$taxPercent."% for timesheet #".$this->get_id();
+            $rtn[$product] = $this->createTransaction($product, ($this->pay_info["total_customerBilledDollars"]-$this->pay_info["total_customerBilledDollars_minus_gst"]), $taxTfID, "tax", $status);
+
+          // 3. Credit Employee TF
+            $product = "Timesheet #".$this->get_id()." for ".$projectName." (".$this->pay_info["summary_unit_totals"].")";
+            $rtn[$product] = $this->createTransaction($product, $this->pay_info["total_dollars"], $recipient_tfID, "timesheet", $status);
+
+          // 4. Credit Project Commissions
+            $db->query(
+                "SELECT * FROM projectCommissionPerson where projectID = %d ORDER BY commissionPercent DESC",
+                $this->get_value("projectID")
+            );
+
+            while ($db->next_record()) {
+                if ($db->f("commissionPercent") > 0) {
+                    $product = "Commission ".$db->f("commissionPercent")."% of ".$this->pay_info["currency"].$this->pay_info["total_customerBilledDollars_minus_gst"];
+                    $product.= " from timesheet #".$this->get_id().".  Project: ".$projectName;
+                    $amount = $this->pay_info["total_customerBilledDollars_minus_gst"]*($db->f("commissionPercent")/100);
+                    $rtn[$product] = $this->createTransaction($product, $amount, $db->f("tfID"), "commission", $status);
+
+                // Suck up the rest of funds if it is a special zero % commission
+                } else if ($db->f("commissionPercent") == 0) {
+                    $amount = $this->pay_info["total_customerBilledDollars_minus_gst"] - $this->get_amount_so_far();
+                    $amount < 0 and $amount = 0;
+
+                  // If the 0% commission is for the company tf, dump it in the company tf
+                    if ($db->f("tfID") == $company_tfID) {
+                        $product = "Commission Remaining from timesheet #".$this->get_id().".  Project: ".$projectName;
+                        $rtn[$product] = $this->createTransaction($product, $amount, $db->f("tfID"), "commission");
+                    } else {
+                    // If it's cyber do a 50/50 split with the commission tf and the company
+                        if (config::for_cyber()) {
+                            $amount = $amount/2;
+                            $product = "Commission Remaining from timesheet #".$this->get_id().".  Project: ".$projectName;
+                            $rtn[$product] = $this->createTransaction($product, $amount, $db->f("tfID"), "commission");
+                            $rtn[$product] = $this->createTransaction($product, $amount, $company_tfID, "commission", $status); // 50/50
+                        } else {
+                            $product = "Commission Remaining from timesheet #".$this->get_id().".  Project: ".$projectName;
+                            $rtn[$product] = $this->createTransaction($product, $amount, $db->f("tfID"), "commission");
+                        }
+                    }
+                }
+            }
+        }
+
+        foreach ($rtn as $error => $v) {
+            $v != 1 and $errmsg.= "<br>FAILED: ".$error;
+        }
+        if ($errmsg) {
+            $this->destroyTransactions();
+            $rtnmsg.= "<br>Failed to create transactions... ".$errmsg;
+        }
+        return $rtnmsg;
+    }
+
+    function get_amount_so_far($include_tax = false)
+    {
+        $q = prepare("SELECT SUM(amount * pow(10,-currencyType.numberToBasic) * exchangeRate) AS balance
                     FROM transaction 
                LEFT JOIN currencyType ON currencyType.currencyTypeID = transaction.currencyTypeID
                    WHERE timeSheetID = %d AND transactionType != 'invoice'
-                 ",$this->get_id());
-    $include_tax or $q.= "AND transactionType != 'tax'";
-    $db = new db_alloc();
-    $r = $db->qr($q);
-    return $r['balance'];
-  }
-
-  function createTransaction($product, $amount, $tfID, $transactionType, $status="", $fromTfID=false) {
-
-    if ($amount == 0) return 1;
-
-    $status or $status = "pending";
-    $fromTfID or $fromTfID = $this->fromTfID;
-
-    if ($tfID == 0 || !$tfID || !is_numeric($tfID) || !is_numeric($amount)) {
-      return "Error -> \$tfID: ".$tfID."  and  \$amount: ".$amount;
-    } else {
-      $transaction = new transaction();
-      $transaction->set_value("product", $product);
-      $transaction->set_value("amount", $amount);
-      $transaction->set_value("status", $status);
-      $transaction->set_value("fromTfID", $fromTfID);
-      $transaction->set_value("tfID", $tfID);
-      $transaction->set_value("transactionDate", date("Y-m-d"));
-      $transaction->set_value("transactionType", $transactionType);
-      $transaction->set_value("timeSheetID", $this->get_id());
-      $transaction->set_value("currencyTypeID", $this->get_value("currencyTypeID"));
-      $transaction->save();
-      return 1;
+                 ", $this->get_id());
+        $include_tax or $q.= "AND transactionType != 'tax'";
+        $db = new db_alloc();
+        $r = $db->qr($q);
+        return $r['balance'];
     }
-  }
 
-  function shootEmail($email) {
+    function createTransaction($product, $amount, $tfID, $transactionType, $status = "", $fromTfID = false)
+    {
+
+        if ($amount == 0) {
+            return 1;
+        }
+
+        $status or $status = "pending";
+        $fromTfID or $fromTfID = $this->fromTfID;
+
+        if ($tfID == 0 || !$tfID || !is_numeric($tfID) || !is_numeric($amount)) {
+            return "Error -> \$tfID: ".$tfID."  and  \$amount: ".$amount;
+        } else {
+            $transaction = new transaction();
+            $transaction->set_value("product", $product);
+            $transaction->set_value("amount", $amount);
+            $transaction->set_value("status", $status);
+            $transaction->set_value("fromTfID", $fromTfID);
+            $transaction->set_value("tfID", $tfID);
+            $transaction->set_value("transactionDate", date("Y-m-d"));
+            $transaction->set_value("transactionType", $transactionType);
+            $transaction->set_value("timeSheetID", $this->get_id());
+            $transaction->set_value("currencyTypeID", $this->get_value("currencyTypeID"));
+            $transaction->save();
+            return 1;
+        }
+    }
+
+    function shootEmail($email)
+    {
     
-    $addr = $email["to"];
-    $msg = $email["body"];
-    $sub = $email["subject"];
-    $type = $email["type"];
-    $dummy = $_POST["dont_send_email"];
+        $addr = $email["to"];
+        $msg = $email["body"];
+        $sub = $email["subject"];
+        $type = $email["type"];
+        $dummy = $_POST["dont_send_email"];
     
-    // New email object wrapper takes care of logging etc.
-    $email = new email_send($addr,$sub,$msg,$type);
+      // New email object wrapper takes care of logging etc.
+        $email = new email_send($addr, $sub, $msg, $type);
 
-    // REMOVE ME!!
-    #$email->ignore_no_email_urls = true;
+      // REMOVE ME!!
+      #$email->ignore_no_email_urls = true;
 
 
-    if ($dummy) {
-      return "Elected not to send email.";
-    } else if (!$email->is_valid_url()) {
-      return "Almost sent email to: ".$email->to_address;
-    } else if (!$email->to_address) {
-      return "Could not send email, invalid email address: ".$email->to_address;
-    } else if ($email->send()) {
-      return "Sent email to: ".$email->to_address;
-    } else {
-      return "Problem sending email to: ".$email->to_address;
-    }
-  }
-
-  function get_task_list_dropdown($status,$timeSheetID,$taskID="") {
-
-    if (is_object($this)) {
-      $personID = $this->get_value('personID');
-      $projectID = $this->get_value('projectID');
-    } else if ($timeSheetID) {
-      $t = new timeSheet();
-      $t->set_id($timeSheetID);    
-      $t->select();
-      $personID = $t->get_value('personID');
-      $projectID = $t->get_value('projectID');
+        if ($dummy) {
+            return "Elected not to send email.";
+        } else if (!$email->is_valid_url()) {
+            return "Almost sent email to: ".$email->to_address;
+        } else if (!$email->to_address) {
+            return "Could not send email, invalid email address: ".$email->to_address;
+        } else if ($email->send()) {
+            return "Sent email to: ".$email->to_address;
+        } else {
+            return "Problem sending email to: ".$email->to_address;
+        }
     }
 
-    $options["projectID"] = $projectID;
-    $options["personID"] = $personID;
-    $options["taskView"] = "byProject";
-    $options["return"] = "array";
-    $options["taskTimeSheetStatus"] = $status;
-    $taskrows = task::get_list($options);
-    foreach ((array)$taskrows as $tid => $row) {
-      $tasks[$tid] = str_repeat("&nbsp;&nbsp;&nbsp;&nbsp;",$row["padding"]).$tid." ".$row["taskName"];
+    function get_task_list_dropdown($status, $timeSheetID, $taskID = "")
+    {
+
+        if (is_object($this)) {
+            $personID = $this->get_value('personID');
+            $projectID = $this->get_value('projectID');
+        } else if ($timeSheetID) {
+            $t = new timeSheet();
+            $t->set_id($timeSheetID);
+            $t->select();
+            $personID = $t->get_value('personID');
+            $projectID = $t->get_value('projectID');
+        }
+
+        $options["projectID"] = $projectID;
+        $options["personID"] = $personID;
+        $options["taskView"] = "byProject";
+        $options["return"] = "array";
+        $options["taskTimeSheetStatus"] = $status;
+        $taskrows = task::get_list($options);
+        foreach ((array)$taskrows as $tid => $row) {
+            $tasks[$tid] = str_repeat("&nbsp;&nbsp;&nbsp;&nbsp;", $row["padding"]).$tid." ".$row["taskName"];
+        }
+
+        if ($taskID) {
+            $t = new task();
+            $t->set_id($taskID);
+            $t->select();
+            $tasks[$taskID] = $t->get_id()." ".$t->get_name();
+        }
+
+        $dropdown_options = page::select_options((array)$tasks, $taskID, 100);
+        return "<select name=\"timeSheetItem_taskID\" style=\"width:400px\"><option value=\"\">".$dropdown_options."</select>";
     }
 
-    if ($taskID) {
-      $t = new task();
-      $t->set_id($taskID);
-      $t->select();
-      $tasks[$taskID] = $t->get_id()." ".$t->get_name();
+    public static function get_list_filter($filter = array())
+    {
+        $current_user = &singleton("current_user");
+
+      // If they want starred, load up the timeSheetID filter element
+        if ($filter["starred"]) {
+            foreach ((array)$current_user->prefs["stars"]["timeSheet"] as $k => $v) {
+                $filter["timeSheetID"][] = $k;
+            }
+            is_array($filter["timeSheetID"]) or $filter["timeSheetID"][] = -1;
+        }
+
+      // Filter timeSheetID
+        $filter["timeSheetID"] and $sql[] = sprintf_implode("timeSheet.timeSheetID = %d", $filter["timeSheetID"]);
+
+      // No point continuing if primary key specified, so return
+        if ($filter["timeSheetID"] || $filter["starred"]) {
+            return $sql;
+        }
+
+        $filter["tfID"]      and $sql[] = sprintf_implode("timeSheet.recipient_tfID = %d", $filter["tfID"]);
+        $filter["projectID"] and $sql[] = sprintf_implode("timeSheet.projectID = %d", $filter["projectID"]);
+        $filter["taskID"]    and $sql[] = sprintf_implode("timeSheetItem.taskID = %d", $filter["taskID"]);
+        $filter["personID"]  and $sql[] = sprintf_implode("timeSheet.personID = %d", $filter["personID"]);
+        $filter["status"]    and $sql[] = sprintf_implode("timeSheet.status = '%s'", $filter["status"]);
+
+        if ($filter["dateFrom"]) {
+            in_array($filter["dateFromComparator"], array("=","!=",">",">=","<","<=")) or $filter["dateFromComparator"] = '=';
+            $sql[] = prepare("(timeSheet.dateFrom ".$filter['dateFromComparator']." '%s')", $filter["dateFrom"]);
+        }
+        if ($filter["dateTo"]) {
+            in_array($filter["dateToComparator"], array("=","!=",">",">=","<","<=")) or $filter["dateToComparator"] = '=';
+            $sql[] = prepare("(timeSheet.dateTo ".$filter['dateToComparator']." '%s')", $filter["dateTo"]);
+        }
+        return $sql;
     }
 
-    $dropdown_options = page::select_options((array)$tasks, $taskID, 100);
-    return "<select name=\"timeSheetItem_taskID\" style=\"width:400px\"><option value=\"\">".$dropdown_options."</select>";
-  }
-
-  public static function get_list_filter($filter=array()) {
-    $current_user = &singleton("current_user");
-
-    // If they want starred, load up the timeSheetID filter element
-    if ($filter["starred"]) {
-      foreach ((array)$current_user->prefs["stars"]["timeSheet"] as $k=>$v) {
-        $filter["timeSheetID"][] = $k;
-      }
-      is_array($filter["timeSheetID"]) or $filter["timeSheetID"][] = -1;
-    }
-
-    // Filter timeSheetID
-    $filter["timeSheetID"] and $sql[] = sprintf_implode("timeSheet.timeSheetID = %d",$filter["timeSheetID"]);
-
-    // No point continuing if primary key specified, so return
-    if ($filter["timeSheetID"] || $filter["starred"]) {
-      return $sql;
-    }
-
-    $filter["tfID"]      and $sql[] = sprintf_implode("timeSheet.recipient_tfID = %d", $filter["tfID"]);
-    $filter["projectID"] and $sql[] = sprintf_implode("timeSheet.projectID = %d",$filter["projectID"]);
-    $filter["taskID"]    and $sql[] = sprintf_implode("timeSheetItem.taskID = %d", $filter["taskID"]);
-    $filter["personID"]  and $sql[] = sprintf_implode("timeSheet.personID = %d",$filter["personID"]);
-    $filter["status"]    and $sql[] = sprintf_implode("timeSheet.status = '%s'",$filter["status"]);
-
-    if ($filter["dateFrom"]) {
-      in_array($filter["dateFromComparator"],array("=","!=",">",">=","<","<=")) or $filter["dateFromComparator"] = '=';
-      $sql[] = prepare("(timeSheet.dateFrom ".$filter['dateFromComparator']." '%s')",$filter["dateFrom"]);
-    }
-    if ($filter["dateTo"]) {
-      in_array($filter["dateToComparator"],array("=","!=",">",">=","<","<=")) or $filter["dateToComparator"] = '=';
-      $sql[] = prepare("(timeSheet.dateTo ".$filter['dateToComparator']." '%s')",$filter["dateTo"]);
-    }
-    return $sql;
-  }
-
-  public static function get_list($_FORM) {
-    /*
-     * This is the definitive method of getting a list of timeSheets that need a sophisticated level of filtering
-     *
-     */
+    public static function get_list($_FORM)
+    {
+      /*
+       * This is the definitive method of getting a list of timeSheets that need a sophisticated level of filtering
+       *
+       */
   
-    global $TPL;
-    $current_user = &singleton("current_user");
-    $_FORM["showShortProjectLink"] and $_FORM["showProjectLink"] = true;
-    $filter = timeSheet::get_list_filter($_FORM);
+        global $TPL;
+        $current_user = &singleton("current_user");
+        $_FORM["showShortProjectLink"] and $_FORM["showProjectLink"] = true;
+        $filter = timeSheet::get_list_filter($_FORM);
 
-    // Used in timeSheetListS.tpl
-    $extra["showFinances"] = $_FORM["showFinances"];
+      // Used in timeSheetListS.tpl
+        $extra["showFinances"] = $_FORM["showFinances"];
 
-    $debug = $_FORM["debug"];
-    $debug and print "<pre>_FORM: ".print_r($_FORM,1)."</pre>";
-    $debug and print "<pre>filter: ".print_r($filter,1)."</pre>";
+        $debug = $_FORM["debug"];
+        $debug and print "<pre>_FORM: ".print_r($_FORM, 1)."</pre>";
+        $debug and print "<pre>filter: ".print_r($filter, 1)."</pre>";
 
-    $_FORM["return"] or $_FORM["return"] = "html";
+        $_FORM["return"] or $_FORM["return"] = "html";
 
-    if (is_array($filter) && count($filter)) {
-      $filter = " WHERE ".implode(" AND ",$filter);
-    }
+        if (is_array($filter) && count($filter)) {
+            $filter = " WHERE ".implode(" AND ", $filter);
+        }
 
-    $q = "SELECT timeSheet.*, person.personID, projectName, projectShortName
+        $q = "SELECT timeSheet.*, person.personID, projectName, projectShortName
             FROM timeSheet 
        LEFT JOIN person ON timeSheet.personID = person.personID
        LEFT JOIN project ON timeSheet.projectID = project.projectID
@@ -523,129 +537,136 @@ class timeSheet extends db_entity {
         GROUP BY timeSheet.timeSheetID
         ORDER BY dateFrom,projectName,timeSheet.status,surname";
 
-    $debug and print "Query: ".$q;
-    $db = new db_alloc();
-    $db->query($q);
-    $status_array = timeSheet::get_timeSheet_statii();
-    $people_array =& get_cached_table("person");
+        $debug and print "Query: ".$q;
+        $db = new db_alloc();
+        $db->query($q);
+        $status_array = timeSheet::get_timeSheet_statii();
+        $people_array =& get_cached_table("person");
 
-    while ($row = $db->next_record()) {
-      $t = new timeSheet();
-      if (!$t->read_db_record($db))
-        continue;
+        while ($row = $db->next_record()) {
+            $t = new timeSheet();
+            if (!$t->read_db_record($db)) {
+                continue;
+            }
 
-      $t->load_pay_info();
+            $t->load_pay_info();
 
-      if ($_FORM["timeSheetItemHours"] && !parse_operator_comparison($_FORM["timeSheetItemHours"],$t->pay_info["total_duration_hours"])) 
-        continue;
+            if ($_FORM["timeSheetItemHours"] && !parse_operator_comparison($_FORM["timeSheetItemHours"], $t->pay_info["total_duration_hours"])) {
+                continue;
+            }
 
-      $row["currencyTypeID"] = $t->get_value("currencyTypeID");
-      $row["amount"] = $t->pay_info["total_dollars"];
-      $amount_tallies[] = array("amount"=>$row["amount"],"currency"=>$row["currencyTypeID"]);
-      $extra["amountTotal"] += exchangeRate::convert($row["currencyTypeID"],$row["amount"]);
-      $extra["totalHours"] += $t->pay_info["total_duration_hours"];
-      $row["totalHours"] += $t->pay_info["total_duration_hours"];
-      $row["duration"] = $t->pay_info["summary_unit_totals"];
+            $row["currencyTypeID"] = $t->get_value("currencyTypeID");
+            $row["amount"] = $t->pay_info["total_dollars"];
+            $amount_tallies[] = array("amount"=>$row["amount"],"currency"=>$row["currencyTypeID"]);
+            $extra["amountTotal"] += exchangeRate::convert($row["currencyTypeID"], $row["amount"]);
+            $extra["totalHours"] += $t->pay_info["total_duration_hours"];
+            $row["totalHours"] += $t->pay_info["total_duration_hours"];
+            $row["duration"] = $t->pay_info["summary_unit_totals"];
 
-      if ($t->get_value("status") == "edit" && imp($current_user->prefs["timeSheetHoursWarn"])
-      && $t->pay_info["total_duration_hours"] >= $current_user->prefs["timeSheetHoursWarn"]) {
-        $row["hoursWarn"] = page::help("This time sheet has gone over ".$current_user->prefs["timeSheetHoursWarn"]." hours.",page::warn());
-      }
-      if ($t->get_value("status") == "edit" && imp($current_user->prefs["timeSheetDaysWarn"]) 
-      && (mktime()-format_date("U",$t->get_value("dateFrom")))/60/60/24 >= $current_user->prefs["timeSheetDaysWarn"]) {
-        $row["daysWarn"] = page::help("This time sheet is over ".$current_user->prefs["timeSheetDaysWarn"]." days old.",page::warn());
-      }
+            if ($t->get_value("status") == "edit" && imp($current_user->prefs["timeSheetHoursWarn"])
+            && $t->pay_info["total_duration_hours"] >= $current_user->prefs["timeSheetHoursWarn"]) {
+                $row["hoursWarn"] = page::help("This time sheet has gone over ".$current_user->prefs["timeSheetHoursWarn"]." hours.", page::warn());
+            }
+            if ($t->get_value("status") == "edit" && imp($current_user->prefs["timeSheetDaysWarn"])
+            && (mktime()-format_date("U", $t->get_value("dateFrom")))/60/60/24 >= $current_user->prefs["timeSheetDaysWarn"]) {
+                $row["daysWarn"] = page::help("This time sheet is over ".$current_user->prefs["timeSheetDaysWarn"]." days old.", page::warn());
+            }
 
-      $row["person"] = $people_array[$row["personID"]]["name"];
-      $row["status"] = $status_array[$row["status"]];
-      $row["customerBilledDollars"] = $t->pay_info["total_customerBilledDollars"];
-      $extra["customerBilledDollarsTotal"] += exchangeRate::convert($row["currencyTypeID"],$t->pay_info["total_customerBilledDollars"]);
-      $billed_tallies[] = array("amount"=>$row["customerBilledDollars"],"currency"=>$row["currencyTypeID"]);
+            $row["person"] = $people_array[$row["personID"]]["name"];
+            $row["status"] = $status_array[$row["status"]];
+            $row["customerBilledDollars"] = $t->pay_info["total_customerBilledDollars"];
+            $extra["customerBilledDollarsTotal"] += exchangeRate::convert($row["currencyTypeID"], $t->pay_info["total_customerBilledDollars"]);
+            $billed_tallies[] = array("amount"=>$row["customerBilledDollars"],"currency"=>$row["currencyTypeID"]);
 
-      if ($_FORM["showFinances"]) {
-        list($pos,$neg) = $t->get_transaction_totals();
-        $row["transactionsPos"] = page::money_print($pos);
-        $row["transactionsNeg"] = page::money_print($neg);
-        foreach ((array)$pos as $v) {
-          $pos_tallies[] = $v;
+            if ($_FORM["showFinances"]) {
+                list($pos,$neg) = $t->get_transaction_totals();
+                $row["transactionsPos"] = page::money_print($pos);
+                $row["transactionsNeg"] = page::money_print($neg);
+                foreach ((array)$pos as $v) {
+                    $pos_tallies[] = $v;
+                }
+                foreach ((array)$neg as $v) {
+                    $neg_tallies[] = $v;
+                }
+            }
+
+            $p = new project();
+            $p->read_db_record($db);
+            $row["projectLink"] = $t->get_link($p->get_name($_FORM));
+            $rows[$row["timeSheetID"]] = $row;
         }
-        foreach ((array)$neg as $v) {
-          $neg_tallies[] = $v;
-        }
-      }
 
-      $p = new project();
-      $p->read_db_record($db);
-      $row["projectLink"] = $t->get_link($p->get_name($_FORM));
-      $rows[$row["timeSheetID"]] = $row;
+        $extra["amount_tallies"] = page::money_print($amount_tallies);
+        $extra["billed_tallies"] = page::money_print($billed_tallies);
+        $extra["positive_tallies"] = page::money_print($pos_tallies);
+        $extra["negative_tallies"] = page::money_print($neg_tallies);
+
+        if (!$_FORM["noextra"]) {
+            return array("rows"=>(array)$rows,"extra"=>$extra);
+        } else {
+            return (array)$rows;
+        }
     }
 
-    $extra["amount_tallies"] = page::money_print($amount_tallies);
-    $extra["billed_tallies"] = page::money_print($billed_tallies);
-    $extra["positive_tallies"] = page::money_print($pos_tallies);
-    $extra["negative_tallies"] = page::money_print($neg_tallies);
-
-    if (!$_FORM["noextra"]) {
-      return array("rows"=>(array)$rows,"extra"=>$extra);
-    } else {
-      return (array)$rows;
+    function get_list_html($rows = array(), $extra = array())
+    {
+        global $TPL;
+        $TPL["timeSheetListRows"] = $rows;
+        $TPL["extra"] = $extra;
+        include_template(dirname(__FILE__)."/../templates/timeSheetListS.tpl");
     }
-  }
 
-  function get_list_html($rows=array(),$extra=array()) {
-    global $TPL;
-    $TPL["timeSheetListRows"] = $rows;
-    $TPL["extra"] = $extra;
-    include_template(dirname(__FILE__)."/../templates/timeSheetListS.tpl");
-  }
-
-  function get_transaction_totals() {
+    function get_transaction_totals()
+    {
   
-    $db = new db_alloc();
-    $q = prepare("SELECT amount * pow(10,-currencyType.numberToBasic) AS amount,
+        $db = new db_alloc();
+        $q = prepare("SELECT amount * pow(10,-currencyType.numberToBasic) AS amount,
                          transaction.currencyTypeID as currency
                     FROM transaction 
                LEFT JOIN currencyType on transaction.currencyTypeID = currencyType.currencyTypeID
                    WHERE status = 'approved' 
                      AND timeSheetID = %d
-                 ",$this->get_id());
-    $db->query($q);
-    while($row = $db->row()) {
-      if ($row["amount"] > 0) {
-        $pos[] = $row;
-      } else {
-        $neg[] = $row;
-      }
+                 ", $this->get_id());
+        $db->query($q);
+        while ($row = $db->row()) {
+            if ($row["amount"] > 0) {
+                $pos[] = $row;
+            } else {
+                $neg[] = $row;
+            }
+        }
+
+        return array($pos,$neg);
     }
 
-    return array($pos,$neg);
-  }
+    function get_url()
+    {
+        global $sess;
+        $sess or $sess = new session();
 
-  function get_url() {
-    global $sess;
-    $sess or $sess = new session();
+        $url = "time/timeSheet.php?timeSheetID=".$this->get_id();
 
-    $url = "time/timeSheet.php?timeSheetID=".$this->get_id();
+        if ($sess->Started()) {
+            $url = $sess->url(SCRIPT_PATH.$url);
 
-    if ($sess->Started()) {
-      $url = $sess->url(SCRIPT_PATH.$url);
-
-    // This for urls that are emailed
-    } else {
-      static $prefix;
-      $prefix or $prefix = config::get_config_item("allocURL");
-      $url = $prefix.$url;
+        // This for urls that are emailed
+        } else {
+            static $prefix;
+            $prefix or $prefix = config::get_config_item("allocURL");
+            $url = $prefix.$url;
+        }
+        return $url;
     }
-    return $url;
-  }
 
-  function get_link($text=false) {
-    $text or $text = $this->get_id();
-    return "<a href=\"".$this->get_url()."\">".$text."</a>";
-  }
+    function get_link($text = false)
+    {
+        $text or $text = $this->get_id();
+        return "<a href=\"".$this->get_url()."\">".$text."</a>";
+    }
 
-  function get_list_vars() {
-    return array("return"                         => "[MANDATORY] eg: array | html"
+    function get_list_vars()
+    {
+        return array("return"                         => "[MANDATORY] eg: array | html"
                 ,"timeSheetID"                    => "Time Sheet that has this ID"
                 ,"starred"                        => "Time Sheet that have been starred"
                 ,"projectID"                      => "Time Sheets that belong to this Project"
@@ -666,208 +687,212 @@ class timeSheet extends db_entity {
                 ,"tfID"                           => "Time sheets that belong to this TF"
                 ,"showAllProjects"                => "Show archived and potential projects"
                 );
-  }
-
-  function load_form_data($defaults=array()) {
-    $current_user = &singleton("current_user");
-
-    $page_vars = array_keys(timeSheet::get_list_vars());
-
-    $_FORM = get_all_form_data($page_vars,$defaults);
-
-    if (!$_FORM["applyFilter"]) {
-      $_FORM = $current_user->prefs[$_FORM["form_name"]];
-      if (!isset($current_user->prefs[$_FORM["form_name"]])) {
-        $_FORM["status"] = "edit";
-        $_FORM["personID"] = $current_user->get_id();
-      }
-
-    } else if ($_FORM["applyFilter"] && is_object($current_user) && !$_FORM["dontSave"]) {
-      $url = $_FORM["url_form_action"];
-      unset($_FORM["url_form_action"]);
-      $current_user->prefs[$_FORM["form_name"]] = $_FORM;
-      $_FORM["url_form_action"] = $url;
     }
 
-    return $_FORM;
-  }
+    function load_form_data($defaults = array())
+    {
+        $current_user = &singleton("current_user");
 
-  function load_timeSheet_filter($_FORM) {
-    $current_user = &singleton("current_user");
+        $page_vars = array_keys(timeSheet::get_list_vars());
 
-    // display the list of project name.
-    $db = new db_alloc();
-    if (!$_FORM['showAllProjects']) {
-      $filter = "WHERE projectStatus = 'Current' ";
-    }
-    $query = prepare("SELECT projectID AS value, projectName AS label FROM project $filter ORDER by projectName");
-    $rtn["show_project_options"] = page::select_options($query, $_FORM["projectID"],70);
+        $_FORM = get_all_form_data($page_vars, $defaults);
 
-    // display the list of user name.
-    if (have_entity_perm("timeSheet", PERM_READ, $current_user, false)) {
-      $rtn["show_userID_options"] = page::select_options(person::get_username_list(), $_FORM["personID"]);
-      
-    } else {
-      $person = new person();
-      $person->set_id($current_user->get_id());
-      $person->select();
-      $person_array = array($current_user->get_id()=>$person->get_name());
-      $rtn["show_userID_options"] = page::select_options($person_array, $_FORM["personID"]);
-    } 
+        if (!$_FORM["applyFilter"]) {
+            $_FORM = $current_user->prefs[$_FORM["form_name"]];
+            if (!isset($current_user->prefs[$_FORM["form_name"]])) {
+                $_FORM["status"] = "edit";
+                $_FORM["personID"] = $current_user->get_id();
+            }
+        } else if ($_FORM["applyFilter"] && is_object($current_user) && !$_FORM["dontSave"]) {
+            $url = $_FORM["url_form_action"];
+            unset($_FORM["url_form_action"]);
+            $current_user->prefs[$_FORM["form_name"]] = $_FORM;
+            $_FORM["url_form_action"] = $url;
+        }
 
-    // display a list of status
-    $status_array = timeSheet::get_timeSheet_statii();
-    unset($status_array["create"]);
-
-    if (!$_FORM["status"]) {
-      $_FORM["status"][] = 'edit';
-    }
-    $rtn["show_status_options"] = page::select_options($status_array,$_FORM["status"]);
-
-    // display the date from filter value
-    $rtn["dateFrom"] = $_FORM["dateFrom"];
-    $rtn["dateTo"] = $_FORM["dateTo"];
-    $rtn["userID"] = $current_user->get_id();
-    $rtn["showFinances"] = $_FORM["showFinances"];
-    $rtn["showAllProjects"] = $_FORM["showAllProjects"];
-
-    // Get
-    $rtn["FORM"] = "FORM=".urlencode(serialize($_FORM));
-
-    return $rtn;
-  }
-
-  function get_invoice_link() {
-    global $TPL;
-    $rows = invoiceEntity::get("timeSheet",$this->get_id());
-    foreach ($rows as $row) {
-      $str.= $sp."<a href=\"".$TPL["url_alloc_invoice"]."invoiceID=".$row["invoiceID"]."\">".$row["invoiceNum"]."</a>";
-      $sp = "&nbsp;&nbsp;";
-    }
-    return $str;
-  }
-
-  function change_status($direction) {
-    // access controls are partially disabled for timesheets. Make sure time sheet is really accessible by checking
-    // user ID - it's restricted to being NOT NULL in the DB. Not doing this check allows a user to overwrite
-    // an existing timesheet with a new one assigned to themself.
-
-    if (!$this->get_value("personID")) {
-      alloc_error("You do not have access to this timesheet.");
+        return $_FORM;
     }
 
-    $info = $this->get_email_vars();
-    if (is_array($info["projectManagers"]) && count($info["projectManagers"])) {
-      $steps["forwards"]["edit"] = "manager";
-      $steps["forwards"]["rejected"] = "manager";
-      $steps["backwards"]["admin"] = "manager";
-    } else {
-      $steps["forwards"]["edit"] = "admin";
-      $steps["forwards"]["rejected"] = "admin";
-      $steps["backwards"]["admin"] = "edit";
-    }
-    $steps["forwards"][""] = "edit";
-    $steps["forwards"]["manager"] = "admin";
-    $steps["forwards"]["admin"] = "invoiced";
-    $steps["forwards"]["invoiced"] = "finished";
-    $steps["forwards"]["finished"] = "";
-    $steps["backwards"]["finished"] = "invoiced";
-    $steps["backwards"]["invoiced"] = "admin";
-    $steps["backwards"]["manager"] = "edit";
-    $status = $this->get_value("status");
-    $newstatus = $steps[$direction][$status];
-    if ($newstatus) {
-      $m = $this->{"email_move_status_to_".$newstatus}($direction,$info);
-      //$this->save();
-      if (is_array($m)) { 
-        return implode("<br>",$m);
-      }
-    }
-  }
+    function load_timeSheet_filter($_FORM)
+    {
+        $current_user = &singleton("current_user");
 
-  function email_move_status_to_edit($direction,$info) { 
-    // is possible to move backwards to "edit", from both "manager" and "admin"
-    // requires manager or APPROVE_TIMESHEET permission
-    $current_user = &singleton("current_user");
-    $project = $this->get_foreign_object("project");
-    $projectManagers = $project->get_timeSheetRecipients();
-    if ($direction == "backwards") {
-      if (!in_array($current_user->get_id(), $projectManagers) &&
-        !$this->have_perm(PERM_TIME_APPROVE_TIMESHEETS)) {
-          //error, go away
-          alloc_error("You do not have permission to change this timesheet.");
-      }
-      $email = array();
-      $email["type"] = "timesheet_reject";
-      $email["to"] = $info["timeSheet_personID_email"];
-      $email["subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_timeSheetFromManager"), "timeSheet", $this->get_id());
-      $email["body"] = <<<EOD
+      // display the list of project name.
+        $db = new db_alloc();
+        if (!$_FORM['showAllProjects']) {
+            $filter = "WHERE projectStatus = 'Current' ";
+        }
+        $query = prepare("SELECT projectID AS value, projectName AS label FROM project $filter ORDER by projectName");
+        $rtn["show_project_options"] = page::select_options($query, $_FORM["projectID"], 70);
+
+      // display the list of user name.
+        if (have_entity_perm("timeSheet", PERM_READ, $current_user, false)) {
+            $rtn["show_userID_options"] = page::select_options(person::get_username_list(), $_FORM["personID"]);
+        } else {
+            $person = new person();
+            $person->set_id($current_user->get_id());
+            $person->select();
+            $person_array = array($current_user->get_id()=>$person->get_name());
+            $rtn["show_userID_options"] = page::select_options($person_array, $_FORM["personID"]);
+        }
+
+      // display a list of status
+        $status_array = timeSheet::get_timeSheet_statii();
+        unset($status_array["create"]);
+
+        if (!$_FORM["status"]) {
+            $_FORM["status"][] = 'edit';
+        }
+        $rtn["show_status_options"] = page::select_options($status_array, $_FORM["status"]);
+
+      // display the date from filter value
+        $rtn["dateFrom"] = $_FORM["dateFrom"];
+        $rtn["dateTo"] = $_FORM["dateTo"];
+        $rtn["userID"] = $current_user->get_id();
+        $rtn["showFinances"] = $_FORM["showFinances"];
+        $rtn["showAllProjects"] = $_FORM["showAllProjects"];
+
+      // Get
+        $rtn["FORM"] = "FORM=".urlencode(serialize($_FORM));
+
+        return $rtn;
+    }
+
+    function get_invoice_link()
+    {
+        global $TPL;
+        $rows = invoiceEntity::get("timeSheet", $this->get_id());
+        foreach ($rows as $row) {
+            $str.= $sp."<a href=\"".$TPL["url_alloc_invoice"]."invoiceID=".$row["invoiceID"]."\">".$row["invoiceNum"]."</a>";
+            $sp = "&nbsp;&nbsp;";
+        }
+        return $str;
+    }
+
+    function change_status($direction)
+    {
+      // access controls are partially disabled for timesheets. Make sure time sheet is really accessible by checking
+      // user ID - it's restricted to being NOT NULL in the DB. Not doing this check allows a user to overwrite
+      // an existing timesheet with a new one assigned to themself.
+
+        if (!$this->get_value("personID")) {
+            alloc_error("You do not have access to this timesheet.");
+        }
+
+        $info = $this->get_email_vars();
+        if (is_array($info["projectManagers"]) && count($info["projectManagers"])) {
+            $steps["forwards"]["edit"] = "manager";
+            $steps["forwards"]["rejected"] = "manager";
+            $steps["backwards"]["admin"] = "manager";
+        } else {
+            $steps["forwards"]["edit"] = "admin";
+            $steps["forwards"]["rejected"] = "admin";
+            $steps["backwards"]["admin"] = "edit";
+        }
+        $steps["forwards"][""] = "edit";
+        $steps["forwards"]["manager"] = "admin";
+        $steps["forwards"]["admin"] = "invoiced";
+        $steps["forwards"]["invoiced"] = "finished";
+        $steps["forwards"]["finished"] = "";
+        $steps["backwards"]["finished"] = "invoiced";
+        $steps["backwards"]["invoiced"] = "admin";
+        $steps["backwards"]["manager"] = "edit";
+        $status = $this->get_value("status");
+        $newstatus = $steps[$direction][$status];
+        if ($newstatus) {
+            $m = $this->{"email_move_status_to_".$newstatus}($direction, $info);
+          //$this->save();
+            if (is_array($m)) {
+                return implode("<br>", $m);
+            }
+        }
+    }
+
+    function email_move_status_to_edit($direction, $info)
+    {
+      // is possible to move backwards to "edit", from both "manager" and "admin"
+      // requires manager or APPROVE_TIMESHEET permission
+        $current_user = &singleton("current_user");
+        $project = $this->get_foreign_object("project");
+        $projectManagers = $project->get_timeSheetRecipients();
+        if ($direction == "backwards") {
+            if (!in_array($current_user->get_id(), $projectManagers) &&
+            !$this->have_perm(PERM_TIME_APPROVE_TIMESHEETS)) {
+                //error, go away
+                alloc_error("You do not have permission to change this timesheet.");
+            }
+            $email = array();
+            $email["type"] = "timesheet_reject";
+            $email["to"] = $info["timeSheet_personID_email"];
+            $email["subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_timeSheetFromManager"), "timeSheet", $this->get_id());
+            $email["body"] = <<<EOD
          To: {$info["timeSheet_personID_name"]}
  Time Sheet: {$info["url"]}
 For Project: {$info["projectName"]}
 Rejected By: {$info["people_cache"][$current_user->get_id()]["name"]}
 
 EOD;
-      $this->get_value("billingNote") 
-      and $email["body"].= "Billing Note: ".$this->get_value("billingNote");
-      $msg[] = $this->shootEmail($email);
+            $this->get_value("billingNote")
+            and $email["body"].= "Billing Note: ".$this->get_value("billingNote");
+            $msg[] = $this->shootEmail($email);
 
-      $this->set_value("dateSubmittedToAdmin", "");   
-      $this->set_value("approvedByAdminPersonID", "");   
-      $this->set_value("dateSubmittedToManager", "");     
-      $this->set_value("approvedByManagerPersonID", "");   
-      $this->set_value("dateRejected", date("Y-m-d"));
-    }
-    $this->set_value("status", "rejected");
-    return $msg;
-  }
-
-  function email_move_status_to_manager($direction,$info) { 
-    $current_user = &singleton("current_user");
-    $project = $this->get_foreign_object("project");
-    $projectManagers = $project->get_timeSheetRecipients();
-    // Can get forwards to "manager" only from "edit" or "rejected"
-    if ($direction == "forwards") {
-      //forward to manager requires the timesheet to be owned by the current 
-      //user or TIME_INVOICE_TIMESHEETS
-      //project managers may not do this
-      if (!($this->get_value("personID") == $current_user->get_id() || $this->have_perm(PERM_TIME_INVOICE_TIMESHEETS))) {
-        alloc_error("You do not have permission to change this timesheet.");
-      }
-      $this->set_value("dateSubmittedToManager", date("Y-m-d"));
-      $this->set_value("dateRejected", "");
-      // Check for time overrun
-      $overrun_tasks = array();
-      $db = new db_alloc();
-      $task_id_query = prepare("SELECT DISTINCT taskID FROM timeSheetItem WHERE timeSheetID=%d ORDER BY dateTimeSheetItem, timeSheetItemID", $this->get_id());
-      $db->query($task_id_query);
-      while($db->next_record()) {
-        $task = new task();
-        $task->read_db_record($db);
-        $task->select();
-        if($task->get_value('timeLimit') > 0) {
-          $total_billed_time = ($task->get_time_billed(false)) / 3600;
-          if($total_billed_time > $task->get_value('timeLimit')) {
-            $overrun_tasks[] = sprintf(" * %d %s (limit: %.02f hours, billed so far: %.02f hours)", $task->get_id(), $task->get_value('taskName'), $task->get_value('timeLimit'), $total_billed_time);
-          }
+            $this->set_value("dateSubmittedToAdmin", "");
+            $this->set_value("approvedByAdminPersonID", "");
+            $this->set_value("dateSubmittedToManager", "");
+            $this->set_value("approvedByManagerPersonID", "");
+            $this->set_value("dateRejected", date("Y-m-d"));
         }
-        $hasItems = true;
-      }
+        $this->set_value("status", "rejected");
+        return $msg;
+    }
 
-      if (!$hasItems) {
-        return alloc_error('Unable to submit time sheet, no items have been added.');
-      }
+    function email_move_status_to_manager($direction, $info)
+    {
+        $current_user = &singleton("current_user");
+        $project = $this->get_foreign_object("project");
+        $projectManagers = $project->get_timeSheetRecipients();
+      // Can get forwards to "manager" only from "edit" or "rejected"
+        if ($direction == "forwards") {
+          //forward to manager requires the timesheet to be owned by the current
+          //user or TIME_INVOICE_TIMESHEETS
+          //project managers may not do this
+            if (!($this->get_value("personID") == $current_user->get_id() || $this->have_perm(PERM_TIME_INVOICE_TIMESHEETS))) {
+                alloc_error("You do not have permission to change this timesheet.");
+            }
+            $this->set_value("dateSubmittedToManager", date("Y-m-d"));
+            $this->set_value("dateRejected", "");
+          // Check for time overrun
+            $overrun_tasks = array();
+            $db = new db_alloc();
+            $task_id_query = prepare("SELECT DISTINCT taskID FROM timeSheetItem WHERE timeSheetID=%d ORDER BY dateTimeSheetItem, timeSheetItemID", $this->get_id());
+            $db->query($task_id_query);
+            while ($db->next_record()) {
+                $task = new task();
+                $task->read_db_record($db);
+                $task->select();
+                if ($task->get_value('timeLimit') > 0) {
+                    $total_billed_time = ($task->get_time_billed(false)) / 3600;
+                    if ($total_billed_time > $task->get_value('timeLimit')) {
+                        $overrun_tasks[] = sprintf(" * %d %s (limit: %.02f hours, billed so far: %.02f hours)", $task->get_id(), $task->get_value('taskName'), $task->get_value('timeLimit'), $total_billed_time);
+                    }
+                }
+                $hasItems = true;
+            }
 
-      if(count($overrun_tasks)) {
-        $overrun_notice = "\n\nThe following tasks billed on this timesheet have exceeded their time estimates:\n";
-        $overrun_notice .= implode("\n", $overrun_tasks);
-      }
-      foreach ($info["projectManagers"] as $pm) {
-        $email = array();
-        $email["type"] = "timesheet_submit";
-        $email["to"] = $info["people_cache"][$pm]["emailAddress"];
-        $email["subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_timeSheetToManager"), "timeSheet", $this->get_id());
-        $email["body"] = <<<EOD
+            if (!$hasItems) {
+                return alloc_error('Unable to submit time sheet, no items have been added.');
+            }
+
+            if (count($overrun_tasks)) {
+                $overrun_notice = "\n\nThe following tasks billed on this timesheet have exceeded their time estimates:\n";
+                $overrun_notice .= implode("\n", $overrun_tasks);
+            }
+            foreach ($info["projectManagers"] as $pm) {
+                $email = array();
+                $email["type"] = "timesheet_submit";
+                $email["to"] = $info["people_cache"][$pm]["emailAddress"];
+                $email["subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_timeSheetToManager"), "timeSheet", $this->get_id());
+                $email["body"] = <<<EOD
   To Manager: {$info["people_cache"][$pm]["name"]}
   Time Sheet: {$info["url"]}
 Submitted By: {$info["timeSheet_personID_name"]}
@@ -878,22 +903,22 @@ submit the timesheet to the Administrator. If not, make it editable again for
 re-submission.$overrun_notice
 
 EOD;
-        $this->get_value("billingNote") and 
-        $email["body"].= "\n\nBilling Note: ".$this->get_value("billingNote");
-        $msg[] = $this->shootEmail($email);
-      }
-    // Can get backwards to "manager" only from "admin"
-    } else if ($direction == "backwards") {
-      //admin->manager requires APPROVE_TIMESHEETS
-      if (!$this->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
-        //no permission, go away
-        alloc_error("You do not have permission to change this timesheet.");
-      }
-      $email = array();
-      $email["type"] = "timesheet_reject";
-      $email["to"] = $info["approvedByManagerPersonID_email"];
-      $email["subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_timeSheetFromAdministrator"), "timeSheet", $this->get_id());
-      $email["body"] = <<<EOD
+                $this->get_value("billingNote") and
+                $email["body"].= "\n\nBilling Note: ".$this->get_value("billingNote");
+                $msg[] = $this->shootEmail($email);
+            }
+        // Can get backwards to "manager" only from "admin"
+        } else if ($direction == "backwards") {
+          //admin->manager requires APPROVE_TIMESHEETS
+            if (!$this->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
+                //no permission, go away
+                alloc_error("You do not have permission to change this timesheet.");
+            }
+            $email = array();
+            $email["type"] = "timesheet_reject";
+            $email["to"] = $info["approvedByManagerPersonID_email"];
+            $email["subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_timeSheetFromAdministrator"), "timeSheet", $this->get_id());
+            $email["body"] = <<<EOD
   To Manager: {$info["approvedByManagerPersonID_name"]}
   Time Sheet: {$info["url"]}
 Submitted By: {$info["timeSheet_personID_name"]}
@@ -901,53 +926,54 @@ Submitted By: {$info["timeSheet_personID_name"]}
  Rejected By: {$info["people_cache"][$current_user->get_id()]["name"]}
 
 EOD;
-      $this->get_value("billingNote") 
-      and $email["body"].= "Billing Note: ".$this->get_value("billingNote");
-      $msg[] = $this->shootEmail($email);
-      $this->set_value("dateRejected", date("Y-m-d"));
-    }
-    $this->set_value("status", "manager");
-    $this->set_value("dateSubmittedToAdmin", "");
-    $this->set_value("approvedByAdminPersonID", "");
-    return $msg;
-  }
-
-  function email_move_status_to_admin($direction,$info) { 
-    $current_user = &singleton("current_user");
-    $project = $this->get_foreign_object("project");
-    $projectManagers = $project->get_timeSheetRecipients();
-    // Can get forwards to "admin" from "edit" and "manager"
-    if ($direction == "forwards") {
-      //3 ways to have permission to do this
-      //project manager for the timesheet
-      //no project manager and owner of the timesheet
-      //the permission flag
-      if (!(in_array($current_user->get_id(), $projectManagers) || 
-        (empty($projectManagers) && $this->get_value("personID") == $current_user->get_id()) ||
-        $this->have_perm(PERM_TIME_APPROVE_TIMESHEETS))) {
-          //error, go away
-        alloc_error("You do not have permission to change this timesheet.");
-      }
-
-      $db = new db_alloc();
-      $hasItems = $db->qr("SELECT * FROM timeSheetItem WHERE timeSheetID = %d",$this->get_id());
-      if (!$hasItems) {
-        return alloc_error('Unable to submit time sheet, no items have been added.');
-      }
-
-        if ($this->get_value("status") == "manager") { 
-          $this->set_value("approvedByManagerPersonID",$current_user->get_id());
-          $extra = " Approved By: ".person::get_fullname($current_user->get_id());
+            $this->get_value("billingNote")
+            and $email["body"].= "Billing Note: ".$this->get_value("billingNote");
+            $msg[] = $this->shootEmail($email);
+            $this->set_value("dateRejected", date("Y-m-d"));
         }
-        $this->set_value("status", "admin");
-        $this->set_value("dateSubmittedToAdmin", date("Y-m-d"));
-	      $this->set_value("dateRejected", "");
-        foreach($info["timeSheetAdministrators"] as $adminID)  {
-          $email = array();
-          $email["type"] = "timesheet_submit";
-          $email["to"] = $info["people_cache"][$adminID]["emailAddress"];
-          $email["subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_timeSheetToAdministrator"), "timeSheet", $this->get_id());
-          $email["body"] = <<<EOD
+        $this->set_value("status", "manager");
+        $this->set_value("dateSubmittedToAdmin", "");
+        $this->set_value("approvedByAdminPersonID", "");
+        return $msg;
+    }
+
+    function email_move_status_to_admin($direction, $info)
+    {
+        $current_user = &singleton("current_user");
+        $project = $this->get_foreign_object("project");
+        $projectManagers = $project->get_timeSheetRecipients();
+      // Can get forwards to "admin" from "edit" and "manager"
+        if ($direction == "forwards") {
+          //3 ways to have permission to do this
+          //project manager for the timesheet
+          //no project manager and owner of the timesheet
+          //the permission flag
+            if (!(in_array($current_user->get_id(), $projectManagers) ||
+            (empty($projectManagers) && $this->get_value("personID") == $current_user->get_id()) ||
+            $this->have_perm(PERM_TIME_APPROVE_TIMESHEETS))) {
+                //error, go away
+                alloc_error("You do not have permission to change this timesheet.");
+            }
+
+            $db = new db_alloc();
+            $hasItems = $db->qr("SELECT * FROM timeSheetItem WHERE timeSheetID = %d", $this->get_id());
+            if (!$hasItems) {
+                return alloc_error('Unable to submit time sheet, no items have been added.');
+            }
+
+            if ($this->get_value("status") == "manager") {
+                $this->set_value("approvedByManagerPersonID", $current_user->get_id());
+                $extra = " Approved By: ".person::get_fullname($current_user->get_id());
+            }
+            $this->set_value("status", "admin");
+            $this->set_value("dateSubmittedToAdmin", date("Y-m-d"));
+            $this->set_value("dateRejected", "");
+            foreach ($info["timeSheetAdministrators"] as $adminID) {
+                $email = array();
+                $email["type"] = "timesheet_submit";
+                $email["to"] = $info["people_cache"][$adminID]["emailAddress"];
+                $email["subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_timeSheetToAdministrator"), "timeSheet", $this->get_id());
+                $email["body"] = <<<EOD
     To Admin: {$info["admin_name"]}
   Time Sheet: {$info["url"]}
 Submitted By: {$info["timeSheet_personID_name"]}
@@ -958,66 +984,68 @@ A timesheet has been submitted for your approval. If it is not
 satisfactory, make it editable again for re-submission.
 
 EOD;
-          $this->get_value("billingNote") 
-          and $email["body"].= "Billing Note: ".$this->get_value("billingNote");
-          $msg[] = $this->shootEmail($email);
+                $this->get_value("billingNote")
+                and $email["body"].= "Billing Note: ".$this->get_value("billingNote");
+                $msg[] = $this->shootEmail($email);
+            }
+
+        // Can get backwards to "admin" from "invoiced"
+        } else {
+          //requires INVOICE_TIMESHEETS
+            if (!$this->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
+                //no permission, go away
+                alloc_error("You do not have permission to change this timesheet.");
+            }
+
+            $this->set_value("approvedByAdminPersonID", "");
+        }
+        $this->set_value("status", "admin");
+        return $msg;
+    }
+
+    function email_move_status_to_invoiced($direction, $info)
+    {
+        $current_user = &singleton("current_user");
+      // Can get forwards to "invoiced" from "admin"
+      // requires INVOICE_TIMESHEETS
+        if (!$this->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
+            //no permission, go away
+            alloc_error("You do not have permission to change this timesheet.");
         }
 
-    // Can get backwards to "admin" from "invoiced" 
-    } else {
-      //requires INVOICE_TIMESHEETS
-      if (!$this->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
-        //no permission, go away
-        alloc_error("You do not have permission to change this timesheet.");
-      }
-
-      $this->set_value("approvedByAdminPersonID", "");
-    }
-    $this->set_value("status", "admin");
-    return $msg;
-  }
-
-  function email_move_status_to_invoiced($direction,$info) { 
-    $current_user = &singleton("current_user");
-    // Can get forwards to "invoiced" from "admin" 
-    // requires INVOICE_TIMESHEETS
-    if (!$this->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
-        //no permission, go away
-      alloc_error("You do not have permission to change this timesheet.");
+        if ($info["projectManagers"]
+        && !$this->get_value("approvedByManagerPersonID")) {
+            $this->set_value("approvedByManagerPersonID", $current_user->get_id());
+        }
+        $this->set_value("approvedByAdminPersonID", $current_user->get_id());
+        $this->set_value("status", "invoiced");
     }
 
-    if ($info["projectManagers"] 
-    && !$this->get_value("approvedByManagerPersonID")) {
-      $this->set_value("approvedByManagerPersonID", $current_user->get_id());
-    }
-    $this->set_value("approvedByAdminPersonID", $current_user->get_id());
-    $this->set_value("status", "invoiced");
-  }
+    function email_move_status_to_finished($direction, $info)
+    {
+        if ($direction == "forwards") {
+          //requires INVOICE_TIMESHEETS
+            if (!$this->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
+                //no permission, go away
+                alloc_error("You do not have permission to change this timesheet.");
+            }
 
-  function email_move_status_to_finished($direction,$info) {
-    if ($direction == "forwards") {
-      //requires INVOICE_TIMESHEETS
-      if (!$this->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
-        //no permission, go away
-        alloc_error("You do not have permission to change this timesheet.");
-      }
-
-      //transactions
-      $q = prepare("SELECT DISTINCT transaction.transactionDate, transaction.product, transaction.status
+          //transactions
+            $q = prepare("SELECT DISTINCT transaction.transactionDate, transaction.product, transaction.status
                       FROM transaction
                       JOIN tf ON tf.tfID = transaction.tfID OR tf.tfID = transaction.fromTfID
                 RIGHT JOIN tfPerson ON tfPerson.personID = %d AND tfPerson.tfID = tf.tfID
                      WHERE transaction.timeSheetID = %d
                    ", $this->get_value('personID'), $this->get_id());
-      $db = new db_alloc();
-      $db->query($q);
+            $db = new db_alloc();
+            $db->query($q);
 
-      //the email itself
-      $email = array();
-      $email["type"] = "timesheet_finished";
-      $email["to"] = $info["timeSheet_personID_email"];
-      $email["subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_timeSheetCompleted"), "timeSheet", $this->get_id());
-      $email["body"] = <<<EOD
+          //the email itself
+            $email = array();
+            $email["type"] = "timesheet_finished";
+            $email["to"] = $info["timeSheet_personID_email"];
+            $email["subject"] = commentTemplate::populate_string(config::get_config_item("emailSubject_timeSheetCompleted"), "timeSheet", $this->get_id());
+            $email["body"] = <<<EOD
          To: {$info["timeSheet_personID_name"]}
  Time Sheet: {$info["url"]}
 For Project: {$info["projectName"]}
@@ -1026,315 +1054,317 @@ Your timesheet has been completed by {$info["current_user_name"]}.
 
 EOD;
 
-      if($db->num_rows() > 0) {
-        $email["body"] .= "Transaction summary:\n";
-        $status_ops = array("pending" => "Pending", "approved" => "Approved", "rejected" => "Rejected");
-        while($db->next_record()) {
-          $email["body"] .= $db->f("transactionDate") . " for " . $db->f("product") . ": " . $status_ops[$db->f("status")] . "\n";
+            if ($db->num_rows() > 0) {
+                  $email["body"] .= "Transaction summary:\n";
+                  $status_ops = array("pending" => "Pending", "approved" => "Approved", "rejected" => "Rejected");
+                while ($db->next_record()) {
+                    $email["body"] .= $db->f("transactionDate") . " for " . $db->f("product") . ": " . $status_ops[$db->f("status")] . "\n";
+                }
+            }
+            $msg[] = $this->shootEmail($email);
+            $this->set_value("status", "finished");
+            return $msg;
         }
-      }
-      $msg[] = $this->shootEmail($email);
-      $this->set_value("status", "finished");
-      return $msg;
-    } 
-  }
-
-  function pending_transactions_to_approved() {
-    if (!$this->have_perm(PERM_TIME_APPROVE_TIMESHEETS)) {
-      //no permission, die
-      alloc_error("You do not have permission to approve transactions for this timesheet.");
     }
 
-    $db = new db_alloc();
-    $q = prepare("UPDATE transaction SET status = 'approved' WHERE timeSheetID = %d AND status = 'pending'",$this->get_id());
-    $db->query($q);
-  }
+    function pending_transactions_to_approved()
+    {
+        if (!$this->have_perm(PERM_TIME_APPROVE_TIMESHEETS)) {
+          //no permission, die
+            alloc_error("You do not have permission to approve transactions for this timesheet.");
+        }
 
-  function get_email_vars() {
-    $current_user = &singleton("current_user");
-    static $rtn;
-    if ($rtn) {
-      return $rtn;
-    }
-    // Get vars for the emails below
-    $rtn["people_cache"] = $people_cache =& get_cached_table("person");
-    $project = $this->get_foreign_object("project");
-    $rtn["projectManagers"] = $project->get_timeSheetRecipients();
-    $rtn["projectName"] = $project->get_value("projectName");
-    $rtn["timeSheet_personID_email"] = $people_cache[$this->get_value("personID")]["emailAddress"];
-    $rtn["timeSheet_personID_name"]  = $people_cache[$this->get_value("personID")]["name"];
-    $rtn["url"] = config::get_config_item("allocURL")."time/timeSheet.php?timeSheetID=".$this->get_id();
-    $rtn["timeSheetAdministrators"] = config::get_config_item('defaultTimeSheetAdminList');
-    $rtn["approvedByManagerPersonID_email"] = $people_cache[$this->get_value("approvedByManagerPersonID")]["emailAddress"];
-    $rtn["approvedByManagerPersonID_name"] = $people_cache[$this->get_value("approvedByManagerPersonID")]["name"];
-    $rtn["approvedByAdminPersonID_name"] = $people_cache[$this->get_value("approvedByAdminPersonID")]["name"];
-    $rtn["current_user_name"] = $people_cache[$current_user->get_id()]["name"];
-    return $rtn;
-  }
-
-  function add_timeSheetItem($stuff) {
-    $current_user = &singleton("current_user");
-
-    $errstr = "Failed to record new time sheet item. ";
-    $taskID = $stuff["taskID"];
-    $projectID = $stuff["projectID"];
-    $duration = $stuff["duration"];
-    $comment = $stuff["comment"];
-    $emailUID = $stuff["msg_uid"];
-    $emailMessageID = $stuff["msg_id"];
-    $date = $stuff["date"];
-    $unit = $stuff["unit"];
-    $multiplier = $stuff["multiplier"];
-
-    if ($taskID) {
-      $task = new task();
-      $task->set_id($taskID);
-      $task->select();
-      $projectID = $task->get_value("projectID");
-      $extra = " for task ".$taskID;
+        $db = new db_alloc();
+        $q = prepare("UPDATE transaction SET status = 'approved' WHERE timeSheetID = %d AND status = 'pending'", $this->get_id());
+        $db->query($q);
     }
 
-    $projectID or alloc_error(sprintf($errstr."No project found%s.",$extra));
+    function get_email_vars()
+    {
+        $current_user = &singleton("current_user");
+        static $rtn;
+        if ($rtn) {
+            return $rtn;
+        }
+      // Get vars for the emails below
+        $rtn["people_cache"] = $people_cache =& get_cached_table("person");
+        $project = $this->get_foreign_object("project");
+        $rtn["projectManagers"] = $project->get_timeSheetRecipients();
+        $rtn["projectName"] = $project->get_value("projectName");
+        $rtn["timeSheet_personID_email"] = $people_cache[$this->get_value("personID")]["emailAddress"];
+        $rtn["timeSheet_personID_name"]  = $people_cache[$this->get_value("personID")]["name"];
+        $rtn["url"] = config::get_config_item("allocURL")."time/timeSheet.php?timeSheetID=".$this->get_id();
+        $rtn["timeSheetAdministrators"] = config::get_config_item('defaultTimeSheetAdminList');
+        $rtn["approvedByManagerPersonID_email"] = $people_cache[$this->get_value("approvedByManagerPersonID")]["emailAddress"];
+        $rtn["approvedByManagerPersonID_name"] = $people_cache[$this->get_value("approvedByManagerPersonID")]["name"];
+        $rtn["approvedByAdminPersonID_name"] = $people_cache[$this->get_value("approvedByAdminPersonID")]["name"];
+        $rtn["current_user_name"] = $people_cache[$current_user->get_id()]["name"];
+        return $rtn;
+    }
 
-    $row_projectPerson = projectPerson::get_projectPerson_row($projectID, $current_user->get_id());
-    $row_projectPerson or alloc_error($errstr."The person(".$current_user->get_id().") has not been added to the project(".$projectID.").");
+    function add_timeSheetItem($stuff)
+    {
+        $current_user = &singleton("current_user");
 
-    if ($row_projectPerson && $projectID) {
+        $errstr = "Failed to record new time sheet item. ";
+        $taskID = $stuff["taskID"];
+        $projectID = $stuff["projectID"];
+        $duration = $stuff["duration"];
+        $comment = $stuff["comment"];
+        $emailUID = $stuff["msg_uid"];
+        $emailMessageID = $stuff["msg_id"];
+        $date = $stuff["date"];
+        $unit = $stuff["unit"];
+        $multiplier = $stuff["multiplier"];
 
-      if ($stuff["timeSheetID"]) {
-        $q = prepare("SELECT *
+        if ($taskID) {
+            $task = new task();
+            $task->set_id($taskID);
+            $task->select();
+            $projectID = $task->get_value("projectID");
+            $extra = " for task ".$taskID;
+        }
+
+        $projectID or alloc_error(sprintf($errstr."No project found%s.", $extra));
+
+        $row_projectPerson = projectPerson::get_projectPerson_row($projectID, $current_user->get_id());
+        $row_projectPerson or alloc_error($errstr."The person(".$current_user->get_id().") has not been added to the project(".$projectID.").");
+
+        if ($row_projectPerson && $projectID) {
+            if ($stuff["timeSheetID"]) {
+                $q = prepare("SELECT *
                         FROM timeSheet
                        WHERE status = 'edit'
                          AND personID = %d
                          AND timeSheetID = %d
                     ORDER BY dateFrom
                        LIMIT 1
-                  ",$current_user->get_id(),$stuff["timeSheetID"]);
-        $db = new db_alloc();
-        $db->query($q);
-        $row = $db->row();
-        $row or alloc_error("Couldn't find an editable time sheet with that ID.");
-
-      } else {
-        $q = prepare("SELECT *
+                  ", $current_user->get_id(), $stuff["timeSheetID"]);
+                $db = new db_alloc();
+                $db->query($q);
+                $row = $db->row();
+                $row or alloc_error("Couldn't find an editable time sheet with that ID.");
+            } else {
+                $q = prepare("SELECT *
                         FROM timeSheet
                        WHERE status = 'edit'
                          AND projectID = %d
                          AND personID = %d
                     ORDER BY dateFrom
                        LIMIT 1
-                  ",$projectID, $current_user->get_id());
-        $db = new db_alloc();
-        $db->query($q);
-        $row = $db->row();
-      }
+                  ", $projectID, $current_user->get_id());
+                $db = new db_alloc();
+                $db->query($q);
+                $row = $db->row();
+            }
 
-      // If no timeSheets add a new one
-      if (!$row) {
-        $project = new project();
-        $project->set_id($projectID);
-        $project->select();
+          // If no timeSheets add a new one
+            if (!$row) {
+                $project = new project();
+                $project->set_id($projectID);
+                $project->select();
 
-        $timeSheet = new timeSheet();
-        $timeSheet->set_value("projectID",$projectID);
-        $timeSheet->set_value("status","edit");
-        $timeSheet->set_value("personID", $current_user->get_id());
-        $timeSheet->set_value("recipient_tfID",$current_user->get_value("preferred_tfID"));
-        $timeSheet->set_value("customerBilledDollars",page::money($project->get_value("currencyTypeID"),$project->get_value("customerBilledDollars"),"%mo"));
-        $timeSheet->set_value("currencyTypeID",$project->get_value("currencyTypeID"));
-        $timeSheet->save();
-        $timeSheetID = $timeSheet->get_id();
+                $timeSheet = new timeSheet();
+                $timeSheet->set_value("projectID", $projectID);
+                $timeSheet->set_value("status", "edit");
+                $timeSheet->set_value("personID", $current_user->get_id());
+                $timeSheet->set_value("recipient_tfID", $current_user->get_value("preferred_tfID"));
+                $timeSheet->set_value("customerBilledDollars", page::money($project->get_value("currencyTypeID"), $project->get_value("customerBilledDollars"), "%mo"));
+                $timeSheet->set_value("currencyTypeID", $project->get_value("currencyTypeID"));
+                $timeSheet->save();
+                $timeSheetID = $timeSheet->get_id();
 
-      // Else use the first timesheet we found
-      } else {
-        $timeSheetID = $row["timeSheetID"];
-      }   
+              // Else use the first timesheet we found
+            } else {
+                $timeSheetID = $row["timeSheetID"];
+            }
 
-      $timeSheetID or alloc_error($errstr."Couldn't locate an existing, or create a new Time Sheet.");
+            $timeSheetID or alloc_error($errstr."Couldn't locate an existing, or create a new Time Sheet.");
 
-      // Add new time sheet item
-      if ($timeSheetID) {
-        $timeSheet = new timeSheet();
-        $timeSheet->set_id($timeSheetID);
-        $timeSheet->select();
+          // Add new time sheet item
+            if ($timeSheetID) {
+                $timeSheet = new timeSheet();
+                $timeSheet->set_id($timeSheetID);
+                $timeSheet->select();
 
-        $tsi = new timeSheetItem();
-        $tsi->currency = $timeSheet->get_value("currencyTypeID");
-        $tsi->set_value("timeSheetID",$timeSheetID);
-        $d = $date or $d = date("Y-m-d");
-        $tsi->set_value("dateTimeSheetItem",$d);
-        $tsi->set_value("timeSheetItemDuration",$duration);
-        $tsi->set_value("timeSheetItemDurationUnitID", $unit);
-        if (is_object($task)) {
-          $tsi->set_value("description",$task->get_name());
-          $tsi->set_value("taskID",sprintf("%d",$taskID));
-          $_POST["timeSheetItem_taskID"] = sprintf("%d",$taskID); // this gets used in timeSheetItem->save();
+                $tsi = new timeSheetItem();
+                $tsi->currency = $timeSheet->get_value("currencyTypeID");
+                $tsi->set_value("timeSheetID", $timeSheetID);
+                $d = $date or $d = date("Y-m-d");
+                $tsi->set_value("dateTimeSheetItem", $d);
+                $tsi->set_value("timeSheetItemDuration", $duration);
+                $tsi->set_value("timeSheetItemDurationUnitID", $unit);
+                if (is_object($task)) {
+                    $tsi->set_value("description", $task->get_name());
+                    $tsi->set_value("taskID", sprintf("%d", $taskID));
+                    $_POST["timeSheetItem_taskID"] = sprintf("%d", $taskID); // this gets used in timeSheetItem->save();
+                }
+                $tsi->set_value("personID", $current_user->get_id());
+                $tsi->set_value("rate", page::money($timeSheet->get_value("currencyTypeID"), $row_projectPerson["rate"], "%mo"));
+                $tsi->set_value("multiplier", $multiplier);
+                $tsi->set_value("comment", $comment);
+                $tsi->set_value("emailUID", $emailUID);
+                $tsi->set_value("emailMessageID", $emailMessageID);
+                $tsi->save();
+                $id = $tsi->get_id();
+
+                $tsi = new timeSheetItem();
+                $tsi->set_id($id);
+                $tsi->select();
+                $ID = $tsi->get_value("timeSheetID");
+            }
         }
-        $tsi->set_value("personID",$current_user->get_id());
-        $tsi->set_value("rate",page::money($timeSheet->get_value("currencyTypeID"),$row_projectPerson["rate"],"%mo"));
-        $tsi->set_value("multiplier",$multiplier);
-        $tsi->set_value("comment",$comment);
-        $tsi->set_value("emailUID",$emailUID);
-        $tsi->set_value("emailMessageID",$emailMessageID);
-        $tsi->save();
-        $id = $tsi->get_id();
 
-        $tsi = new timeSheetItem();
-        $tsi->set_id($id);
-        $tsi->select();
-        $ID = $tsi->get_value("timeSheetID");
-      }
+        if ($ID) {
+            return array("status"=>"yay","message"=>$ID);
+        } else {
+            alloc_error($errstr."Time not added.");
+        }
     }
 
-    if ($ID) {
-      return array("status"=>"yay","message"=>$ID);
-    } else {
-      alloc_error($errstr."Time not added.");
+    function get_all_parties($projectID = "")
+    {
+        $db = new db_alloc();
+        $interestedPartyOptions = array();
+
+        if (!$projectID && is_object($this)) {
+            $projectID = $this->get_value("projectID");
+        }
+
+        if ($projectID) {
+            $project = new project($projectID);
+            $interestedPartyOptions = $project->get_all_parties();
+        }
+
+        $extra_interested_parties = config::get_config_item("defaultInterestedParties") or $extra_interested_parties=array();
+        foreach ($extra_interested_parties as $name => $email) {
+            $interestedPartyOptions[$email] = array("name"=>$name);
+        }
+
+        if (is_object($this)) {
+            if ($this->get_value("personID")) {
+                $p = new person();
+                $p->set_id($this->get_value("personID"));
+                $p->select();
+                $p->get_value("emailAddress") and $interestedPartyOptions[$p->get_value("emailAddress")] = array("name"=>$p->get_value("firstName")." ".$p->get_value("surname"), "role"=>"assignee", "selected"=>false, "personID"=>$this->get_value("personID"));
+            }
+            if ($this->get_value("approvedByManagerPersonID")) {
+                $p = new person();
+                $p->set_id($this->get_value("approvedByManagerPersonID"));
+                $p->select();
+                $p->get_value("emailAddress") and $interestedPartyOptions[$p->get_value("emailAddress")] = array("name"=>$p->get_value("firstName")." ".$p->get_value("surname"), "role"=>"manager", "selected"=>true, "personID"=>$this->get_value("approvedByManagerPersonID"));
+            }
+            $this_id = $this->get_id();
+        }
+      // return an aggregation of the current task/proj/client parties + the existing interested parties
+        $interestedPartyOptions = interestedParty::get_interested_parties("timeSheet", $this_id, $interestedPartyOptions);
+        return $interestedPartyOptions;
     }
-  }
 
-  function get_all_parties($projectID="") {
-    $db = new db_alloc();
-    $interestedPartyOptions = array();
-
-    if (!$projectID && is_object($this)) {
-      $projectID = $this->get_value("projectID");
-    }
-
-    if ($projectID) {
-      $project = new project($projectID);
-      $interestedPartyOptions = $project->get_all_parties();
-    }
-
-    $extra_interested_parties = config::get_config_item("defaultInterestedParties") or $extra_interested_parties=array();
-    foreach ($extra_interested_parties as $name => $email) {
-      $interestedPartyOptions[$email] = array("name"=>$name);
-    }
-
-    if (is_object($this)) {
-      if ($this->get_value("personID")) {
-        $p = new person();
-        $p->set_id($this->get_value("personID"));
-        $p->select();
-        $p->get_value("emailAddress") and $interestedPartyOptions[$p->get_value("emailAddress")] = array("name"=>$p->get_value("firstName")." ".$p->get_value("surname"), "role"=>"assignee", "selected"=>false, "personID"=>$this->get_value("personID"));
-      }
-      if ($this->get_value("approvedByManagerPersonID")) {
-        $p = new person();
-        $p->set_id($this->get_value("approvedByManagerPersonID"));
-        $p->select();
-        $p->get_value("emailAddress") and $interestedPartyOptions[$p->get_value("emailAddress")] = array("name"=>$p->get_value("firstName")." ".$p->get_value("surname"), "role"=>"manager", "selected"=>true, "personID"=>$this->get_value("approvedByManagerPersonID"));
-      }
-      $this_id = $this->get_id();
-    }
-    // return an aggregation of the current task/proj/client parties + the existing interested parties
-    $interestedPartyOptions = interestedParty::get_interested_parties("timeSheet",$this_id,$interestedPartyOptions);
-    return $interestedPartyOptions;
-  }
-
-  function get_amount_allocated($fmt="%s%mo") {
-    // Return total amount used and total amount allocated
-    if (is_object($this) && $this->get_id()) {
-      $db = new db_alloc();
-      // Get most recent invoiceItem that this time sheet belongs to.
-      $q = prepare("SELECT invoiceID
+    function get_amount_allocated($fmt = "%s%mo")
+    {
+      // Return total amount used and total amount allocated
+        if (is_object($this) && $this->get_id()) {
+            $db = new db_alloc();
+          // Get most recent invoiceItem that this time sheet belongs to.
+            $q = prepare("SELECT invoiceID
                       FROM invoiceItem
                      WHERE invoiceItem.timeSheetID = %d
                   ORDER BY invoiceItem.iiDate DESC
                      LIMIT 1
-                  ",$this->get_id());
-      $db->query($q);
-      $row = $db->row();
-      $invoiceID = $row["invoiceID"];
-      if ($invoiceID) {
-        $invoice = new invoice();
-        $invoice->set_id($invoiceID);
-        $invoice->select();
-        $maxAmount = page::money($invoice->get_value("currencyTypeID"),$invoice->get_value("maxAmount"),$fmt);
+                  ", $this->get_id());
+            $db->query($q);
+            $row = $db->row();
+            $invoiceID = $row["invoiceID"];
+            if ($invoiceID) {
+                  $invoice = new invoice();
+                  $invoice->set_id($invoiceID);
+                  $invoice->select();
+                  $maxAmount = page::money($invoice->get_value("currencyTypeID"), $invoice->get_value("maxAmount"), $fmt);
     
-        // Loop through all the other invoice items on that invoice
-        $q = prepare("SELECT sum(iiAmount) AS totalUsed FROM invoiceItem WHERE invoiceID = %d",$invoiceID);
-        $db->query($q);
-        $row2 = $db->row();
+                  // Loop through all the other invoice items on that invoice
+                  $q = prepare("SELECT sum(iiAmount) AS totalUsed FROM invoiceItem WHERE invoiceID = %d", $invoiceID);
+                  $db->query($q);
+                  $row2 = $db->row();
 
-        return array(page::money($invoice->get_value("currencyTypeID"),$row2["totalUsed"],$fmt),$maxAmount);
-
-      }
-    }
-  }
-
-  function has_attachment_permission() {
-    return $this->is_owner();
-  }
-
-  function get_name($_FORM=array()) {
-    $project = new project();
-    $project->set_id($this->get_value("projectID"));
-    $project->select();
-    $p =& get_cached_table("person");
-    return "Time Sheet for ".$project->get_name($_FORM)." by ".$p[$this->get_value("personID")]["name"];
-  }
-
-  function update_search_index_doc(&$index) {
-    $p =& get_cached_table("person");
-    $personID = $this->get_value("personID");
-    $person_field = $personID." ".$p[$personID]["username"]." ".$p[$personID]["name"];
-    $managerID = $this->get_value("approvedByManagerPersonID");
-    $manager_field = $managerID." ".$p[$managerID]["username"]." ".$p[$managerID]["name"];
-    $adminID = $this->get_value("approvedByAdminPersonID");
-    $admin_field = $adminID." ".$p[$adminID]["username"]." ".$p[$adminID]["name"];
-    $tf_field = $this->get_value("recipient_tfID")." ".tf::get_name($this->get_value("recipient_tfID"));
-
-    if ($this->get_value("projectID")) {
-      $project = new project();
-      $project->set_id($this->get_value("projectID"));
-      $project->select();
-      $projectName = $project->get_name();
-      $projectShortName = $project->get_name(array("showShortProjectLink"=>true));
-      $projectShortName && $projectShortName != $projectName and $projectName.= " ".$projectShortName;
+                  return array(page::money($invoice->get_value("currencyTypeID"), $row2["totalUsed"], $fmt),$maxAmount);
+            }
+        }
     }
 
-    $q = prepare("SELECT dateTimeSheetItem, taskID, description, comment, commentPrivate 
+    function has_attachment_permission()
+    {
+        return $this->is_owner();
+    }
+
+    function get_name($_FORM = array())
+    {
+        $project = new project();
+        $project->set_id($this->get_value("projectID"));
+        $project->select();
+        $p =& get_cached_table("person");
+        return "Time Sheet for ".$project->get_name($_FORM)." by ".$p[$this->get_value("personID")]["name"];
+    }
+
+    function update_search_index_doc(&$index)
+    {
+        $p =& get_cached_table("person");
+        $personID = $this->get_value("personID");
+        $person_field = $personID." ".$p[$personID]["username"]." ".$p[$personID]["name"];
+        $managerID = $this->get_value("approvedByManagerPersonID");
+        $manager_field = $managerID." ".$p[$managerID]["username"]." ".$p[$managerID]["name"];
+        $adminID = $this->get_value("approvedByAdminPersonID");
+        $admin_field = $adminID." ".$p[$adminID]["username"]." ".$p[$adminID]["name"];
+        $tf_field = $this->get_value("recipient_tfID")." ".tf::get_name($this->get_value("recipient_tfID"));
+
+        if ($this->get_value("projectID")) {
+            $project = new project();
+            $project->set_id($this->get_value("projectID"));
+            $project->select();
+            $projectName = $project->get_name();
+            $projectShortName = $project->get_name(array("showShortProjectLink"=>true));
+            $projectShortName && $projectShortName != $projectName and $projectName.= " ".$projectShortName;
+        }
+
+        $q = prepare("SELECT dateTimeSheetItem, taskID, description, comment, commentPrivate 
                     FROM timeSheetItem 
                    WHERE timeSheetID = %d 
-                ORDER BY dateTimeSheetItem ASC",$this->get_id());
-    $db = new db_alloc();
-    $db->query($q);
-    while ($r = $db->row()) {
-      $desc.= $br.$r["dateTimeSheetItem"]." ".$r["taskID"]." ".$r["description"]."\n";
-      $r["comment"] && $r["commentPrivate"] or $desc.= $r["comment"]."\n";
-      $br = "\n";
+                ORDER BY dateTimeSheetItem ASC", $this->get_id());
+        $db = new db_alloc();
+        $db->query($q);
+        while ($r = $db->row()) {
+            $desc.= $br.$r["dateTimeSheetItem"]." ".$r["taskID"]." ".$r["description"]."\n";
+            $r["comment"] && $r["commentPrivate"] or $desc.= $r["comment"]."\n";
+            $br = "\n";
+        }
+
+        $doc = new Zend_Search_Lucene_Document();
+        $doc->addField(Zend_Search_Lucene_Field::Keyword('id', $this->get_id()));
+        $doc->addField(Zend_Search_Lucene_Field::Text('project', $projectName, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('pid', $this->get_value("projectID"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('creator', $person_field, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('desc', $desc, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('status', $this->get_value("status"), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('tf', $tf_field, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('manager', $manager_field, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('admin', $admin_field, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateManager', str_replace("-", "", $this->get_value("dateSubmittedToManager")), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateAdmin', str_replace("-", "", $this->get_value("dateSubmittedToAdmin")), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateFrom', str_replace("-", "", $this->get_value("dateFrom")), "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('dateTo', str_replace("-", "", $this->get_value("dateTo")), "utf-8"));
+        $index->addDocument($doc);
     }
 
-    $doc = new Zend_Search_Lucene_Document();
-    $doc->addField(Zend_Search_Lucene_Field::Keyword('id'   ,$this->get_id()));
-    $doc->addField(Zend_Search_Lucene_Field::Text('project' ,$projectName,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('pid'     ,$this->get_value("projectID"),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('creator' ,$person_field,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('desc'    ,$desc,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('status'  ,$this->get_value("status"),"utf-8")); 
-    $doc->addField(Zend_Search_Lucene_Field::Text('tf'      ,$tf_field,"utf-8")); 
-    $doc->addField(Zend_Search_Lucene_Field::Text('manager' ,$manager_field,"utf-8")); 
-    $doc->addField(Zend_Search_Lucene_Field::Text('admin'   ,$admin_field,"utf-8")); 
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateManager',str_replace("-","",$this->get_value("dateSubmittedToManager")),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateAdmin',str_replace("-","",$this->get_value("dateSubmittedToAdmin")),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateFrom',str_replace("-","",$this->get_value("dateFrom")),"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('dateTo'  ,str_replace("-","",$this->get_value("dateTo")),"utf-8"));
-    $index->addDocument($doc);
-  }
+    function can_edit_rate()
+    {
+        $current_user = &singleton("current_user");
+        $db = new db_alloc();
+        $row = $db->qr("SELECT can_edit_rate(%d,%d) as allow", $current_user->get_id(), $this->get_value("projectID"));
+        return $row["allow"];
+    }
 
-  function can_edit_rate() {
-    $current_user = &singleton("current_user");
-    $db = new db_alloc();
-    $row = $db->qr("SELECT can_edit_rate(%d,%d) as allow",$current_user->get_id(),$this->get_value("projectID"));
-    return $row["allow"];
-  }
-
-  function get_project_id() {
-    return $this->get_value("projectID");
-  }
-}  
-
-
-
-
-?>
+    function get_project_id()
+    {
+        return $this->get_value("projectID");
+    }
+}

--- a/time/lib/timeSheetGraph.inc.php
+++ b/time/lib/timeSheetGraph.inc.php
@@ -3,30 +3,32 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class timeSheetGraph {
+class timeSheetGraph
+{
 
-  function __construct() {
-
-  }
-  function get_list_vars() {
-    return array(
+    function __construct()
+    {
+    }
+    function get_list_vars()
+    {
+        return array(
                 //"projectIDs" => "An array of projectIDs"
                  "dateFrom"    => "From Date"
                 ,"dateTo"      => "To Date"
@@ -34,39 +36,38 @@ class timeSheetGraph {
                 ,"groupBy"     => "Group the results by day or month"
                 ,"applyFilter" => "Store the filter settings"
                 );
-  }
-
-  function load_filter($defaults) {
-    $current_user = &singleton("current_user");
-
-    // display the list of project name.
-    $db = new db_alloc();
-    $page_vars = array_keys(timeSheetGraph::get_list_vars());
-    $_FORM = get_all_form_data($page_vars,$defaults);
-
-    if ($_FORM["applyFilter"] && is_object($current_user)) {
-      // we have a new filter configuration from the user, and must save it
-      if (!$_FORM["dontSave"]) {
-        $url = $_FORM["url_form_action"];
-        unset($_FORM["url_form_action"]);
-        $current_user->prefs[$_FORM["form_name"]] = $_FORM;
-        $_FORM["url_form_action"] = $url;
-      }
-    } else {
-      // we haven't been given a filter configuration, so load it from user preferences
-      $_FORM = $current_user->prefs[$_FORM["form_name"]];
     }
 
-    $rtn["personOptions"] = page::select_options(person::get_username_list($_FORM["personID"]), $_FORM["personID"]);
-    $rtn["dateFrom"] = $_FORM["dateFrom"];
-    $rtn["dateTo"] = $_FORM["dateTo"];
-    $rtn["personID"] = $_FORM["personID"];
-    $rtn["groupBy"] = $_FORM["groupBy"];
+    function load_filter($defaults)
+    {
+        $current_user = &singleton("current_user");
 
-    // GET
-    $rtn["FORM"] = "FORM=".urlencode(serialize($_FORM));
-    return $rtn;
-  }
+      // display the list of project name.
+        $db = new db_alloc();
+        $page_vars = array_keys(timeSheetGraph::get_list_vars());
+        $_FORM = get_all_form_data($page_vars, $defaults);
 
-}  
-?>
+        if ($_FORM["applyFilter"] && is_object($current_user)) {
+          // we have a new filter configuration from the user, and must save it
+            if (!$_FORM["dontSave"]) {
+                $url = $_FORM["url_form_action"];
+                unset($_FORM["url_form_action"]);
+                $current_user->prefs[$_FORM["form_name"]] = $_FORM;
+                $_FORM["url_form_action"] = $url;
+            }
+        } else {
+          // we haven't been given a filter configuration, so load it from user preferences
+            $_FORM = $current_user->prefs[$_FORM["form_name"]];
+        }
+
+        $rtn["personOptions"] = page::select_options(person::get_username_list($_FORM["personID"]), $_FORM["personID"]);
+        $rtn["dateFrom"] = $_FORM["dateFrom"];
+        $rtn["dateTo"] = $_FORM["dateTo"];
+        $rtn["personID"] = $_FORM["personID"];
+        $rtn["groupBy"] = $_FORM["groupBy"];
+
+      // GET
+        $rtn["FORM"] = "FORM=".urlencode(serialize($_FORM));
+        return $rtn;
+    }
+}

--- a/time/lib/timeSheetHomeItem.inc.php
+++ b/time/lib/timeSheetHomeItem.inc.php
@@ -3,46 +3,48 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class timeSheetHomeItem extends home_item {
+class timeSheetHomeItem extends home_item
+{
 
-  function __construct() {
-    parent::__construct("time_edit", "New Time Sheet Item", "time", "timeSheetH.tpl", "narrow", 24);
-  }
-
-  function visible() {
-    $current_user = &singleton("current_user");
-
-    if (!isset($current_user->prefs["showTimeSheetItemHome"])) {
-      $current_user->prefs["showTimeSheetItemHome"] = 1;
+    function __construct()
+    {
+        parent::__construct("time_edit", "New Time Sheet Item", "time", "timeSheetH.tpl", "narrow", 24);
     }
 
-    if ($current_user->prefs["showTimeSheetItemHome"]) {
-      return true;
-    }
-  }
+    function visible()
+    {
+        $current_user = &singleton("current_user");
 
-  function render() {
-    $current_user = &singleton("current_user");
-    global $TPL;
-    return true;
-  }
+        if (!isset($current_user->prefs["showTimeSheetItemHome"])) {
+            $current_user->prefs["showTimeSheetItemHome"] = 1;
+        }
+
+        if ($current_user->prefs["showTimeSheetItemHome"]) {
+            return true;
+        }
+    }
+
+    function render()
+    {
+        $current_user = &singleton("current_user");
+        global $TPL;
+        return true;
+    }
 }
-
-?>

--- a/time/lib/timeSheetItem.inc.php
+++ b/time/lib/timeSheetItem.inc.php
@@ -3,28 +3,29 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class timeSheetItem extends db_entity {
-  public $data_table = "timeSheetItem";
-  public $display_field_name = "description";
-  public $key_field = "timeSheetItemID";
-  public $data_fields = array("timeSheetID"
+class timeSheetItem extends db_entity
+{
+    public $data_table = "timeSheetItem";
+    public $display_field_name = "description";
+    public $key_field = "timeSheetItemID";
+    public $data_fields = array("timeSheetID"
                              ,"dateTimeSheetItem"
                              ,"timeSheetItemDuration"
                              ,"timeSheetItemDurationUnitID"
@@ -43,52 +44,54 @@ class timeSheetItem extends db_entity {
                              ,"timeSheetItemModifiedUser"
                              );
 
-  function save() {
-    $current_user = &singleton("current_user");
-    $timeSheet = new timeSheet();
-    $timeSheet->set_id($this->get_value("timeSheetID"));
-    $timeSheet->select();
+    function save()
+    {
+        $current_user = &singleton("current_user");
+        $timeSheet = new timeSheet();
+        $timeSheet->set_id($this->get_value("timeSheetID"));
+        $timeSheet->select();
 
-    $timeSheet->load_pay_info();
-    list($amount_used,$amount_allocated) = $timeSheet->get_amount_allocated("%mo");
+        $timeSheet->load_pay_info();
+        list($amount_used,$amount_allocated) = $timeSheet->get_amount_allocated("%mo");
 
-    $this->currency = $timeSheet->get_value("currencyTypeID");
+        $this->currency = $timeSheet->get_value("currencyTypeID");
 
-    $this->set_value("comment",rtrim($this->get_value("comment")));
+        $this->set_value("comment", rtrim($this->get_value("comment")));
 
-    $amount_of_item = $this->calculate_item_charge($timeSheet->get_value("currencyTypeID"),$timeSheet->get_value("customerBilledDollars"));
-    if ($amount_allocated && ($amount_of_item + $amount_used) > $amount_allocated) {
-      alloc_error("Adding this Time Sheet Item would exceed the amount allocated on the Pre-paid invoice. Time Sheet Item not saved.");
-    } 
+        $amount_of_item = $this->calculate_item_charge($timeSheet->get_value("currencyTypeID"), $timeSheet->get_value("customerBilledDollars"));
+        if ($amount_allocated && ($amount_of_item + $amount_used) > $amount_allocated) {
+            alloc_error("Adding this Time Sheet Item would exceed the amount allocated on the Pre-paid invoice. Time Sheet Item not saved.");
+        }
 
-    // If unit is changed via CLI
-    if ($this->get_value("timeSheetItemDurationUnitID") && $timeSheet->pay_info["project_rateUnitID"]
-    && $timeSheet->pay_info["project_rateUnitID"] != $this->get_value("timeSheetItemDurationUnitID") && !$timeSheet->can_edit_rate()) {
-      alloc_error("Not permitted to edit time sheet item unit.");
+      // If unit is changed via CLI
+        if ($this->get_value("timeSheetItemDurationUnitID") && $timeSheet->pay_info["project_rateUnitID"]
+        && $timeSheet->pay_info["project_rateUnitID"] != $this->get_value("timeSheetItemDurationUnitID") && !$timeSheet->can_edit_rate()) {
+            alloc_error("Not permitted to edit time sheet item unit.");
+        }
+
+        if (!$this->get_value("timeSheetItemDurationUnitID") && $timeSheet->pay_info["project_rateUnitID"]) {
+            $this->set_value("timeSheetItemDurationUnitID", $timeSheet->pay_info["project_rateUnitID"]);
+        }
+
+      // Last ditch perm checking - useful for the CLI
+        if (!is_object($timeSheet) || !$timeSheet->get_id()) {
+            alloc_error("Unknown time sheet.");
+        }
+        if ($timeSheet->get_value("status") != "edit" && !$this->skip_tsi_status_check) {
+            alloc_error("Time sheet is not at status edit");
+        }
+        if (!$this->is_owner()) {
+            alloc_error("Time sheet is not editable for you.");
+        }
+
+        $rtn = parent::save();
+        $timeSheet->update_related_invoices();
+        return $rtn;
     }
 
-    if (!$this->get_value("timeSheetItemDurationUnitID") && $timeSheet->pay_info["project_rateUnitID"]) {
-      $this->set_value("timeSheetItemDurationUnitID", $timeSheet->pay_info["project_rateUnitID"]);
-    }
-
-    // Last ditch perm checking - useful for the CLI
-    if (!is_object($timeSheet) || !$timeSheet->get_id()) {
-      alloc_error("Unknown time sheet.");
-    }
-    if ($timeSheet->get_value("status") != "edit" && !$this->skip_tsi_status_check) {
-      alloc_error("Time sheet is not at status edit");
-    }
-    if (!$this->is_owner()) {
-      alloc_error("Time sheet is not editable for you.");
-    }
-
-    $rtn = parent::save();
-    $timeSheet->update_related_invoices();
-    return $rtn;
-  } 
-
-  function parse_time_string($str) {
-    preg_match("/^"
+    function parse_time_string($str)
+    {
+        preg_match("/^"
               ."(\d\d\d\d\-\d\d?\-\d\d?\s+)?"   # date
               ."([\d\.]+)?"          # duration
               ."\s*"
@@ -100,219 +103,225 @@ class timeSheetItem extends db_entity {
               ."\s*"
               ."(.*)"               # comment
               ."\s*"
-              #."(private)?"        # whether the comment is private 
-              ."$/i",$str,$m);
+              #."(private)?"        # whether the comment is private
+              ."$/i", $str, $m);
 
-    $rtn["date"] = trim($m[1]) or $rtn["date"] = date("Y-m-d");
-    $rtn["duration"] = $m[2];
-    $rtn["unit"] = $m[3];
-    $rtn["multiplier"] = str_replace(array("x","X"," "),"",$m[4]) or $rtn["multiplier"] = 1;
-    $rtn["taskID"] = $m[5];
-    $rtn["comment"] = $m[6];
-    //$rtn["private"] = $m[7];
+        $rtn["date"] = trim($m[1]) or $rtn["date"] = date("Y-m-d");
+        $rtn["duration"] = $m[2];
+        $rtn["unit"] = $m[3];
+        $rtn["multiplier"] = str_replace(array("x","X"," "), "", $m[4]) or $rtn["multiplier"] = 1;
+        $rtn["taskID"] = $m[5];
+        $rtn["comment"] = $m[6];
+      //$rtn["private"] = $m[7];
 
-    // use the first letter of the unit for the lookup
-    $tu = array("h"=>1,"d"=>2,"w"=>3,"m"=>4,"f"=>5);
-    $rtn["unit"] = $tu[$rtn["unit"][0]] or $rtn["unit"] = 1;
+      // use the first letter of the unit for the lookup
+        $tu = array("h"=>1,"d"=>2,"w"=>3,"m"=>4,"f"=>5);
+        $rtn["unit"] = $tu[$rtn["unit"][0]] or $rtn["unit"] = 1;
 
-    // change 2010/10/27 to 2010-10-27
-    $rtn["date"] = str_replace("/","-",$rtn["date"]);
+      // change 2010/10/27 to 2010-10-27
+        $rtn["date"] = str_replace("/", "-", $rtn["date"]);
 
-    return $rtn;
-  }
+        return $rtn;
+    }
 
-  function calculate_item_charge($currency,$rate=0) {
-    return page::money($currency, $rate * $this->get_value("timeSheetItemDuration") * $this->get_value("multiplier"), "%mo");
-  }
+    function calculate_item_charge($currency, $rate = 0)
+    {
+        return page::money($currency, $rate * $this->get_value("timeSheetItemDuration") * $this->get_value("multiplier"), "%mo");
+    }
 
-  function delete() {
-    $timeSheetID = $this->get_value("timeSheetID");
+    function delete()
+    {
+        $timeSheetID = $this->get_value("timeSheetID");
 
-    $db = new db_alloc();
-    $q = prepare("SELECT invoiceItem.*
+        $db = new db_alloc();
+        $q = prepare("SELECT invoiceItem.*
                     FROM invoiceItem
                LEFT JOIN invoice ON invoiceItem.invoiceID = invoice.invoiceID
                    WHERE timeSheetID = %d
-                     AND invoiceStatus != 'finished'",$timeSheetID);
-    $db->query($q);
-    while ($row = $db->row()) {
-      $ii = new invoiceItem();
-      $ii->set_id($row["invoiceItemID"]);
-      $ii->select();
-      if ($ii->get_value("timeSheetItemID") == $this->get_id()) {
-        $ii->delete();
-      } else if (!$ii->get_value("timeSheetItemID")) {
-        invoiceEntity::save_invoice_timeSheet($row["invoiceID"],$timeSheetID);  // will update the existing invoice item
-      }
-    }
-    return parent::delete();
-  }
-
-  function get_fortnightly_average($personID=false) {
-
-    // Need an array of the past years fortnights 
-    $x = 0;
-    while ($x < 365) {
-      if ($x % 14 == 0) {
-        $fortnight++;
-      }
-      $fortnights[date("Y-m-d",mktime(0,0,0,date("m"),date("d")-365+$x,date("Y")))] = $fortnight;
-      $x++;
+                     AND invoiceStatus != 'finished'", $timeSheetID);
+        $db->query($q);
+        while ($row = $db->row()) {
+            $ii = new invoiceItem();
+            $ii->set_id($row["invoiceItemID"]);
+            $ii->select();
+            if ($ii->get_value("timeSheetItemID") == $this->get_id()) {
+                $ii->delete();
+            } else if (!$ii->get_value("timeSheetItemID")) {
+                invoiceEntity::save_invoice_timeSheet($row["invoiceID"], $timeSheetID);  // will update the existing invoice item
+            }
+        }
+        return parent::delete();
     }
 
-    $dateTimeSheetItem = date("Y-m-d",mktime(0,0,0,date("m"),date("d")-365,date("Y")));
-    $personID and $personID_sql = prepare(" AND personID = %d", $personID);
+    function get_fortnightly_average($personID = false)
+    {
 
-    $q = prepare("SELECT DISTINCT dateTimeSheetItem, personID
+      // Need an array of the past years fortnights
+        $x = 0;
+        while ($x < 365) {
+            if ($x % 14 == 0) {
+                $fortnight++;
+            }
+            $fortnights[date("Y-m-d", mktime(0, 0, 0, date("m"), date("d")-365+$x, date("Y")))] = $fortnight;
+            $x++;
+        }
+
+        $dateTimeSheetItem = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d")-365, date("Y")));
+        $personID and $personID_sql = prepare(" AND personID = %d", $personID);
+
+        $q = prepare("SELECT DISTINCT dateTimeSheetItem, personID
                     FROM timeSheetItem 
                    WHERE dateTimeSheetItem > '%s'
                       ".$personID_sql."
                 GROUP BY dateTimeSheetItem,personID
-                 ",$dateTimeSheetItem);
+                 ", $dateTimeSheetItem);
 
-    $db = new db_alloc();
-    $db->query($q);
-    while ($db->next_record()) {
-      
-      if (!$done[$db->f("personID")][$fortnights[$db->f("dateTimeSheetItem")]]) {
-        $how_many_fortnights[$db->f("personID")]++;
-        $done[$db->f("personID")][$fortnights[$db->f("dateTimeSheetItem")]] = true;
-      }
+        $db = new db_alloc();
+        $db->query($q);
+        while ($db->next_record()) {
+            if (!$done[$db->f("personID")][$fortnights[$db->f("dateTimeSheetItem")]]) {
+                $how_many_fortnights[$db->f("personID")]++;
+                $done[$db->f("personID")][$fortnights[$db->f("dateTimeSheetItem")]] = true;
+            }
+        }
+
+        $rtn = array();
+        list($rows,$rows_dollars) = $this->get_averages($dateTimeSheetItem, $personID);
+        foreach ($rows as $id => $avg) {
+            $rtn[$id] = $avg / $how_many_fortnights[$id];
+          #echo "<br>".$id." ".$how_many_fortnights[$id];
+        }
+
+      // Convert all the monies into native currency
+        foreach ($rows_dollars as $id => $arr) {
+            foreach ($arr as $r) {
+                $alex[$id] += exchangeRate::convert($r["currency"], $r["amount"]);
+            }
+        }
+
+      // Get the averages for each
+        foreach ((array)$alex as $id => $sum) {
+            $rtn_dollars[$id] = $sum / $how_many_fortnights[$id];
+        }
+
+        return array($rtn,$rtn_dollars);
     }
 
-    $rtn = array();
-    list($rows,$rows_dollars) = $this->get_averages($dateTimeSheetItem,$personID);
-    foreach ($rows as $id => $avg) {
-      $rtn[$id] = $avg / $how_many_fortnights[$id];
-      #echo "<br>".$id." ".$how_many_fortnights[$id];
+    function is_owner()
+    {
+        if ($this->get_value("timeSheetID")) {
+            $timeSheet = new timeSheet();
+            $timeSheet->set_id($this->get_value("timeSheetID"));
+            $timeSheet->select();
+            return $timeSheet->is_owner();
+        }
     }
-
-    // Convert all the monies into native currency
-    foreach ($rows_dollars as $id => $arr) {
-      foreach ($arr as $r) {
-        $alex[$id] += exchangeRate::convert($r["currency"],$r["amount"]);
-      }
-    }
-
-    // Get the averages for each
-    foreach ((array)$alex as $id => $sum) {
-      $rtn_dollars[$id] = $sum / $how_many_fortnights[$id];
-    }
-
-    return array($rtn,$rtn_dollars);
-  }
-
-  function is_owner() {
-    if ($this->get_value("timeSheetID")) {
-      $timeSheet = new timeSheet();
-      $timeSheet->set_id($this->get_value("timeSheetID"));
-      $timeSheet->select();
-      return $timeSheet->is_owner();
-    }
-  }
   
-  public static function get_list_filter($filter=array()) {
+    public static function get_list_filter($filter = array())
+    {
 
-    // If timeSheetID is an array
-    if ($filter["timeSheetID"] && is_array($filter["timeSheetID"])) {
-      $timeSheetIDs = $filter["timeSheetID"];
+      // If timeSheetID is an array
+        if ($filter["timeSheetID"] && is_array($filter["timeSheetID"])) {
+            $timeSheetIDs = $filter["timeSheetID"];
 
-    // Else
-    } else if ($filter["timeSheetID"] && is_numeric($filter["timeSheetID"])) {
-      $timeSheetIDs[] = $filter["timeSheetID"];
+        // Else
+        } else if ($filter["timeSheetID"] && is_numeric($filter["timeSheetID"])) {
+            $timeSheetIDs[] = $filter["timeSheetID"];
+        }
+
+        if (is_array($timeSheetIDs) && count($timeSheetIDs)) {
+            $sql[] = prepare("(timeSheetItem.timeSheetID IN (%s))", $timeSheetIDs);
+        }
+
+        if ($filter["projectID"]) {
+            $sql[] = prepare("(timeSheet.projectID = %d)", $filter["projectID"]);
+        }
+
+        if ($filter["taskID"]) {
+            $sql[] = prepare("(timeSheetItem.taskID = %d)", $filter["taskID"]);
+        }
+
+        if ($filter["date"]) {
+            in_array($filter["dateComparator"], array("=","!=",">",">=","<","<=")) or $filter["dateComparator"] = '=';
+            $sql[] = prepare("(timeSheetItem.dateTimeSheetItem ".$filter["dateComparator"]." '%s')", $filter["date"]);
+        }
+
+        if ($filter["personID"]) {
+            $sql[] = prepare("(timeSheetItem.personID = %d)", $filter["personID"]);
+        }
+
+        if ($filter["timeSheetItemID"]) {
+            $sql[] = prepare("(timeSheetItem.timeSheetItemID = %d)", $filter["timeSheetItemID"]);
+        }
+
+        if ($filter["comment"]) {
+            $sql[] = prepare("(timeSheetItem.comment LIKE '%%%s%%')", $filter["comment"]);
+        }
+
+        if ($filter["tfID"]) {
+            $sql[] = prepare("(timeSheet.recipient_tfID = %d)", $filter["tfID"]);
+        }
+
+        return $sql;
     }
 
-    if (is_array($timeSheetIDs) && count($timeSheetIDs)) {
-      $sql[] = prepare("(timeSheetItem.timeSheetID IN (%s))",$timeSheetIDs);
-    } 
-
-    if ($filter["projectID"]) {
-      $sql[] = prepare("(timeSheet.projectID = %d)",$filter["projectID"]);
-    } 
-
-    if ($filter["taskID"]) {
-      $sql[] = prepare("(timeSheetItem.taskID = %d)",$filter["taskID"]);
-    } 
-
-    if ($filter["date"]) {
-      in_array($filter["dateComparator"],array("=","!=",">",">=","<","<=")) or $filter["dateComparator"] = '=';
-      $sql[] = prepare("(timeSheetItem.dateTimeSheetItem ".$filter["dateComparator"]." '%s')",$filter["date"]);
-    } 
-
-    if ($filter["personID"]) {
-      $sql[] = prepare("(timeSheetItem.personID = %d)",$filter["personID"]);
-    } 
-
-    if ($filter["timeSheetItemID"]) {
-      $sql[] = prepare("(timeSheetItem.timeSheetItemID = %d)",$filter["timeSheetItemID"]);
-    }
-
-    if ($filter["comment"]) {
-      $sql[] = prepare("(timeSheetItem.comment LIKE '%%%s%%')",$filter["comment"]);
-    }
-
-    if ($filter["tfID"]) {
-      $sql[] = prepare("(timeSheet.recipient_tfID = %d)", $filter["tfID"]);
-    }
-
-    return $sql;
-  }
-
-  public static function get_list($_FORM) {
-    /*
-     * This is the definitive method of getting a list of timeSheetItems that need a sophisticated level of filtering
-     *
-     */
+    public static function get_list($_FORM)
+    {
+      /*
+       * This is the definitive method of getting a list of timeSheetItems that need a sophisticated level of filtering
+       *
+       */
    
-    global $TPL;
-    $filter = timeSheetItem::get_list_filter($_FORM);
+        global $TPL;
+        $filter = timeSheetItem::get_list_filter($_FORM);
 
-    $debug = $_FORM["debug"];
-    $debug and print "<pre>_FORM: ".print_r($_FORM,1)."</pre>";
-    $debug and print "<pre>filter: ".print_r($filter,1)."</pre>";
-    $_FORM["return"] or $_FORM["return"] = "html";
+        $debug = $_FORM["debug"];
+        $debug and print "<pre>_FORM: ".print_r($_FORM, 1)."</pre>";
+        $debug and print "<pre>filter: ".print_r($filter, 1)."</pre>";
+        $_FORM["return"] or $_FORM["return"] = "html";
 
-    if (is_array($filter) && count($filter)) {
-      $filter = " WHERE ".implode(" AND ",$filter);
-    }
+        if (is_array($filter) && count($filter)) {
+            $filter = " WHERE ".implode(" AND ", $filter);
+        }
 
-    $q = "SELECT * FROM timeSheetItem
+        $q = "SELECT * FROM timeSheetItem
        LEFT JOIN timeSheet ON timeSheet.timeSheetID = timeSheetItem.timeSheetID
                  ".$filter."
         ORDER BY timeSheet.timeSheetID,dateTimeSheetItem asc";
-    $debug and print "Query: ".$q;
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->next_record()) {
-      $print = true;
-      $t = new timeSheet();
-      $t->read_db_record($db);
+        $debug and print "Query: ".$q;
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->next_record()) {
+            $print = true;
+            $t = new timeSheet();
+            $t->read_db_record($db);
       
-      $tsi = new timeSheetItem();
-      $tsi->read_db_record($db);
-      $tsi->currency = $t->get_value("currencyTypeID");
+            $tsi = new timeSheetItem();
+            $tsi->read_db_record($db);
+            $tsi->currency = $t->get_value("currencyTypeID");
 
-      $row["secondsBilled"] = $row["hoursBilled"] = $row["timeLimit"] = $row["limitWarning"] = ""; # set these for the CLI
-      if ($tsi->get_value("taskID")) {
-        $task = $tsi->get_foreign_object('task');
-        $row["secondsBilled"] = $task->get_time_billed();
-        $row["hoursBilled"] = sprintf("%0.2f",$row["secondsBilled"] / 60 / 60);
-        $task->get_value('timeLimit') && $row["hoursBilled"] > $task->get_value('timeLimit') and $row["limitWarning"] = 'Exceeds Limit!';
-        $row["timeLimit"] = $task->get_value("timeLimit");
-      }
-      $row["rate"] = $tsi->get_value("rate",DST_HTML_DISPLAY);
-      $row["worth"] = page::money($tsi->currency, $row["rate"] * $tsi->get_value("multiplier") * $tsi->get_value("timeSheetItemDuration"),"%m");
+            $row["secondsBilled"] = $row["hoursBilled"] = $row["timeLimit"] = $row["limitWarning"] = ""; # set these for the CLI
+            if ($tsi->get_value("taskID")) {
+                $task = $tsi->get_foreign_object('task');
+                $row["secondsBilled"] = $task->get_time_billed();
+                $row["hoursBilled"] = sprintf("%0.2f", $row["secondsBilled"] / 60 / 60);
+                $task->get_value('timeLimit') && $row["hoursBilled"] > $task->get_value('timeLimit') and $row["limitWarning"] = 'Exceeds Limit!';
+                $row["timeLimit"] = $task->get_value("timeLimit");
+            }
+            $row["rate"] = $tsi->get_value("rate", DST_HTML_DISPLAY);
+            $row["worth"] = page::money($tsi->currency, $row["rate"] * $tsi->get_value("multiplier") * $tsi->get_value("timeSheetItemDuration"), "%m");
 
-      $rows[$row["timeSheetItemID"]] = $row;
+            $rows[$row["timeSheetItemID"]] = $row;
+        }
+
+        if ($print && $_FORM["return"] == "array") {
+            return $rows;
+        }
     }
 
-    if ($print && $_FORM["return"] == "array") {
-      return $rows;
-    }
-  }
-
-  function get_list_vars() {
-    return array("return"                   => "[MANDATORY] eg: array | html | dropdown_options"
+    function get_list_vars()
+    {
+        return array("return"                   => "[MANDATORY] eg: array | html | dropdown_options"
                 ,"timeSheetID"              => "Show items for a particular time sheet"
                 ,"projectID"                => "Show items for a particular project"
                 ,"taskID"                   => "Show items for a particular task"
@@ -320,7 +329,7 @@ class timeSheetItem extends db_entity {
                 ,"personID"                 => "Show items for a particular person"
                 ,"comment"                  => "Show items that have a comment like eg: *uick brown fox jump*"
                 );
-  }
+    }
 
   #function get_averages_past_fortnight($personID=false) {
    # $dateTimeSheetItem = date("Y-m-d",mktime(0,0,0,date("m"),date("d")-14, date("Y")));
@@ -334,12 +343,13 @@ class timeSheetItem extends db_entity {
   #}
 
 
-  function get_averages($dateTimeSheetItem, $personID=false, $divisor="", $endDate=null) {
+    function get_averages($dateTimeSheetItem, $personID = false, $divisor = "", $endDate = null)
+    {
 
-    $personID and $personID_sql = prepare(" AND timeSheetItem.personID = %d", $personID);
-    $endDate and $endDate_sql = prepare(" AND timeSheetItem.dateTimeSheetItem <= '%s'",$endDate);
+        $personID and $personID_sql = prepare(" AND timeSheetItem.personID = %d", $personID);
+        $endDate and $endDate_sql = prepare(" AND timeSheetItem.dateTimeSheetItem <= '%s'", $endDate);
 
-    $q = prepare("SELECT personID
+        $q = prepare("SELECT personID
                        , SUM(timeSheetItemDuration*timeUnitSeconds) ".$divisor." AS avg
                     FROM timeSheetItem 
                LEFT JOIN timeUnit ON timeUnitID = timeSheetItemDurationUnitID 
@@ -349,15 +359,16 @@ class timeSheetItem extends db_entity {
                 GROUP BY personID
                  ", $dateTimeSheetItem);
 
-    $db = new db_alloc();
-    $db->query($q);
-    $rows = array();
-    while ($db->next_record()) {
-      $rows[$db->f("personID")] = $db->f("avg")/3600;
-    }
+        $db = new db_alloc();
+        $db->query($q);
+        $rows = array();
+        while ($db->next_record()) {
+            $rows[$db->f("personID")] = $db->f("avg")/3600;
+        }
 
-    //Calculate the dollar values
-    $q = prepare("SELECT (rate * POW(10, -currencyType.numberToBasic) * timeSheetItemDuration * multiplier) as amount
+      //Calculate the dollar values
+        $q = prepare(
+            "SELECT (rate * POW(10, -currencyType.numberToBasic) * timeSheetItemDuration * multiplier) as amount
                        , timeSheet.currencyTypeID as currency 
                        , timeSheetItem.*
                     FROM timeSheetItem 
@@ -365,37 +376,39 @@ class timeSheetItem extends db_entity {
                LEFT JOIN currencyType ON timeSheet.currencyTypeID = currencyType.currencyTypeID
                 WHERE dateTimeSheetItem > '%s'
                       ".$personID_sql."
-                      ".$endDate_sql
-                , $dateTimeSheetItem);
-    $db->query($q);
-    $rows_dollars = array();
-    while($row = $db->row()) {
-      $tsi = new timeSheetItem();
-      $tsi->read_db_record($db);
-      $rows_dollars[$row["personID"]][] = $row;
+                      ".$endDate_sql,
+            $dateTimeSheetItem
+        );
+        $db->query($q);
+        $rows_dollars = array();
+        while ($row = $db->row()) {
+            $tsi = new timeSheetItem();
+            $tsi->read_db_record($db);
+            $rows_dollars[$row["personID"]][] = $row;
+        }
+        return array($rows,$rows_dollars);
     }
-    return array($rows,$rows_dollars);
-  }
 
-  function get_timeSheetItemComments($taskID="",$starred=false) {
-    // Init
-    $rows = array();
+    function get_timeSheetItemComments($taskID = "", $starred = false)
+    {
+      // Init
+        $rows = array();
 
-    if ($taskID) {
-      $where = prepare("timeSheetItem.taskID = %d",$taskID);
-    } else if ($starred) {
-      $current_user = &singleton("current_user");
-      $timeSheetItemIDs = array();
-      foreach ((array)$current_user->prefs["stars"]["timeSheetItem"] as $k=>$v) {
-        $timeSheetItemIDs[] = $k;
-      }
-      $where = prepare("(timeSheetItem.timeSheetItemID in (%s))",$timeSheetItemIDs);
-    }
+        if ($taskID) {
+            $where = prepare("timeSheetItem.taskID = %d", $taskID);
+        } else if ($starred) {
+            $current_user = &singleton("current_user");
+            $timeSheetItemIDs = array();
+            foreach ((array)$current_user->prefs["stars"]["timeSheetItem"] as $k => $v) {
+                $timeSheetItemIDs[] = $k;
+            }
+            $where = prepare("(timeSheetItem.timeSheetItemID in (%s))", $timeSheetItemIDs);
+        }
     
-    $where or $where = " 1 ";
+        $where or $where = " 1 ";
 
-    // Get list of comments from timeSheetItem table
-    $query = prepare("SELECT timeSheetID
+      // Get list of comments from timeSheetItem table
+        $query = prepare("SELECT timeSheetID
                            , timeSheetItemID
                            , dateTimeSheetItem AS date
                            , comment
@@ -410,93 +423,98 @@ class timeSheetItem extends db_entity {
                     ORDER BY dateTimeSheetItem,timeSheetItemID
                      ");
 
-    $db = new db_alloc();
-    $db->query($query);
-    while ($row = $db->row()) {
-      $rows[] = $row;
+        $db = new db_alloc();
+        $db->query($query);
+        while ($row = $db->row()) {
+            $rows[] = $row;
+        }
+
+        is_array($rows) or $rows = array();
+        return $rows;
     }
 
-    is_array($rows) or $rows = array();
-    return $rows;
-  }
 
+    function get_total_hours_worked_per_day($personID, $start = null, $end = null)
+    {
+        $current_user =& singleton("current_user");
 
-  function get_total_hours_worked_per_day($personID,$start=null,$end=null) {
-    $current_user =& singleton("current_user");
+        $personID or $personID = $current_user->get_id();
+        $start    or $start    = date("Y-m-d", mktime()-(60*60*24*28));
+        $end      or $end      = date("Y-m-d");
 
-    $personID or $personID = $current_user->get_id();
-    $start    or $start    = date("Y-m-d",mktime()-(60*60*24*28));
-    $end      or $end      = date("Y-m-d");
-
-    $q = prepare("SELECT dateTimeSheetItem, sum(timeSheetItemDuration*timeUnitSeconds) / 3600 AS hours
+        $q = prepare(
+            "SELECT dateTimeSheetItem, sum(timeSheetItemDuration*timeUnitSeconds) / 3600 AS hours
                     FROM timeSheetItem
                LEFT JOIN timeUnit ON timeUnitID = timeSheetItemDurationUnitID
                    WHERE personID = %d
                      AND dateTimeSheetItem >= '%s'
                      AND dateTimeSheetItem <= '%s'
-                GROUP BY dateTimeSheetItem"
-                ,$personID, $start, $end);
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $info[$row["dateTimeSheetItem"]] = $row;
+                GROUP BY dateTimeSheetItem",
+            $personID,
+            $start,
+            $end
+        );
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $info[$row["dateTimeSheetItem"]] = $row;
+        }
+
+        list($sy,$sm,$sd) = explode("-", $start);
+        list($ey,$em,$ed) = explode("-", $end);
+
+        $x = 0;
+        while (mktime(0, 0, 0, $sm, $sd+$x, $sy)<=mktime(0, 0, 0, $em, $ed, $ey)) {
+            $d = date("Y-m-d", mktime(0, 0, 0, $sm, $sd+$x, $sy));
+            $points[] = array($d." 12:00PM", sprintf("%.2F", $info[$d]["hours"]));
+            $x++;
+        }
+
+        return $points;
     }
 
-    list($sy,$sm,$sd) = explode("-",$start);
-    list($ey,$em,$ed) = explode("-",$end);
+    function get_total_hours_worked_per_month($personID, $start = null, $end = null)
+    {
+        $current_user =& singleton("current_user");
 
-    $x = 0;
-    while (mktime(0,0,0,$sm,$sd+$x,$sy)<=mktime(0,0,0,$em,$ed,$ey)) {
-      $d = date("Y-m-d",mktime(0,0,0,$sm,$sd+$x,$sy));
-      $points[] = array($d." 12:00PM", sprintf("%.2F",$info[$d]["hours"]));
-      $x++;
-    }
+        $personID or $personID = $current_user->get_id();
+        $start    or $start    = date("Y-m-d", mktime()-(60*60*24*28));
+        $end      or $end      = date("Y-m-d");
 
-    return $points;
-  }
-
-  function get_total_hours_worked_per_month($personID,$start=null,$end=null) {
-    $current_user =& singleton("current_user");
-
-    $personID or $personID = $current_user->get_id();
-    $start    or $start    = date("Y-m-d",mktime()-(60*60*24*28));
-    $end      or $end      = date("Y-m-d");
-
-    $q = prepare("SELECT CONCAT(YEAR(dateTimeSheetItem),'-',MONTH(dateTimeSheetItem)) AS dateTimeSheetItem
+        $q = prepare(
+            "SELECT CONCAT(YEAR(dateTimeSheetItem),'-',MONTH(dateTimeSheetItem)) AS dateTimeSheetItem
                        , sum(timeSheetItemDuration*timeUnitSeconds) / 3600 AS hours
                     FROM timeSheetItem
                LEFT JOIN timeUnit ON timeUnitID = timeSheetItemDurationUnitID
                    WHERE personID = %d
                      AND dateTimeSheetItem >= '%s'
                      AND dateTimeSheetItem <= '%s'
-                GROUP BY YEAR(dateTimeSheetItem), MONTH(dateTimeSheetItem)"
-                ,$personID, $start, $end);
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $f = explode("-",$row["dateTimeSheetItem"]);
-      $info[sprintf("%4d-%02d",$f[0],$f[1])] = $row; // the %02d is just to make sure the months are consistently zero padded
-    }
+                GROUP BY YEAR(dateTimeSheetItem), MONTH(dateTimeSheetItem)",
+            $personID,
+            $start,
+            $end
+        );
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $f = explode("-", $row["dateTimeSheetItem"]);
+            $info[sprintf("%4d-%02d", $f[0], $f[1])] = $row; // the %02d is just to make sure the months are consistently zero padded
+        }
 
-    $s = format_date("U",$start);
-    $e = format_date("U",$end);
-    $s_months = (date("Y",$s) * 12) + date("m",$s);
-    $e_months = (date("Y",$e) * 12) + date("m",$e);
+        $s = format_date("U", $start);
+        $e = format_date("U", $end);
+        $s_months = (date("Y", $s) * 12) + date("m", $s);
+        $e_months = (date("Y", $e) * 12) + date("m", $e);
 
-    $num_months_back = $e_months - $s_months;
-    $x = 0;
-    while ($x<=$num_months_back) {
-      $time = mktime(0,0,0,date("m",$s)+$x,1,date("Y",$s));
-      $d = date("Y-m",$time);
-      $points[] = array($d, sprintf("%d",$info[$d]["hours"]));
-      $x++;
-    }
+        $num_months_back = $e_months - $s_months;
+        $x = 0;
+        while ($x<=$num_months_back) {
+            $time = mktime(0, 0, 0, date("m", $s)+$x, 1, date("Y", $s));
+            $d = date("Y-m", $time);
+            $points[] = array($d, sprintf("%d", $info[$d]["hours"]));
+            $x++;
+        }
     
-    return $points;
-  }
-
+        return $points;
+    }
 }
-
-
-
-?>

--- a/time/lib/timeSheetListHomeItem.inc.php
+++ b/time/lib/timeSheetListHomeItem.inc.php
@@ -3,49 +3,51 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class timeSheetListHomeItem extends home_item {
+class timeSheetListHomeItem extends home_item
+{
 
-  function __construct() {
-    $this->has_config = true;
-    parent::__construct("time_list", "Current Time Sheets", "time", "timeSheetListH.tpl", "narrow", 30);
-  }
-
-  function visible() {
-    $current_user = &singleton("current_user");
-    return isset($current_user) && $current_user->is_employee();
-  }
-
-  function render() {
-    $current_user = &singleton("current_user");
-    global $TPL;
-    $ops["showShortProjectLink"] = "true";
-    $ops["personID"] = $current_user->get_id();
-    $ops["status"] = array('edit','manager','admin','invoiced','rejected');
-
-    $rtn = timeSheet::get_list($ops);
-    $TPL["timeSheetListRows"] = $rtn["rows"];
-    $TPL["timeSheetListExtra"] = $rtn["extra"];
-    if ($TPL["timeSheetListRows"]) {
-      return true;
+    function __construct()
+    {
+        $this->has_config = true;
+        parent::__construct("time_list", "Current Time Sheets", "time", "timeSheetListH.tpl", "narrow", 30);
     }
-  }
-}
 
-?>
+    function visible()
+    {
+        $current_user = &singleton("current_user");
+        return isset($current_user) && $current_user->is_employee();
+    }
+
+    function render()
+    {
+        $current_user = &singleton("current_user");
+        global $TPL;
+        $ops["showShortProjectLink"] = "true";
+        $ops["personID"] = $current_user->get_id();
+        $ops["status"] = array('edit','manager','admin','invoiced','rejected');
+
+        $rtn = timeSheet::get_list($ops);
+        $TPL["timeSheetListRows"] = $rtn["rows"];
+        $TPL["timeSheetListExtra"] = $rtn["extra"];
+        if ($TPL["timeSheetListRows"]) {
+            return true;
+        }
+    }
+}

--- a/time/lib/timeSheetPrint.inc.php
+++ b/time/lib/timeSheetPrint.inc.php
@@ -3,463 +3,464 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("DEFAULT_SEP","\n");
+define("DEFAULT_SEP", "\n");
 
-class timeSheetPrint {
+class timeSheetPrint
+{
 
-  function get_timeSheetItem_vars($timeSheetID) {
+    function get_timeSheetItem_vars($timeSheetID)
+    {
  
-    $timeSheet = new timeSheet();
-    $timeSheet->set_id($timeSheetID);
-    $timeSheet->select();
+        $timeSheet = new timeSheet();
+        $timeSheet->set_id($timeSheetID);
+        $timeSheet->select();
 
-    $timeUnit = new timeUnit();
-    $unit_array = $timeUnit->get_assoc_array("timeUnitID","timeUnitLabelA");
+        $timeUnit = new timeUnit();
+        $unit_array = $timeUnit->get_assoc_array("timeUnitID", "timeUnitLabelA");
 
-    $q = prepare("SELECT * from timeSheetItem WHERE timeSheetID=%d ", $timeSheetID);
-    $q.= prepare("GROUP BY timeSheetItemID ORDER BY dateTimeSheetItem, timeSheetItemID");
-    $db = new db_alloc();
-    $db->query($q);
+        $q = prepare("SELECT * from timeSheetItem WHERE timeSheetID=%d ", $timeSheetID);
+        $q.= prepare("GROUP BY timeSheetItemID ORDER BY dateTimeSheetItem, timeSheetItemID");
+        $db = new db_alloc();
+        $db->query($q);
 
-    $customerBilledDollars = $timeSheet->get_value("customerBilledDollars");
-    $currency = page::money($timeSheet->get_value("currencyTypeID"),'',"%S");
+        $customerBilledDollars = $timeSheet->get_value("customerBilledDollars");
+        $currency = page::money($timeSheet->get_value("currencyTypeID"), '', "%S");
 
-    return array($db, $customerBilledDollars,$timeSheet,$unit_array,$currency);
-  }
+        return array($db, $customerBilledDollars,$timeSheet,$unit_array,$currency);
+    }
 
-  function get_timeSheetItem_list_money($timeSheetID) {
-    global $TPL;
-    list($db,$customerBilledDollars,$timeSheet,$unit_array,$currency) = $this->get_timeSheetItem_vars($timeSheetID);
+    function get_timeSheetItem_list_money($timeSheetID)
+    {
+        global $TPL;
+        list($db,$customerBilledDollars,$timeSheet,$unit_array,$currency) = $this->get_timeSheetItem_vars($timeSheetID);
 
-    $taxPercent = config::get_config_item("taxPercent");
-    $taxPercentDivisor = ($taxPercent/100) + 1;
+        $taxPercent = config::get_config_item("taxPercent");
+        $taxPercentDivisor = ($taxPercent/100) + 1;
 
-    while ($db->next_record()) {
-      $timeSheetItem = new timeSheetItem();
-      $timeSheetItem->read_db_record($db);
+        while ($db->next_record()) {
+            $timeSheetItem = new timeSheetItem();
+            $timeSheetItem->read_db_record($db);
 
-      $taskID = sprintf("%d",$timeSheetItem->get_value("taskID"));
+            $taskID = sprintf("%d", $timeSheetItem->get_value("taskID"));
 
-      $num = $timeSheetItem->calculate_item_charge($currency, $customerBilledDollars ? $customerBilledDollars : $timeSheetItem->get_value("rate"));
+            $num = $timeSheetItem->calculate_item_charge($currency, $customerBilledDollars ? $customerBilledDollars : $timeSheetItem->get_value("rate"));
 
-      if ($taxPercent !== '') {
-        $num_minus_gst = $num / $taxPercentDivisor;
-        $gst =           $num - $num_minus_gst; 
+            if ($taxPercent !== '') {
+                $num_minus_gst = $num / $taxPercentDivisor;
+                $gst =           $num - $num_minus_gst;
 
-        if (($num_minus_gst + $gst) != $num) {
-          $num_minus_gst += $num - ($num_minus_gst + $gst); // round it up.
+                if (($num_minus_gst + $gst) != $num) {
+                    $num_minus_gst += $num - ($num_minus_gst + $gst); // round it up.
+                }
+
+                $rows[$taskID]["money"]+= page::money($timeSheet->get_value("currencyTypeID"), $num_minus_gst, "%mo");
+                $rows[$taskID]["gst"] += page::money($timeSheet->get_value("currencyTypeID"), $gst, "%mo");
+                $info["total_gst"] += $gst;
+                $info["total"] += $num_minus_gst;
+            } else {
+                $rows[$taskID]["money"] += page::money($timeSheet->get_value("currencyTypeID"), $num, "%mo");
+                $info["total"] += $num;
+            }
+
+
+            $unit = $unit_array[$timeSheetItem->get_value("timeSheetItemDurationUnitID")];
+            $units[$taskID][$unit] += sprintf("%0.2f", $timeSheetItem->get_value("timeSheetItemDuration") * $timeSheetItem->get_value("multiplier"));
+
+            unset($str);
+            $d = $timeSheetItem->get_value('taskID', DST_HTML_DISPLAY) . ": " . $timeSheetItem->get_value('description', DST_HTML_DISPLAY);
+            $d && !$rows[$taskID]["desc"] and $str[] = "<b>".$d."</b>"; //inline because the PDF needs it that way
+
+          // Get task description
+            if ($taskID && $TPL["printDesc"]) {
+                $t = new task();
+                $t->set_id($taskID);
+                $t->select();
+                $d2 = str_replace("\r\n", "\n", $t->get_value("taskDescription", DST_HTML_DISPLAY));
+                $d2 .= "\n";
+
+                $d2 && !$d2s[$taskID] and $str[] = $d2;
+                $d2 and $d2s[$taskID] = true;
+            }
+
+            $c = str_replace("\r\n", "\n", $timeSheetItem->get_value("comment"));
+            !$timeSheetItem->get_value("commentPrivate") && $c and $str[] = page::htmlentities($c);
+
+            is_array($str) and $rows[$taskID]["desc"].= trim(implode(DEFAULT_SEP, $str));
         }
 
-        $rows[$taskID]["money"]+= page::money($timeSheet->get_value("currencyTypeID"),$num_minus_gst,"%mo");
-        $rows[$taskID]["gst"] += page::money($timeSheet->get_value("currencyTypeID"),$gst,"%mo");
-        $info["total_gst"] += $gst;
-        $info["total"] += $num_minus_gst;
-      } else {
-        $rows[$taskID]["money"] += page::money($timeSheet->get_value("currencyTypeID"),$num,"%mo");
-        $info["total"] += $num;
-      }
+      // Group by units ie, a particular row/task might have  3 Weeks, 2 Hours of work done.
+        $units or $units = array();
+        foreach ($units as $tid => $u) {
+            unset($commar);
+            foreach ($u as $unit => $amount) {
+                $rows[$tid]["units"] .= $commar.$amount." ".$unit;
+                $commar = ", ";
+                $i[$unit] += $amount;
+            }
+        }
+        unset($commar);
+        $i or $i = array();
+        foreach ($i as $unit => $amount) {
+            $info["total_units"].= $commar.$amount." ".$unit;
+            $commar = ", ";
+        }
 
+        $info["total_inc_gst"] = page::money($timeSheet->get_value("currencyTypeID"), $info["total"]+$info["total_gst"], "%s%mo");
 
-      $unit = $unit_array[$timeSheetItem->get_value("timeSheetItemDurationUnitID")];
-      $units[$taskID][$unit] += sprintf("%0.2f",$timeSheetItem->get_value("timeSheetItemDuration") * $timeSheetItem->get_value("multiplier"));
-
-      unset($str);
-      $d = $timeSheetItem->get_value('taskID', DST_HTML_DISPLAY) . ": " . $timeSheetItem->get_value('description',DST_HTML_DISPLAY);
-      $d && !$rows[$taskID]["desc"] and $str[] = "<b>".$d."</b>"; //inline because the PDF needs it that way
-
-      // Get task description
-      if ($taskID && $TPL["printDesc"]) {
-        $t = new task();
-        $t->set_id($taskID);
-        $t->select();
-        $d2 = str_replace("\r\n","\n",$t->get_value("taskDescription",DST_HTML_DISPLAY));
-	$d2 .= "\n";
-
-        $d2 && !$d2s[$taskID] and $str[] = $d2;
-        $d2 and $d2s[$taskID] = true;
-      }
-
-      $c = str_replace("\r\n","\n",$timeSheetItem->get_value("comment"));
-      !$timeSheetItem->get_value("commentPrivate") && $c and $str[] = page::htmlentities($c);
-
-      is_array($str) and $rows[$taskID]["desc"].= trim(implode(DEFAULT_SEP,$str));
+      // If we are in dollar mode, then prefix the total with a dollar sign
+        $info["total"] = page::money($timeSheet->get_value("currencyTypeID"), $info["total"], "%s%mo");
+        $info["total_gst"] = page::money($timeSheet->get_value("currencyTypeID"), $info["total_gst"], "%s%mo");
+        $rows or $rows = array();
+        $info or $info = array();
+        return array($rows,$info);
     }
 
-    // Group by units ie, a particular row/task might have  3 Weeks, 2 Hours of work done.
-    $units or $units = array();
-    foreach ($units as $tid => $u) {
-      unset($commar);
-      foreach ($u as $unit => $amount) {
-        $rows[$tid]["units"] .= $commar.$amount." ".$unit;
-        $commar = ", ";
-        $i[$unit] += $amount;
-      }
-    }
-    unset($commar);
-    $i or $i = array();
-    foreach ($i as $unit => $amount) {
-      $info["total_units"].= $commar.$amount." ".$unit;
-      $commar = ", ";
-    }
+    function get_timeSheetItem_list_units($timeSheetID)
+    {
+        global $TPL;
+        list($db,$customerBilledDollars,$timeSheet,$unit_array,$currency) = $this->get_timeSheetItem_vars($timeSheetID);
 
-    $info["total_inc_gst"] = page::money($timeSheet->get_value("currencyTypeID"),$info["total"]+$info["total_gst"],"%s%mo");
+        while ($db->next_record()) {
+            $timeSheetItem = new timeSheetItem();
+            $timeSheetItem->read_db_record($db);
 
-    // If we are in dollar mode, then prefix the total with a dollar sign
-    $info["total"] = page::money($timeSheet->get_value("currencyTypeID"),$info["total"],"%s%mo");
-    $info["total_gst"] = page::money($timeSheet->get_value("currencyTypeID"),$info["total_gst"],"%s%mo");
-    $rows or $rows = array();
-    $info or $info = array();
-    return array($rows,$info);
-  }
+            $taskID = sprintf("%d", $timeSheetItem->get_value("taskID"));
+            $taskID or $taskID = "hey"; // Catch entries without task selected. ie timesheetitem.comment entries.
 
-  function get_timeSheetItem_list_units($timeSheetID) {
-    global $TPL;
-    list($db,$customerBilledDollars,$timeSheet,$unit_array,$currency) = $this->get_timeSheetItem_vars($timeSheetID);
+            $num = sprintf("%0.2f", $timeSheetItem->get_value("timeSheetItemDuration"));
+          #$info["total"] += $num;
 
-    while ($db->next_record()) {
-      $timeSheetItem = new timeSheetItem();
-      $timeSheetItem->read_db_record($db);
+            $unit = $unit_array[$timeSheetItem->get_value("timeSheetItemDurationUnitID")];
+            $units[$taskID][$unit] += $num;
 
-      $taskID = sprintf("%d",$timeSheetItem->get_value("taskID"));
-      $taskID or $taskID = "hey"; // Catch entries without task selected. ie timesheetitem.comment entries.
-
-      $num = sprintf("%0.2f",$timeSheetItem->get_value("timeSheetItemDuration"));
-      #$info["total"] += $num;
-
-      $unit = $unit_array[$timeSheetItem->get_value("timeSheetItemDurationUnitID")];
-      $units[$taskID][$unit] += $num;
-
-      unset($str);
-      $d = $timeSheetItem->get_value('taskID', DST_HTML_DISPLAY) . ": " . $timeSheetItem->get_value('description',DST_HTML_DISPLAY);
-      $d && !$rows[$taskID]["desc"] and $str[] = "<b>".$d."</b>";
+            unset($str);
+            $d = $timeSheetItem->get_value('taskID', DST_HTML_DISPLAY) . ": " . $timeSheetItem->get_value('description', DST_HTML_DISPLAY);
+            $d && !$rows[$taskID]["desc"] and $str[] = "<b>".$d."</b>";
 
 
-      // Get task description
-      if ($taskID && $TPL["printDesc"]) {
-        $t = new task();
-        $t->set_id($taskID);
-        $t->select();
-        $d2 = str_replace("\r\n","\n",$t->get_value("taskDescription",DST_HTML_DISPLAY));
-	$d2 .= "\n";
+          // Get task description
+            if ($taskID && $TPL["printDesc"]) {
+                $t = new task();
+                $t->set_id($taskID);
+                $t->select();
+                $d2 = str_replace("\r\n", "\n", $t->get_value("taskDescription", DST_HTML_DISPLAY));
+                $d2 .= "\n";
 
-        $d2 && !$d2s[$taskID] and $str[] = $d2;
-        $d2 and $d2s[$taskID] = true;
-      }
+                $d2 && !$d2s[$taskID] and $str[] = $d2;
+                $d2 and $d2s[$taskID] = true;
+            }
 
-      $c = str_replace("\r\n","\n",$timeSheetItem->get_value("comment"));
-      !$timeSheetItem->get_value("commentPrivate") && $c  && !$cs[$c] and $str[] = page::htmlentities($c);
-      $cs[$c] = true;
+            $c = str_replace("\r\n", "\n", $timeSheetItem->get_value("comment"));
+            !$timeSheetItem->get_value("commentPrivate") && $c  && !$cs[$c] and $str[] = page::htmlentities($c);
+            $cs[$c] = true;
 
-      is_array($str) and $rows[$taskID]["desc"].= trim(implode(DEFAULT_SEP,$str));
+            is_array($str) and $rows[$taskID]["desc"].= trim(implode(DEFAULT_SEP, $str));
+        }
 
+      // Group by units ie, a particular row/task might have  3 Weeks, 2 Hours of work done.
+        $units or $units = array();
+        foreach ($units as $tid => $u) {
+            unset($commar);
+            foreach ($u as $unit => $amount) {
+                $rows[$tid]["units"] .= $commar.$amount." ".$unit;
+                $commar = ", ";
+                $i[$unit] += $amount;
+            }
+        }
+
+        unset($commar);
+        $i or $i = array();
+        foreach ($i as $unit => $amount) {
+            $info["total"].= $commar.$amount." ".$unit;
+            $commar = ", ";
+        }
+
+        $timeSheet->load_pay_info();
+        $info["total"] = $timeSheet->pay_info["summary_unit_totals"];
+        $rows or $rows = array();
+        $info or $info = array();
+        return array($rows,$info);
     }
 
-    // Group by units ie, a particular row/task might have  3 Weeks, 2 Hours of work done.
-    $units or $units = array();
-    foreach ($units as $tid => $u) {
-      unset($commar);
-      foreach ($u as $unit => $amount) {
-        $rows[$tid]["units"] .= $commar.$amount." ".$unit;
-        $commar = ", ";
-        $i[$unit] += $amount;
-      }
+    function get_timeSheetItem_list_items($timeSheetID)
+    {
+        global $TPL;
+        list($db,$customerBilledDollars,$timeSheet,$unit_array,$currency) = $this->get_timeSheetItem_vars($timeSheetID);
+
+        $m = new meta("timeSheetItemMultiplier");
+        $multipliers = $m->get_list();
+
+        while ($db->next_record()) {
+            $timeSheetItem = new timeSheetItem();
+            $timeSheetItem->read_db_record($db);
+
+            $row_num++;
+            $taskID = sprintf("%d", $timeSheetItem->get_value("taskID"));
+            $num = sprintf("%0.2f", $timeSheetItem->get_value("timeSheetItemDuration"));
+
+            $info["total"] += $num;
+            $rows[$row_num]["date"] = $timeSheetItem->get_value("dateTimeSheetItem");
+            $rows[$row_num]["units"] = $num." ".$unit_array[$timeSheetItem->get_value("timeSheetItemDurationUnitID")];
+            $rows[$row_num]["multiplier_string"] = $multipliers[$timeSheetItem->get_value("multiplier")]["timeSheetItemMultiplierName"];
+
+            unset($str);
+            $d = $timeSheetItem->get_value('taskID', DST_HTML_DISPLAY) . ": " . $timeSheetItem->get_value('description', DST_HTML_DISPLAY);
+            $d && !$rows[$row_num]["desc"] and $str[] = "<b>".$d."</b>";
+
+          // Get task description
+            if ($taskID && $TPL["printDesc"]) {
+                $t = new task();
+                $t->set_id($taskID);
+                $t->select();
+                $d2 = str_replace("\r\n", "\n", $t->get_value("taskDescription", DST_HTML_DISPLAY));
+                $d2 .= "\n";
+
+                $d2 && !$d2s[$taskID] and $str[] = $d2;
+                $d2 and $d2s[$taskID] = true;
+            }
+
+            $c = str_replace("\r\n", "\n", $timeSheetItem->get_value("comment"));
+            !$timeSheetItem->get_value("commentPrivate") && $c and $str[] = page::htmlentities($c);
+
+            is_array($str) and $rows[$row_num]["desc"].= trim(implode(DEFAULT_SEP, $str));
+        }
+
+        $timeSheet->load_pay_info();
+        $info["total"] = $timeSheet->pay_info["summary_unit_totals"];
+        $rows or $rows = array();
+        $info or $info = array();
+        return array($rows,$info);
     }
 
-    unset($commar);
-    $i or $i = array();
-    foreach ($i as $unit => $amount) {
-      $info["total"].= $commar.$amount." ".$unit;
-      $commar = ", ";
-    }
+    function get_printable_timeSheet_file($timeSheetID, $timeSheetPrintMode, $printDesc, $format)
+    {
+        global $TPL;
 
-    $timeSheet->load_pay_info();
-    $info["total"] = $timeSheet->pay_info["summary_unit_totals"];
-    $rows or $rows = array();
-    $info or $info = array();
-    return array($rows,$info);
-  }
+        $TPL["timeSheetID"] = $timeSheetID;
+        $TPL["timeSheetPrintMode"] = $timeSheetPrintMode;
+        $TPL["printDesc"] = $printDesc;
+        $TPL["format"] = $format;
 
-  function get_timeSheetItem_list_items($timeSheetID) {
-    global $TPL;
-    list($db,$customerBilledDollars,$timeSheet,$unit_array,$currency) = $this->get_timeSheetItem_vars($timeSheetID);
+        $db = new db_alloc();
 
-    $m = new meta("timeSheetItemMultiplier");
-    $multipliers = $m->get_list();
-
-    while ($db->next_record()) {
-      $timeSheetItem = new timeSheetItem();
-      $timeSheetItem->read_db_record($db);
-
-      $row_num++;
-      $taskID = sprintf("%d",$timeSheetItem->get_value("taskID"));
-      $num = sprintf("%0.2f",$timeSheetItem->get_value("timeSheetItemDuration"));
-
-      $info["total"] += $num;
-      $rows[$row_num]["date"] = $timeSheetItem->get_value("dateTimeSheetItem");
-      $rows[$row_num]["units"] = $num." ".$unit_array[$timeSheetItem->get_value("timeSheetItemDurationUnitID")];
-      $rows[$row_num]["multiplier_string"] = $multipliers[$timeSheetItem->get_value("multiplier")]["timeSheetItemMultiplierName"];
-
-      unset($str);
-      $d = $timeSheetItem->get_value('taskID', DST_HTML_DISPLAY) . ": " . $timeSheetItem->get_value('description',DST_HTML_DISPLAY);
-      $d && !$rows[$row_num]["desc"] and $str[] = "<b>".$d."</b>";
-
-      // Get task description
-      if ($taskID && $TPL["printDesc"]) {
-        $t = new task();
-        $t->set_id($taskID);
-        $t->select();
-        $d2 = str_replace("\r\n","\n",$t->get_value("taskDescription",DST_HTML_DISPLAY));
-	$d2 .= "\n";
-
-        $d2 && !$d2s[$taskID] and $str[] = $d2;
-        $d2 and $d2s[$taskID] = true;
-      }
-
-      $c = str_replace("\r\n","\n",$timeSheetItem->get_value("comment"));
-      !$timeSheetItem->get_value("commentPrivate") && $c and $str[] = page::htmlentities($c);
-
-      is_array($str) and $rows[$row_num]["desc"].= trim(implode(DEFAULT_SEP,$str));
-    }
-
-    $timeSheet->load_pay_info();
-    $info["total"] = $timeSheet->pay_info["summary_unit_totals"];
-    $rows or $rows = array();
-    $info or $info = array();
-    return array($rows,$info);
-  }
-
-  function get_printable_timeSheet_file($timeSheetID,$timeSheetPrintMode,$printDesc,$format) {
-    global $TPL;
-
-    $TPL["timeSheetID"] = $timeSheetID;
-    $TPL["timeSheetPrintMode"] = $timeSheetPrintMode;
-    $TPL["printDesc"] = $printDesc;
-    $TPL["format"] = $format;
-
-    $db = new db_alloc();
-
-    if ($timeSheetID) {
-
-      $timeSheet = new timeSheet();
-      $timeSheet->set_id($timeSheetID);
-      $timeSheet->select();
-      $timeSheet->set_tpl_values();
+        if ($timeSheetID) {
+            $timeSheet = new timeSheet();
+            $timeSheet->set_id($timeSheetID);
+            $timeSheet->select();
+            $timeSheet->set_tpl_values();
 
 
-      $person = $timeSheet->get_foreign_object("person");
-      $TPL["timeSheet_personName"] = $person->get_name();
-      $timeSheet->set_tpl_values("timeSheet_");
+            $person = $timeSheet->get_foreign_object("person");
+            $TPL["timeSheet_personName"] = $person->get_name();
+            $timeSheet->set_tpl_values("timeSheet_");
 
 
-      // Display the project name.
-      $project = new project();
-      $project->set_id($timeSheet->get_value("projectID"));
-      $project->select();
-      $TPL["timeSheet_projectName"] = $project->get_value("projectName",DST_HTML_DISPLAY);
+          // Display the project name.
+            $project = new project();
+            $project->set_id($timeSheet->get_value("projectID"));
+            $project->select();
+            $TPL["timeSheet_projectName"] = $project->get_value("projectName", DST_HTML_DISPLAY);
 
-      // Get client name
-      $client = $project->get_foreign_object("client");
-      $client->set_tpl_values();
-      $TPL["clientName"] = $client->get_value("clientName",DST_HTML_DISPLAY);
-      $TPL["companyName"] = config::get_config_item("companyName");
+          // Get client name
+            $client = $project->get_foreign_object("client");
+            $client->set_tpl_values();
+            $TPL["clientName"] = $client->get_value("clientName", DST_HTML_DISPLAY);
+            $TPL["companyName"] = config::get_config_item("companyName");
 
-      $TPL["companyNos1"] = config::get_config_item("companyACN");
-      $TPL["companyNos2"] = config::get_config_item("companyABN");
+            $TPL["companyNos1"] = config::get_config_item("companyACN");
+            $TPL["companyNos2"] = config::get_config_item("companyABN");
 
-      unset($br);
-      $phone = config::get_config_item("companyContactPhone");
-      $fax = config::get_config_item("companyContactFax");
-      $phone and $TPL["phone"] = "Ph: ".$phone;
-      $fax and $TPL["fax"] = "Fax: ".$fax;
+            unset($br);
+            $phone = config::get_config_item("companyContactPhone");
+            $fax = config::get_config_item("companyContactFax");
+            $phone and $TPL["phone"] = "Ph: ".$phone;
+            $fax and $TPL["fax"] = "Fax: ".$fax;
 
 
-      $timeSheet->load_pay_info();
+            $timeSheet->load_pay_info();
 
-      $db->query(prepare("SELECT max(dateTimeSheetItem) AS maxDate
+            $db->query(prepare("SELECT max(dateTimeSheetItem) AS maxDate
                                 ,min(dateTimeSheetItem) AS minDate
                                 ,count(timeSheetItemID) as count
                             FROM timeSheetItem 
                            WHERE timeSheetID=%d ", $timeSheetID));
 
-      $db->next_record();
-      $timeSheet->set_id($timeSheetID);
-      $timeSheet->select() || alloc_error("Unable to select time sheet, trying to use id: ".$timeSheetID);
-      $TPL["period"] = format_date(DATE_FORMAT, $db->f("minDate"))." to ".format_date(DATE_FORMAT, $db->f("maxDate"));
+            $db->next_record();
+            $timeSheet->set_id($timeSheetID);
+            $timeSheet->select() || alloc_error("Unable to select time sheet, trying to use id: ".$timeSheetID);
+            $TPL["period"] = format_date(DATE_FORMAT, $db->f("minDate"))." to ".format_date(DATE_FORMAT, $db->f("maxDate"));
 
-      $TPL["img"] = config::get_config_item("companyImage");
-      $TPL["companyContactAddress"] = config::get_config_item("companyContactAddress");
-      $TPL["companyContactAddress2"] = config::get_config_item("companyContactAddress2");
-      $TPL["companyContactAddress3"] = config::get_config_item("companyContactAddress3");
-      $email = config::get_config_item("companyContactEmail");
-      $email and $TPL["companyContactEmail"] = "Email: ".$email;
-      $web = config::get_config_item("companyContactHomePage");
-      $web and $TPL["companyContactHomePage"] = "Web: ".$web;
+            $TPL["img"] = config::get_config_item("companyImage");
+            $TPL["companyContactAddress"] = config::get_config_item("companyContactAddress");
+            $TPL["companyContactAddress2"] = config::get_config_item("companyContactAddress2");
+            $TPL["companyContactAddress3"] = config::get_config_item("companyContactAddress3");
+            $email = config::get_config_item("companyContactEmail");
+            $email and $TPL["companyContactEmail"] = "Email: ".$email;
+            $web = config::get_config_item("companyContactHomePage");
+            $web and $TPL["companyContactHomePage"] = "Web: ".$web;
 
-      $TPL["footer"] = config::get_config_item("timeSheetPrintFooter");
-      $TPL["taxName"] = config::get_config_item("taxName");
-
-
-
-      $default_header = "Time Sheet";
-      $default_id_label = "Time Sheet ID";
-      $default_contractor_label = "Contractor";
-      $default_total_label = "TOTAL AMOUNT PAYABLE";
-
-      if ($timeSheetPrintMode == "money") {
-        $default_header = "Tax Invoice";
-        $default_id_label = "Invoice Number";
-      }
-      if ($timeSheetPrintMode == "estimate") {
-        $default_header = "Estimate";
-        $default_id_label = "Estimate Number";
-        $default_contractor_label = "Issued By";
-        $default_total_label = "TOTAL AMOUNT ESTIMATED";
-      }
+            $TPL["footer"] = config::get_config_item("timeSheetPrintFooter");
+            $TPL["taxName"] = config::get_config_item("taxName");
 
 
-      if ($format != "html") {
 
-        // Build PDF document
-        $font1 = ALLOC_MOD_DIR."util/fonts/Helvetica.afm";
-        $font2 = ALLOC_MOD_DIR."util/fonts/Helvetica-Oblique.afm";
+            $default_header = "Time Sheet";
+            $default_id_label = "Time Sheet ID";
+            $default_contractor_label = "Contractor";
+            $default_total_label = "TOTAL AMOUNT PAYABLE";
 
-        $pdf_table_options = array("showLines"=>0,"shaded"=>0,"showHeadings"=>0,"xPos"=>"left","xOrientation"=>"right","fontSize"=>10,"rowGap"=>0,"fontSize"=>10);
-
-
-        $cols = array("one"=>"","two"=>"","three"=>"","four"=>"");
-        $cols3 = array("one"=>"","two"=>"");
-        $cols_settings["one"] = array("justification"=>"right");
-        $cols_settings["three"] = array("justification"=>"right");
-        $pdf_table_options2 = array("showLines"=>0,"shaded"=>0,"showHeadings"=>0, "width"=>400, "fontSize"=>10, "xPos"=>"center", "xOrientation"=>"center", "cols"=>$cols_settings);
-        $cols_settings2["gst"] = array("justification"=>"right");
-        $cols_settings2["money"] = array("justification"=>"right");
-        $pdf_table_options3 = array("showLines"=>2,"shaded"=>0,"width"=>400, "xPos"=>"center","fontSize"=>10,"cols"=>$cols_settings2,"lineCol"=>array(0.8, 0.8, 0.8),"splitRows"=>1,"protectRows"=>0);
-        $cols_settings["two"] = array("justification"=>"right","width"=>80);
-        $pdf_table_options4 = array("showLines"=>2,"shaded"=>0,"width"=>400, "showHeadings"=>0, "fontSize"=>10, "xPos"=>"center", "cols"=>$cols_settings,"lineCol"=>array(0.8, 0.8, 0.8));
-
-        $pdf = new Cezpdf();
-        $pdf->ezSetMargins(90,90,90,90);
-
-        $pdf->selectFont($font1);
-        $pdf->ezStartPageNumbers(436,80,10,'right','Page {PAGENUM} of {TOTALPAGENUM}');
-        $pdf->ezStartPageNumbers(200,80,10,'left','<b>'.$default_id_label.': </b>'.$TPL["timeSheetID"]);
-        $pdf->ezSetY(775);
-
-        $TPL["companyName"]            and $contact_info[] = array($TPL["companyName"]);
-        $TPL["companyContactAddress"]  and $contact_info[] = array($TPL["companyContactAddress"]);
-        $TPL["companyContactAddress2"] and $contact_info[] = array($TPL["companyContactAddress2"]);
-        $TPL["companyContactAddress3"] and $contact_info[] = array($TPL["companyContactAddress3"]);
-        $TPL["companyContactEmail"]    and $contact_info[] = array($TPL["companyContactEmail"]);
-        $TPL["companyContactHomePage"] and $contact_info[] = array($TPL["companyContactHomePage"]);
-        $TPL["phone"]                  and $contact_info[] = array($TPL["phone"]);
-        $TPL["fax"]                    and $contact_info[] = array($TPL["fax"]);
-
-        $pdf->selectFont($font2);
-
-        $y = $pdf->ezTable($contact_info,false,"",$pdf_table_options);
-        $pdf->selectFont($font1);
-
-        $line_y = $y-10;
-        $pdf->setLineStyle(1,"round");
-        $pdf->line(90,$line_y,510,$line_y);
+            if ($timeSheetPrintMode == "money") {
+                  $default_header = "Tax Invoice";
+                  $default_id_label = "Invoice Number";
+            }
+            if ($timeSheetPrintMode == "estimate") {
+                $default_header = "Estimate";
+                $default_id_label = "Estimate Number";
+                $default_contractor_label = "Issued By";
+                $default_total_label = "TOTAL AMOUNT ESTIMATED";
+            }
 
 
-        $pdf->ezSetY(782);
-        $image_jpg = ALLOC_LOGO;
-        if (file_exists($image_jpg)) {
-          $pdf->ezImage($image_jpg,0,sprintf("%d",config::get_config_item("logoScaleX")),'none');
-          $y = 700;
-        } else {
-          $y = $pdf->ezText($TPL["companyName"],27, array("justification"=>"right"));
+            if ($format != "html") {
+                // Build PDF document
+                $font1 = ALLOC_MOD_DIR."util/fonts/Helvetica.afm";
+                $font2 = ALLOC_MOD_DIR."util/fonts/Helvetica-Oblique.afm";
+
+                $pdf_table_options = array("showLines"=>0,"shaded"=>0,"showHeadings"=>0,"xPos"=>"left","xOrientation"=>"right","fontSize"=>10,"rowGap"=>0,"fontSize"=>10);
+
+
+                $cols = array("one"=>"","two"=>"","three"=>"","four"=>"");
+                $cols3 = array("one"=>"","two"=>"");
+                $cols_settings["one"] = array("justification"=>"right");
+                $cols_settings["three"] = array("justification"=>"right");
+                $pdf_table_options2 = array("showLines"=>0,"shaded"=>0,"showHeadings"=>0, "width"=>400, "fontSize"=>10, "xPos"=>"center", "xOrientation"=>"center", "cols"=>$cols_settings);
+                $cols_settings2["gst"] = array("justification"=>"right");
+                $cols_settings2["money"] = array("justification"=>"right");
+                $pdf_table_options3 = array("showLines"=>2,"shaded"=>0,"width"=>400, "xPos"=>"center","fontSize"=>10,"cols"=>$cols_settings2,"lineCol"=>array(0.8, 0.8, 0.8),"splitRows"=>1,"protectRows"=>0);
+                $cols_settings["two"] = array("justification"=>"right","width"=>80);
+                $pdf_table_options4 = array("showLines"=>2,"shaded"=>0,"width"=>400, "showHeadings"=>0, "fontSize"=>10, "xPos"=>"center", "cols"=>$cols_settings,"lineCol"=>array(0.8, 0.8, 0.8));
+
+                $pdf = new Cezpdf();
+                $pdf->ezSetMargins(90, 90, 90, 90);
+
+                $pdf->selectFont($font1);
+                $pdf->ezStartPageNumbers(436, 80, 10, 'right', 'Page {PAGENUM} of {TOTALPAGENUM}');
+                $pdf->ezStartPageNumbers(200, 80, 10, 'left', '<b>'.$default_id_label.': </b>'.$TPL["timeSheetID"]);
+                $pdf->ezSetY(775);
+
+                $TPL["companyName"]            and $contact_info[] = array($TPL["companyName"]);
+                $TPL["companyContactAddress"]  and $contact_info[] = array($TPL["companyContactAddress"]);
+                $TPL["companyContactAddress2"] and $contact_info[] = array($TPL["companyContactAddress2"]);
+                $TPL["companyContactAddress3"] and $contact_info[] = array($TPL["companyContactAddress3"]);
+                $TPL["companyContactEmail"]    and $contact_info[] = array($TPL["companyContactEmail"]);
+                $TPL["companyContactHomePage"] and $contact_info[] = array($TPL["companyContactHomePage"]);
+                $TPL["phone"]                  and $contact_info[] = array($TPL["phone"]);
+                $TPL["fax"]                    and $contact_info[] = array($TPL["fax"]);
+
+                $pdf->selectFont($font2);
+
+                $y = $pdf->ezTable($contact_info, false, "", $pdf_table_options);
+                $pdf->selectFont($font1);
+
+                $line_y = $y-10;
+                $pdf->setLineStyle(1, "round");
+                $pdf->line(90, $line_y, 510, $line_y);
+
+
+                $pdf->ezSetY(782);
+                $image_jpg = ALLOC_LOGO;
+                if (file_exists($image_jpg)) {
+                    $pdf->ezImage($image_jpg, 0, sprintf("%d", config::get_config_item("logoScaleX")), 'none');
+                    $y = 700;
+                } else {
+                    $y = $pdf->ezText($TPL["companyName"], 27, array("justification"=>"right"));
+                }
+                $nos_y = $line_y + 22;
+                $TPL["companyNos2"] and $nos_y = $line_y + 34;
+                $pdf->ezSetY($nos_y);
+                $TPL["companyNos1"] and $y = $pdf->ezText($TPL["companyNos1"], 10, array("justification"=>"right"));
+                $TPL["companyNos2"] and $y = $pdf->ezText($TPL["companyNos2"], 10, array("justification"=>"right"));
+
+
+
+                $pdf->ezSetY($line_y -20);
+                $y = $pdf->ezText($default_header, 20, array("justification"=>"center"));
+                $pdf->ezSetY($y -20);
+
+                $ts_info[] = array("one"=>"<b>".$default_id_label.":</b>","two"=>$TPL["timeSheetID"],"three"=>"<b>Date Issued:</b>","four"=>date("d/m/Y"));
+                $ts_info[] = array("one"=>"<b>Client:</b>"        ,"two"=>$TPL["clientName"],"three"=>"<b>Project:</b>","four"=>$TPL["timeSheet_projectName"]);
+                $ts_info[] = array("one"=>"<b>".$default_contractor_label.":</b>"    ,"two"=>$TPL["timeSheet_personName"],"three"=>"<b>Billing Period:</b>","four"=>$TPL["period"]);
+                if ($timeSheetPrintMode == "estimate") { // This line needs to be glued to the above line
+                    $temp = array_pop($ts_info);
+                    $temp["three"] = ""; // Nuke Billing Period for the Estimate version of the pdf.
+                    $temp["four"] = ""; // Nuke Billing Period for the Estimate version of the pdf.
+                    $ts_info[] = $temp;
+                }
+
+
+                $y = $pdf->ezTable($ts_info, $cols, "", $pdf_table_options2);
+
+                $pdf->ezSetY($y -20);
+
+                if ($timeSheetPrintMode == "money" || $timeSheetPrintMode == "estimate") {
+                    list($rows,$info) = $this->get_timeSheetItem_list_money($TPL["timeSheetID"]);
+                    $cols2 = array("desc"=>"Description","units"=>"Units","money"=>"Charges","gst"=>$TPL["taxName"]);
+                    $taxPercent = config::get_config_item("taxPercent");
+                    if ($taxPercent === '') {
+                        unset($cols2["gst"]);
+                    }
+                    $rows[] = array("desc"=>"<b>TOTAL</b>","units"=>$info["total_units"], "money"=>$info["total"],"gst"=>$info["total_gst"]);
+                    $y = $pdf->ezTable($rows, $cols2, "", $pdf_table_options3);
+                    $pdf->ezSetY($y -20);
+                    if ($taxPercent !== '') {
+                        $totals[] = array("one"=>"TOTAL ".$TPL["taxName"],"two"=>$info["total_gst"]);
+                    }
+                    $totals[] = array("one"=>"TOTAL CHARGES","two"=>$info["total"]);
+                    $totals[] = array("one"=>"<b>".$default_total_label."</b>","two"=>"<b>".$info["total_inc_gst"]."</b>");
+                    $y = $pdf->ezTable($totals, $cols3, "", $pdf_table_options4);
+                } else if ($timeSheetPrintMode == "units") {
+                    list($rows,$info) = $this->get_timeSheetItem_list_units($TPL["timeSheetID"]);
+                    $cols2 = array("desc"=>"Description","units"=>"Units");
+                    $rows[] = array("desc"=>"<b>TOTAL</b>","units"=>"<b>".$info["total"]."</b>");
+                    $y = $pdf->ezTable($rows, $cols2, "", $pdf_table_options3);
+                } else if ($timeSheetPrintMode == "items") {
+                    list($rows,$info) = $this->get_timeSheetItem_list_items($TPL["timeSheetID"]);
+                    $cols2 = array("date"=>"Date","units"=>"Units","multiplier_string"=>"Multiplier","desc"=>"Description");
+                    $rows[] = array("date"=>"<b>TOTAL</b>","units"=>"<b>".$info["total"]."</b>");
+                    $y = $pdf->ezTable($rows, $cols2, "", $pdf_table_options3);
+                }
+
+
+                $pdf->ezSetY($y -20);
+                $pdf->ezText(str_replace(array("<br>","<br/>","<br />"), "\n", $TPL["footer"]), 10);
+                $pdf->ezStream(array("Content-Disposition"=>"timeSheet_".$timeSheetID.".pdf"));
+
+              // Else HTML format
+            } else {
+                if (file_exists(ALLOC_LOGO)) {
+                    $TPL["companyName"] = '<img alt="Company logo" src="'.$TPL["url_alloc_logo"].'" />';
+                }
+                $TPL["this_tsp"] = $this;
+                $TPL["main_alloc_title"] = "Time Sheet - ".APPLICATION_NAME;
+                include_template(dirname(__FILE__)."/../templates/timeSheetPrintM.tpl");
+            }
         }
-        $nos_y = $line_y + 22;
-        $TPL["companyNos2"] and $nos_y = $line_y + 34;
-        $pdf->ezSetY($nos_y);
-        $TPL["companyNos1"] and $y = $pdf->ezText($TPL["companyNos1"],10, array("justification"=>"right"));
-        $TPL["companyNos2"] and $y = $pdf->ezText($TPL["companyNos2"],10, array("justification"=>"right"));
-
-
-
-        $pdf->ezSetY($line_y -20);
-        $y = $pdf->ezText($default_header,20, array("justification"=>"center"));
-        $pdf->ezSetY($y -20);
-
-        $ts_info[] = array("one"=>"<b>".$default_id_label.":</b>","two"=>$TPL["timeSheetID"],"three"=>"<b>Date Issued:</b>","four"=>date("d/m/Y"));
-        $ts_info[] = array("one"=>"<b>Client:</b>"        ,"two"=>$TPL["clientName"],"three"=>"<b>Project:</b>","four"=>$TPL["timeSheet_projectName"]);
-        $ts_info[] = array("one"=>"<b>".$default_contractor_label.":</b>"    ,"two"=>$TPL["timeSheet_personName"],"three"=>"<b>Billing Period:</b>","four"=>$TPL["period"]);
-        if ($timeSheetPrintMode == "estimate") { // This line needs to be glued to the above line
-          $temp = array_pop($ts_info);
-          $temp["three"] = ""; // Nuke Billing Period for the Estimate version of the pdf.
-          $temp["four"] = ""; // Nuke Billing Period for the Estimate version of the pdf.
-          $ts_info[] = $temp;
-        }
-
-
-        $y = $pdf->ezTable($ts_info,$cols,"",$pdf_table_options2);
-
-        $pdf->ezSetY($y -20);
-
-        if ($timeSheetPrintMode == "money" || $timeSheetPrintMode == "estimate") {
-          list($rows,$info) = $this->get_timeSheetItem_list_money($TPL["timeSheetID"]);
-          $cols2 = array("desc"=>"Description","units"=>"Units","money"=>"Charges","gst"=>$TPL["taxName"]);
-          $taxPercent = config::get_config_item("taxPercent");
-          if ($taxPercent === '') unset($cols2["gst"]);
-          $rows[] = array("desc"=>"<b>TOTAL</b>","units"=>$info["total_units"], "money"=>$info["total"],"gst"=>$info["total_gst"]);
-          $y = $pdf->ezTable($rows,$cols2,"",$pdf_table_options3);
-          $pdf->ezSetY($y -20);
-          if ($taxPercent !== '') $totals[] = array("one"=>"TOTAL ".$TPL["taxName"],"two"=>$info["total_gst"]);
-          $totals[] = array("one"=>"TOTAL CHARGES","two"=>$info["total"]);
-          $totals[] = array("one"=>"<b>".$default_total_label."</b>","two"=>"<b>".$info["total_inc_gst"]."</b>");
-          $y = $pdf->ezTable($totals,$cols3,"",$pdf_table_options4);
-
-        } else if ($timeSheetPrintMode == "units") {
-          list($rows,$info) = $this->get_timeSheetItem_list_units($TPL["timeSheetID"]);
-          $cols2 = array("desc"=>"Description","units"=>"Units");
-          $rows[] = array("desc"=>"<b>TOTAL</b>","units"=>"<b>".$info["total"]."</b>");
-          $y = $pdf->ezTable($rows,$cols2,"",$pdf_table_options3);
-
-        } else if ($timeSheetPrintMode == "items") {
-          list($rows,$info) = $this->get_timeSheetItem_list_items($TPL["timeSheetID"]);
-          $cols2 = array("date"=>"Date","units"=>"Units","multiplier_string"=>"Multiplier","desc"=>"Description");
-          $rows[] = array("date"=>"<b>TOTAL</b>","units"=>"<b>".$info["total"]."</b>");
-          $y = $pdf->ezTable($rows,$cols2,"",$pdf_table_options3);
-        }
-
-
-        $pdf->ezSetY($y -20);
-        $pdf->ezText(str_replace(array("<br>","<br/>","<br />"),"\n",$TPL["footer"]),10);
-        $pdf->ezStream(array("Content-Disposition"=>"timeSheet_".$timeSheetID.".pdf"));
-
-      // Else HTML format
-      } else {
-        if(file_exists(ALLOC_LOGO)) {
-          $TPL["companyName"] = '<img alt="Company logo" src="'.$TPL["url_alloc_logo"].'" />';
-        }
-        $TPL["this_tsp"] = $this;
-        $TPL["main_alloc_title"] = "Time Sheet - ".APPLICATION_NAME;
-        include_template(dirname(__FILE__)."/../templates/timeSheetPrintM.tpl");
-      }
-
     }
-  }
-
 }
-
-?>

--- a/time/lib/timeSheetStatusHomeItem.inc.php
+++ b/time/lib/timeSheetStatusHomeItem.inc.php
@@ -3,74 +3,76 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class timeSheetStatusHomeItem extends home_item {
+class timeSheetStatusHomeItem extends home_item
+{
 
-  function __construct() {
-    parent::__construct("time_status_list", "Time Sheet Statistics", "time", "timeSheetStatusHomeM.tpl", "narrow", 29);
-  }
-
-  function visible() {
-    $current_user = &singleton("current_user");
-
-    if (!isset($current_user->prefs["showTimeSheetStatsHome"])) {
-      $current_user->prefs["showTimeSheetStatsHome"] = 1;
+    function __construct()
+    {
+        parent::__construct("time_status_list", "Time Sheet Statistics", "time", "timeSheetStatusHomeM.tpl", "narrow", 29);
     }
 
-    return (isset($current_user) && $current_user->is_employee()
+    function visible()
+    {
+        $current_user = &singleton("current_user");
+
+        if (!isset($current_user->prefs["showTimeSheetStatsHome"])) {
+            $current_user->prefs["showTimeSheetStatsHome"] = 1;
+        }
+
+        return (isset($current_user) && $current_user->is_employee()
         && ($current_user->prefs["showTimeSheetStatsHome"]));
-  }
+    }
 
-  function render() {
-    $current_user = &singleton("current_user");
-    global $TPL;
-    // Get averages for hours worked over the past fortnight and year
-    $t = new timeSheetItem();
-    $day = 60*60*24;
-    //mktime(0,0,0,date("m"),date("d")-1, date("Y"))
-    $today = date("Y-m-d",mktime(0,0,0,date("m"),date("d")-1, date("Y")));
-    $yestA = date("Y-m-d",mktime(0,0,0,date("m"),date("d")-2, date("Y")));
-    $yestB = date("Y-m-d",mktime(0,0,0,date("m"),date("d")-1, date("Y")));
-    $fortn = date("Y-m-d",mktime(0,0,0,date("m"),date("d")-14, date("Y")));
+    function render()
+    {
+        $current_user = &singleton("current_user");
+        global $TPL;
+      // Get averages for hours worked over the past fortnight and year
+        $t = new timeSheetItem();
+        $day = 60*60*24;
+      //mktime(0,0,0,date("m"),date("d")-1, date("Y"))
+        $today = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d")-1, date("Y")));
+        $yestA = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d")-2, date("Y")));
+        $yestB = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d")-1, date("Y")));
+        $fortn = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d")-14, date("Y")));
 
-    list($hours_sum_today,$dollars_sum_today)         = $t->get_averages($today,$current_user->get_id());
-    list($hours_sum_yesterday,$dollars_sum_yesterday) = $t->get_averages($yestA,$current_user->get_id(),null,$yestB);
-    list($hours_sum_fortnight,$dollars_sum_fortnight) = $t->get_averages($fortn,$current_user->get_id());
-    list($hours_avg_fortnight,$dollars_avg_fortnight) = $t->get_fortnightly_average($current_user->get_id());
+        list($hours_sum_today,$dollars_sum_today)         = $t->get_averages($today, $current_user->get_id());
+        list($hours_sum_yesterday,$dollars_sum_yesterday) = $t->get_averages($yestA, $current_user->get_id(), null, $yestB);
+        list($hours_sum_fortnight,$dollars_sum_fortnight) = $t->get_averages($fortn, $current_user->get_id());
+        list($hours_avg_fortnight,$dollars_avg_fortnight) = $t->get_fortnightly_average($current_user->get_id());
 
-    $TPL["hours_sum_today"] = sprintf("%0.2f",$hours_sum_today[$current_user->get_id()]);
-    $TPL["dollars_sum_today"] = page::money_print($dollars_sum_today[$current_user->get_id()]);
+        $TPL["hours_sum_today"] = sprintf("%0.2f", $hours_sum_today[$current_user->get_id()]);
+        $TPL["dollars_sum_today"] = page::money_print($dollars_sum_today[$current_user->get_id()]);
 
-    $TPL["hours_sum_yesterday"] = sprintf("%0.2f",$hours_sum_yesterday[$current_user->get_id()]);
-    $TPL["dollars_sum_yesterday"] = page::money_print($dollars_sum_yesterday[$current_user->get_id()]);
+        $TPL["hours_sum_yesterday"] = sprintf("%0.2f", $hours_sum_yesterday[$current_user->get_id()]);
+        $TPL["dollars_sum_yesterday"] = page::money_print($dollars_sum_yesterday[$current_user->get_id()]);
 
-    $TPL["hours_sum_fortnight"] = sprintf("%0.2f",$hours_sum_fortnight[$current_user->get_id()]);
-    $TPL["dollars_sum_fortnight"] = page::money_print($dollars_sum_fortnight[$current_user->get_id()]);
+        $TPL["hours_sum_fortnight"] = sprintf("%0.2f", $hours_sum_fortnight[$current_user->get_id()]);
+        $TPL["dollars_sum_fortnight"] = page::money_print($dollars_sum_fortnight[$current_user->get_id()]);
 
-    $TPL["hours_avg_fortnight"] = sprintf("%0.2f",$hours_avg_fortnight[$current_user->get_id()]);
-    $TPL["dollars_avg_fortnight"] = page::money(config::get_config_item("currency"),$dollars_avg_fortnight[$current_user->get_id()],"%s%m %c");
+        $TPL["hours_avg_fortnight"] = sprintf("%0.2f", $hours_avg_fortnight[$current_user->get_id()]);
+        $TPL["dollars_avg_fortnight"] = page::money(config::get_config_item("currency"), $dollars_avg_fortnight[$current_user->get_id()], "%s%m %c");
 
-    $TPL["dateFrom"] = date("Y-m-d",mktime(0,0,0,date("m"), date("d")-28, date("Y")));
-    $TPL["dateTo"] = date("Y-m-d",mktime(0,0,0,date("m"), date("d")+1, date("Y")));
+        $TPL["dateFrom"] = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d")-28, date("Y")));
+        $TPL["dateTo"] = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d")+1, date("Y")));
 
-    return true;
-  }
+        return true;
+    }
 }
-
-?>

--- a/time/lib/timeUnit.inc.php
+++ b/time/lib/timeUnit.inc.php
@@ -3,30 +3,31 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class timeUnit extends db_entity {
-  public $classname = "timeUnit";
-  public $data_table = "timeUnit";
-  public $display_field_name = "timeUnitLabelA";
-  public $key_field = "timeUnitID";
-  public $data_fields = array("timeUnitName"
+class timeUnit extends db_entity
+{
+    public $classname = "timeUnit";
+    public $data_table = "timeUnit";
+    public $display_field_name = "timeUnitLabelA";
+    public $key_field = "timeUnitID";
+    public $data_fields = array("timeUnitName"
                                ,"timeUnitLabelA"
                                ,"timeUnitLabelB"
                                ,"timeUnitSeconds"
@@ -34,19 +35,13 @@ class timeUnit extends db_entity {
                                ,"timeUnitSequence"
                                );
 
-  function seconds_to_display_time_unit($seconds) {
-    $q = "SELECT * FROM timeUnit";
-    $db = new db_alloc();
-    $db->query($q);
-    while ($db->next_record()) {
-      //blag someother time
-    }  
-
-  }
-
-}  
-
-
-
-
-?>
+    function seconds_to_display_time_unit($seconds)
+    {
+        $q = "SELECT * FROM timeUnit";
+        $db = new db_alloc();
+        $db->query($q);
+        while ($db->next_record()) {
+          //blag someother time
+        }
+    }
+}

--- a/time/lib/tsiHint.inc.php
+++ b/time/lib/tsiHint.inc.php
@@ -3,29 +3,30 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class tsiHint extends db_entity {
-  public $classname = "tsiHint";
-  public $data_table = "tsiHint";
-  public $display_field_name = "projectID";
-  public $key_field = "tsiHintID";
-  public $data_fields = array("taskID"
+class tsiHint extends db_entity
+{
+    public $classname = "tsiHint";
+    public $data_table = "tsiHint";
+    public $display_field_name = "projectID";
+    public $key_field = "tsiHintID";
+    public $data_fields = array("taskID"
                              ,"personID"
                              ,"duration"
                              ,"date"
@@ -36,58 +37,60 @@ class tsiHint extends db_entity {
                              ,"tsiHintModifiedUser"
                              );
 
-  function add_tsiHint($stuff) {
-    $current_user = &singleton("current_user");
-    $errstr = "Failed to record new time sheet item hint. ";
-    $username = $stuff["username"];
+    function add_tsiHint($stuff)
+    {
+        $current_user = &singleton("current_user");
+        $errstr = "Failed to record new time sheet item hint. ";
+        $username = $stuff["username"];
 
-    $people = person::get_people_by_username();
-    $personID = $people[$username]["personID"];
-    $personID or alloc_error("Person ".$username." not found.");
+        $people = person::get_people_by_username();
+        $personID = $people[$username]["personID"];
+        $personID or alloc_error("Person ".$username." not found.");
 
-    $taskID = $stuff["taskID"];
-    $projectID = $stuff["projectID"];
-    $duration = $stuff["duration"];
-    $comment = $stuff["comment"];
-    $date = $stuff["date"];
+        $taskID = $stuff["taskID"];
+        $projectID = $stuff["projectID"];
+        $duration = $stuff["duration"];
+        $comment = $stuff["comment"];
+        $date = $stuff["date"];
 
-    if ($taskID) {
-      $task = new task();
-      $task->set_id($taskID);
-      $task->select();
-      $projectID = $task->get_value("projectID");
-      $extra = " for task ".$taskID;
+        if ($taskID) {
+            $task = new task();
+            $task->set_id($taskID);
+            $task->select();
+            $projectID = $task->get_value("projectID");
+            $extra = " for task ".$taskID;
+        }
+
+        $projectID or alloc_error(sprintf($errstr."No project found%s.", $extra));
+
+        $row_projectPerson = projectPerson::get_projectPerson_row($projectID, $current_user->get_id());
+        $row_projectPerson or alloc_error($errstr."The person(".$current_user->get_id().") has not been added to the project(".$projectID.").");
+
+        if ($row_projectPerson && $projectID) {
+          // Add new time sheet item
+            $tsiHint = new tsiHint();
+            $d = $date or $d = date("Y-m-d");
+            $tsiHint->set_value("date", $d);
+            $tsiHint->set_value("duration", $duration);
+            if (is_object($task)) {
+                $tsiHint->set_value("taskID", sprintf("%d", $taskID));
+            }
+            $tsiHint->set_value("personID", $personID);
+            $tsiHint->set_value("comment", $comment);
+            $tsiHint->save();
+            $ID = $tsiHint->get_id();
+        }
+
+        if ($ID) {
+            return array("status"=>"yay","message"=>$ID);
+        } else {
+            alloc_error($errstr."Time hint not added.");
+        }
     }
 
-    $projectID or alloc_error(sprintf($errstr."No project found%s.",$extra));
-
-    $row_projectPerson = projectPerson::get_projectPerson_row($projectID, $current_user->get_id());
-    $row_projectPerson or alloc_error($errstr."The person(".$current_user->get_id().") has not been added to the project(".$projectID.").");
-
-    if ($row_projectPerson && $projectID) {
-      // Add new time sheet item
-      $tsiHint = new tsiHint();
-      $d = $date or $d = date("Y-m-d");
-      $tsiHint->set_value("date",$d);
-      $tsiHint->set_value("duration",$duration);
-      if (is_object($task)) {
-        $tsiHint->set_value("taskID",sprintf("%d",$taskID));
-      }
-      $tsiHint->set_value("personID",$personID);
-      $tsiHint->set_value("comment",$comment);
-      $tsiHint->save();
-      $ID = $tsiHint->get_id();
-    }
-
-    if ($ID) {
-      return array("status"=>"yay","message"=>$ID);
-    } else {
-      alloc_error($errstr."Time hint not added.");
-    }
-  }
-
-  function parse_tsiHint_string($str) {
-    preg_match("/^"
+    function parse_tsiHint_string($str)
+    {
+        preg_match("/^"
               ."([a-zA-Z0-9]+)"                      # username
               ."\s*"
               ."(\d\d\d\d\-\d\d?\-\d\d?\s+)?"   # date
@@ -97,22 +100,17 @@ class tsiHint extends db_entity {
               ."\s*"
               ."(.*)"               # comment
               ."\s*"
-              ."$/i",$str,$m);
+              ."$/i", $str, $m);
 
-    $rtn["username"] = $m[1];
-    $rtn["date"] = trim($m[2]) or $rtn["date"] = date("Y-m-d");
-    $rtn["duration"] = $m[3];
-    $rtn["taskID"] = $m[4];
-    $rtn["comment"] = $m[5];
+        $rtn["username"] = $m[1];
+        $rtn["date"] = trim($m[2]) or $rtn["date"] = date("Y-m-d");
+        $rtn["duration"] = $m[3];
+        $rtn["taskID"] = $m[4];
+        $rtn["comment"] = $m[5];
 
-    // change 2010/10/27 to 2010-10-27
-    $rtn["date"] = str_replace("/","-",$rtn["date"]);
+      // change 2010/10/27 to 2010-10-27
+        $rtn["date"] = str_replace("/", "-", $rtn["date"]);
 
-    return $rtn;
-  }
-
-}  
-
-
-
-?>
+        return $rtn;
+    }
+}

--- a/time/lib/tsiHintHomeItem.inc.php
+++ b/time/lib/tsiHintHomeItem.inc.php
@@ -3,39 +3,41 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class tsiHintHomeItem extends home_item {
+class tsiHintHomeItem extends home_item
+{
 
-  function __construct() {
-    parent::__construct("tsiHint_edit", "Time Sheet Item Hint", "time", "tsiHintH.tpl", "narrow", 25);
-  }
-
-  function visible() {
-    $current_user = &singleton("current_user");
-    if ($current_user->have_role("manage") && $current_user->prefs["showTimeSheetItemHintHome"]) {
-      return true;
+    function __construct()
+    {
+        parent::__construct("tsiHint_edit", "Time Sheet Item Hint", "time", "tsiHintH.tpl", "narrow", 25);
     }
-  }
 
-  function render() {
-    return true;
-  }
+    function visible()
+    {
+        $current_user = &singleton("current_user");
+        if ($current_user->have_role("manage") && $current_user->prefs["showTimeSheetItemHintHome"]) {
+            return true;
+        }
+    }
+
+    function render()
+    {
+        return true;
+    }
 }
-
-?>

--- a/time/timeSheet.php
+++ b/time/timeSheet.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,11 +23,12 @@
 require_once("../alloc.php");
 
 if (!$current_user->is_employee()) {
-  alloc_error("You do not have permission to access time sheets",true);
+    alloc_error("You do not have permission to access time sheets", true);
 }
 
 
-  function show_transaction_list($template_name) {
+function show_transaction_list($template_name)
+{
     global $timeSheet;
     global $TPL;
 
@@ -37,176 +38,180 @@ if (!$current_user->is_employee()) {
     $total_incoming = $timeSheet->pay_info["total_customerBilledDollars"];
 
     $db->query("SELECT * FROM transaction WHERE timeSheetID = %d AND fromTfID != %d
-               ",$timeSheet->get_id(),config::get_config_item("inTfID"));
+               ", $timeSheet->get_id(), config::get_config_item("inTfID"));
 
     while ($row = $db->row()) {
-      $has_transactions = true;
-      $rows[] = $row;
+        $has_transactions = true;
+        $rows[] = $row;
     }
     $total_allocated = transaction::get_actual_amount_used($rows);
-    $TPL["total_allocated"] = page::money($timeSheet->get_value("currencyTypeID"),$total_allocated,"%s%mo %c");
-    $TPL["total_dollars"] =   page::money($timeSheet->get_value("currencyTypeID"),$timeSheet->pay_info["total_dollars_not_null"],"%s%m %c");
+    $TPL["total_allocated"] = page::money($timeSheet->get_value("currencyTypeID"), $total_allocated, "%s%mo %c");
+    $TPL["total_dollars"] =   page::money($timeSheet->get_value("currencyTypeID"), $timeSheet->pay_info["total_dollars_not_null"], "%s%m %c");
     // used in js preload_field()
-    $TPL["total_remaining"] = page::money($timeSheet->get_value("currencyTypeID"),$total_incoming - $amount_so_far,"%m"); 
+    $TPL["total_remaining"] = page::money($timeSheet->get_value("currencyTypeID"), $total_incoming - $amount_so_far, "%m");
 
     if ($has_transactions || $timeSheet->get_value("status") == "invoiced" || $timeSheet->get_value("status") == "finished") {
+        if ($timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS) && $timeSheet->get_value("status") == "invoiced") {
+            $p_button = "<input style=\"padding:1px 4px\" type=\"submit\" name=\"p_button\" value=\"P\" title=\"Mark transactions pending\">&nbsp;";
+            $a_button = "<input style=\"padding:1px 4px\" type=\"submit\" name=\"a_button\" value=\"A\" title=\"Mark transactions approved\">&nbsp;";
+            $r_button = "<input style=\"padding:1px 4px\" type=\"submit\" name=\"r_button\" value=\"R\" title=\"Mark transactions rejected\">&nbsp;";
+            $session  = "<input type=\"hidden\" name=\"sessID\" value=\"".$TPL["sessID"]."\">";
+            $TPL["p_a_r_buttons"] = "<form action=\"".$TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheet->get_id()."\" method=\"post\">".$p_button.$a_button.$r_button.$session."</form>";
 
-      if ($timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS) && $timeSheet->get_value("status") == "invoiced") {
-        $p_button = "<input style=\"padding:1px 4px\" type=\"submit\" name=\"p_button\" value=\"P\" title=\"Mark transactions pending\">&nbsp;";
-        $a_button = "<input style=\"padding:1px 4px\" type=\"submit\" name=\"a_button\" value=\"A\" title=\"Mark transactions approved\">&nbsp;";
-        $r_button = "<input style=\"padding:1px 4px\" type=\"submit\" name=\"r_button\" value=\"R\" title=\"Mark transactions rejected\">&nbsp;";
-        $session  = "<input type=\"hidden\" name=\"sessID\" value=\"".$TPL["sessID"]."\">";
-        $TPL["p_a_r_buttons"] = "<form action=\"".$TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheet->get_id()."\" method=\"post\">".$p_button.$a_button.$r_button.$session."</form>";
 
+            $TPL["create_transaction_buttons"] = "<tr><td colspan=\"8\" align=\"center\" style=\"padding:10px;\">";
+            $TPL["create_transaction_buttons"].= "<form action=\"".$TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheet->get_id()."\" method=\"post\">";
 
-        $TPL["create_transaction_buttons"] = "<tr><td colspan=\"8\" align=\"center\" style=\"padding:10px;\">";
-        $TPL["create_transaction_buttons"].= "<form action=\"".$TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheet->get_id()."\" method=\"post\">";
-
-        $TPL["create_transaction_buttons"].= '
+            $TPL["create_transaction_buttons"].= '
          <button type="submit" name="create_transactions_default" value="1" class="save_button">Create Default Transactions<i class="icon-cogs"></i></button>
         ';
 
-        $TPL["create_transaction_buttons"] .= '
+            $TPL["create_transaction_buttons"] .= '
         <button type="submit" name="delete_all_transactions" value="1" class="delete_button">Delete Transactions<i class="icon-trash"></i></button>
         ';
 
-        $TPL["create_transaction_buttons"].= "<input type=\"hidden\" name=\"sessID\" value=\"".$TPL["sessID"]."\"></form></tr></tr>";
-      }
+            $TPL["create_transaction_buttons"].= "<input type=\"hidden\" name=\"sessID\" value=\"".$TPL["sessID"]."\"></form></tr></tr>";
+        }
 
 
       
 
-      include_template($template_name);
+        include_template($template_name);
     }
-  }
+}
 
-  function show_transaction_listR($template_name) {
+function show_transaction_listR($template_name)
+{
 
     global $timeSheet;
     global $TPL;
     $current_user = &singleton("current_user");
     global $percent_array;
     $db = new db_alloc();
-    $db->query("SELECT * FROM transaction WHERE timeSheetID = %d",$timeSheet->get_id());
+    $db->query("SELECT * FROM transaction WHERE timeSheetID = %d", $timeSheet->get_id());
 
     if ($db->next_record() || $timeSheet->get_value("status") == "invoiced" || $timeSheet->get_value("status") == "finished") {
-
-      $db->query("SELECT * 
+        $db->query(
+            "SELECT * 
                     FROM tf 
                    WHERE tfActive = 1
                       OR tfID = %d 
                       OR tfID = %d 
-                ORDER BY tfName"
-                ,$db->f("tfID"),$db->f("fromTfID"));
+                ORDER BY tfName",
+            $db->f("tfID"),
+            $db->f("fromTfID")
+        );
 
-      while ($db->row()) {
-        $tf_array[$db->f("tfID")] = $db->f("tfName");
-      }
-      $status_options = array("pending"=>"Pending", "approved"=>"Approved", "rejected"=>"Rejected");
-      $transactionType_options = transaction::get_transactionTypes();
+        while ($db->row()) {
+            $tf_array[$db->f("tfID")] = $db->f("tfName");
+        }
+        $status_options = array("pending"=>"Pending", "approved"=>"Approved", "rejected"=>"Rejected");
+        $transactionType_options = transaction::get_transactionTypes();
 
 
-      if ($timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS) && $timeSheet->get_value("status") == "invoiced") {
+        if ($timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS) && $timeSheet->get_value("status") == "invoiced") {
+            $db->query("SELECT * FROM transaction WHERE timeSheetID = %d ORDER BY transactionID", $timeSheet->get_id());
 
-        $db->query("SELECT * FROM transaction WHERE timeSheetID = %d ORDER BY transactionID",$timeSheet->get_id());
+            while ($db->next_record()) {
+                $transaction = new transaction();
+                $transaction->read_db_record($db);
+                $transaction->set_tpl_values("transaction_");
 
-        while ($db->next_record()) {
-          $transaction = new transaction();
-          $transaction->read_db_record($db);
-          $transaction->set_tpl_values("transaction_");
-
-          $TPL["currency"] = page::money($transaction->get_value("currencyTypeID"),'',"%S");
-          $TPL["currency_code"] = page::money($transaction->get_value("currencyTypeID"),'',"%C");
-          $TPL["tf_options"] = page::select_options($tf_array, $TPL["transaction_tfID"]);
-          $TPL["from_tf_options"] = page::select_options($tf_array, $TPL["transaction_fromTfID"]);
-          $TPL["status_options"] = page::select_options($status_options, $transaction->get_value("status"));
-          $TPL["transactionType_options"] = page::select_options($transactionType_options, $transaction->get_value("transactionType"));
-          $TPL["percent_dropdown"] = page::select_options($percent_array, $empty);
-          $TPL["transaction_buttons"] = '
+                $TPL["currency"] = page::money($transaction->get_value("currencyTypeID"), '', "%S");
+                $TPL["currency_code"] = page::money($transaction->get_value("currencyTypeID"), '', "%C");
+                $TPL["tf_options"] = page::select_options($tf_array, $TPL["transaction_tfID"]);
+                $TPL["from_tf_options"] = page::select_options($tf_array, $TPL["transaction_fromTfID"]);
+                $TPL["status_options"] = page::select_options($status_options, $transaction->get_value("status"));
+                $TPL["transactionType_options"] = page::select_options($transactionType_options, $transaction->get_value("transactionType"));
+                $TPL["percent_dropdown"] = page::select_options($percent_array, $empty);
+                $TPL["transaction_buttons"] = '
             <button type="submit" name="transaction_delete" value="1" class="delete_button">Delete<i class="icon-trash"></i></button>
             <button type="submit" name="transaction_save" value="1" class="save_button">Save<i class="icon-ok-sign"></i></button>
           ';
-          if ($transaction->get_value("transactionType") == "invoice") {
-            $TPL["transaction_transactionType"] = $transaction->get_transaction_type_link();
-            $TPL["transaction_fromTfID"] = tf::get_name($transaction->get_value("fromTfID"));
-            $TPL["transaction_tfID"] = tf::get_name($transaction->get_value("tfID"));
-            $TPL["currency_amount"] = page::money($transaction->get_value("currencyTypeID"),$transaction->get_value("amount"),"%S%mo %c");
-            include_template("templates/timeSheetTransactionListViewR.tpl");
-          } else {
-            include_template($template_name);
-          }
-        }
+                if ($transaction->get_value("transactionType") == "invoice") {
+                    $TPL["transaction_transactionType"] = $transaction->get_transaction_type_link();
+                    $TPL["transaction_fromTfID"] = tf::get_name($transaction->get_value("fromTfID"));
+                    $TPL["transaction_tfID"] = tf::get_name($transaction->get_value("tfID"));
+                    $TPL["currency_amount"] = page::money($transaction->get_value("currencyTypeID"), $transaction->get_value("amount"), "%S%mo %c");
+                    include_template("templates/timeSheetTransactionListViewR.tpl");
+                } else {
+                    include_template($template_name);
+                }
+            }
+        } else {
+          // If you don't have perm INVOICE TIMESHEETS then only select
+          // transactions which you have permissions to see.
 
-      } else {
-
-        // If you don't have perm INVOICE TIMESHEETS then only select 
-        // transactions which you have permissions to see. 
-
-        $query = prepare("SELECT * 
+            $query = prepare("SELECT * 
                             FROM transaction 
                            WHERE timeSheetID = %d
                         ORDER BY transactionID", $timeSheet->get_id());
 
-        $db->query($query);
+            $db->query($query);
 
-        while ($db->next_record()) {
-          $transaction = new transaction();
-          $transaction->read_db_record($db);
-          $transaction->set_tpl_values("transaction_");
-          unset($TPL["transaction_amount_pos"]);
-          unset($TPL["transaction_amount_neg"]);
-          $TPL["currency_amount"] = page::money($transaction->get_value("currencyTypeID"),$transaction->get_value("amount"),"%S%mo %c");
-          $TPL["transaction_fromTfID"] = tf::get_name($transaction->get_value("fromTfID"));
-          $TPL["transaction_tfID"] = tf::get_name($transaction->get_value("tfID"));
-          $TPL["transaction_transactionType"] = $transactionType_options[$transaction->get_value("transactionType")];
-          include_template("templates/timeSheetTransactionListViewR.tpl");
+            while ($db->next_record()) {
+                $transaction = new transaction();
+                $transaction->read_db_record($db);
+                $transaction->set_tpl_values("transaction_");
+                unset($TPL["transaction_amount_pos"]);
+                unset($TPL["transaction_amount_neg"]);
+                $TPL["currency_amount"] = page::money($transaction->get_value("currencyTypeID"), $transaction->get_value("amount"), "%S%mo %c");
+                $TPL["transaction_fromTfID"] = tf::get_name($transaction->get_value("fromTfID"));
+                $TPL["transaction_tfID"] = tf::get_name($transaction->get_value("tfID"));
+                $TPL["transaction_transactionType"] = $transactionType_options[$transaction->get_value("transactionType")];
+                include_template("templates/timeSheetTransactionListViewR.tpl");
+            }
         }
-      }
     }
-  }
+}
 
-  function show_new_transaction($template) {
+function show_new_transaction($template)
+{
     global $timeSheet;
     global $TPL;
     global $db;
     global $percent_array;
 
     if ($timeSheet->get_value("status") == "invoiced" && $timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
-      $tf = new tf();
-      $options = $tf->get_assoc_array("tfID","tfName");
-      $TPL["tf_options"] = page::select_options($options, $none);
+        $tf = new tf();
+        $options = $tf->get_assoc_array("tfID", "tfName");
+        $TPL["tf_options"] = page::select_options($options, $none);
 
-      $transactionType_options = transaction::get_transactionTypes();
-      $TPL["transactionType_options"] = page::select_options($transactionType_options);
+        $transactionType_options = transaction::get_transactionTypes();
+        $TPL["transactionType_options"] = page::select_options($transactionType_options);
 
-      $status_options = array("pending"=>"Pending", "approved"=>"Approved", "rejected"=>"Rejected");
-      $TPL["status_options"] = page::select_options($status_options);
-      $TPL["transaction_timeSheetID"] = $timeSheet->get_id();
-      $TPL["transaction_transactionDate"] = date("Y-m-d");
-      $TPL["transaction_product"] = "";
-      $TPL["transaction_buttons"] = '
+        $status_options = array("pending"=>"Pending", "approved"=>"Approved", "rejected"=>"Rejected");
+        $TPL["status_options"] = page::select_options($status_options);
+        $TPL["transaction_timeSheetID"] = $timeSheet->get_id();
+        $TPL["transaction_transactionDate"] = date("Y-m-d");
+        $TPL["transaction_product"] = "";
+        $TPL["transaction_buttons"] = '
             <button type="submit" name="transaction_save" value="1" class="save_button">Add<i class="icon-plus-sign"></i></button>
       ';
-      $TPL["percent_dropdown"] = page::select_options($percent_array, $empty);
-      include_template($template);
+        $TPL["percent_dropdown"] = page::select_options($percent_array, $empty);
+        include_template($template);
     }
-  }
+}
 
-  function show_main_list() {
+function show_main_list()
+{
     global $timeSheet;
     $current_user = &singleton("current_user");
-    if (!$timeSheet->get_id()) return;
+    if (!$timeSheet->get_id()) {
+        return;
+    }
     
     $db = new db_alloc();
-    $q = prepare("SELECT COUNT(*) AS tally FROM timeSheetItem WHERE timeSheetID = %d AND timeSheetItemID != %d",$timeSheet->get_id(),$_POST["timeSheetItem_timeSheetItemID"]);
+    $q = prepare("SELECT COUNT(*) AS tally FROM timeSheetItem WHERE timeSheetID = %d AND timeSheetItemID != %d", $timeSheet->get_id(), $_POST["timeSheetItem_timeSheetItemID"]);
     $db->query($q);
     $db->next_record();
     if ($db->f("tally")) {
-      include_template("templates/timeSheetItemM.tpl");
+        include_template("templates/timeSheetItemM.tpl");
     }
-  }
+}
 
-  function show_timeSheet_list($template) {
+function show_timeSheet_list($template)
+{
     global $TPL;
     global $timeSheet;
     global $db;
@@ -217,99 +222,98 @@ if (!$current_user->is_employee()) {
     $db_task = new db_alloc();
 
     if (is_object($timeSheet) && ($timeSheet->get_value("status") == "edit" || $timeSheet->get_value("status") == "rejected")) {
-      $TPL["timeSheetItem_buttons"] = '
+        $TPL["timeSheetItem_buttons"] = '
         <button type="submit" name="timeSheetItem_delete" value="1" class="delete_button">Delete<i class="icon-trash"></i></button>
         <button type="submit" name="timeSheetItem_edit" value="1">Edit<i class="icon-edit"></i></button>';
     }
 
-    $TPL["currency"] = page::money($timeSheet->get_value("currencyTypeID"),'',"%S");
+    $TPL["currency"] = page::money($timeSheet->get_value("currencyTypeID"), '', "%S");
 
     $timeUnit = new timeUnit();
-    $unit_array = $timeUnit->get_assoc_array("timeUnitID","timeUnitLabelA");
+    $unit_array = $timeUnit->get_assoc_array("timeUnitID", "timeUnitLabelA");
     
     $item_query = prepare("SELECT * from timeSheetItem WHERE timeSheetID=%d", $timeSheetID);
     // If editing a timeSheetItem then don't display it in the list
     $timeSheetItemID = $_POST["timeSheetItemID"] or $timeSheetItemID = $_GET["timeSheetItemID"];
-    $timeSheetItemID and $item_query.= prepare(" AND timeSheetItemID != %d",$timeSheetItemID);
+    $timeSheetItemID and $item_query.= prepare(" AND timeSheetItemID != %d", $timeSheetItemID);
     $item_query.= prepare(" GROUP BY timeSheetItemID ORDER BY dateTimeSheetItem, timeSheetItemID");
     $db->query($item_query);
 
     if (is_object($timeSheet)) {
-      $project = $timeSheet->get_foreign_object("project");
-      $row_projectPerson = projectPerson::get_projectPerson_row($project->get_id(), $timeSheet->get_value("personID"));
-      $default_rate = array();
-      if ($row_projectPerson && $row_projectPerson['rate'] > 0) {
-        $default_rate['rate'] = $row_projectPerson['rate'];
-        $default_rate['unit'] = $row_projectPerson['rateUnitID'];
-      }
+        $project = $timeSheet->get_foreign_object("project");
+        $row_projectPerson = projectPerson::get_projectPerson_row($project->get_id(), $timeSheet->get_value("personID"));
+        $default_rate = array();
+        if ($row_projectPerson && $row_projectPerson['rate'] > 0) {
+            $default_rate['rate'] = $row_projectPerson['rate'];
+            $default_rate['unit'] = $row_projectPerson['rateUnitID'];
+        }
     }
 
     while ($db->next_record()) {
-      $timeSheetItem = new timeSheetItem();
-      $timeSheetItem->currency = $timeSheet->get_value("currencyTypeID");
-      $timeSheetItem->read_db_record($db);
-      $timeSheetItem->set_tpl_values("timeSheetItem_");
+        $timeSheetItem = new timeSheetItem();
+        $timeSheetItem->currency = $timeSheet->get_value("currencyTypeID");
+        $timeSheetItem->read_db_record($db);
+        $timeSheetItem->set_tpl_values("timeSheetItem_");
       
 
-      $TPL["timeSheet_totalHours"] += $timeSheetItem->get_value("timeSheetItemDuration");
+        $TPL["timeSheet_totalHours"] += $timeSheetItem->get_value("timeSheetItemDuration");
 
-      $TPL["unit"] = $unit_array[$timeSheetItem->get_value("timeSheetItemDurationUnitID")];
+        $TPL["unit"] = $unit_array[$timeSheetItem->get_value("timeSheetItemDurationUnitID")];
 
-      $br = "";
-      $commentPrivateText = "";
+        $br = "";
+        $commentPrivateText = "";
 
-      $text = $timeSheetItem->get_value('description',DST_HTML_DISPLAY);
-      if ($timeSheetItem->get_value("commentPrivate")) {
-        $commentPrivateText = "<b>[Private Comment]</b> ";
-      }
+        $text = $timeSheetItem->get_value('description', DST_HTML_DISPLAY);
+        if ($timeSheetItem->get_value("commentPrivate")) {
+            $commentPrivateText = "<b>[Private Comment]</b> ";
+        }
       
-      $text and $TPL["timeSheetItem_description"] = "<a href=\"".$TPL["url_alloc_task"]."taskID=".$timeSheetItem->get_value('taskID')."\">".$text."</a>";
-      $text && $timeSheetItem->get_value("comment") and $br = "<br>";
-      $timeSheetItem->get_value("comment") and $TPL["timeSheetItem_comment"] = $br.$commentPrivateText.page::to_html($timeSheetItem->get_value("comment"));
-      $TPL["timeSheetItem_unit_times_rate"] = $timeSheetItem->calculate_item_charge($timeSheet->get_value("currencyTypeID"),$timeSheetItem->get_value("rate"));
+        $text and $TPL["timeSheetItem_description"] = "<a href=\"".$TPL["url_alloc_task"]."taskID=".$timeSheetItem->get_value('taskID')."\">".$text."</a>";
+        $text && $timeSheetItem->get_value("comment") and $br = "<br>";
+        $timeSheetItem->get_value("comment") and $TPL["timeSheetItem_comment"] = $br.$commentPrivateText.page::to_html($timeSheetItem->get_value("comment"));
+        $TPL["timeSheetItem_unit_times_rate"] = $timeSheetItem->calculate_item_charge($timeSheet->get_value("currencyTypeID"), $timeSheetItem->get_value("rate"));
 
-      $m = new meta("timeSheetItemMultiplier");
-      $tsMultipliers = $m->get_list();
-      $timeSheetItem->get_value('multiplier') and $TPL["timeSheetItem_multiplier"] = $tsMultipliers[$timeSheetItem->get_value('multiplier')]['timeSheetItemMultiplierName'];
+        $m = new meta("timeSheetItemMultiplier");
+        $tsMultipliers = $m->get_list();
+        $timeSheetItem->get_value('multiplier') and $TPL["timeSheetItem_multiplier"] = $tsMultipliers[$timeSheetItem->get_value('multiplier')]['timeSheetItemMultiplierName'];
   
       // Check to see if this tsi is part of an overrun
-      $TPL["timeSheetItem_class"] = "panel";
-      $TPL["timeSheetItem_status"] = "";
-      $row_messages = array();
-      if($timeSheetItem->get_value('taskID')) {
-        $task = new task();
-        $task->set_id($timeSheetItem->get_value('taskID'));
-        $task->select();
-        if($task->get_value('timeLimit') > 0) {
-          $total_billed_time = ($task->get_time_billed(false)) / 3600;    // get_time_billed returns seconds, limit hours is in hours
-          if($total_billed_time > $task->get_value('timeLimit')) {
-            $row_messages []= "<em class='faint warn nobr'>[ Exceeds Limit ]</em>";
-          }
+        $TPL["timeSheetItem_class"] = "panel";
+        $TPL["timeSheetItem_status"] = "";
+        $row_messages = array();
+        if ($timeSheetItem->get_value('taskID')) {
+            $task = new task();
+            $task->set_id($timeSheetItem->get_value('taskID'));
+            $task->select();
+            if ($task->get_value('timeLimit') > 0) {
+                $total_billed_time = ($task->get_time_billed(false)) / 3600;    // get_time_billed returns seconds, limit hours is in hours
+                if ($total_billed_time > $task->get_value('timeLimit')) {
+                    $row_messages []= "<em class='faint warn nobr'>[ Exceeds Limit ]</em>";
+                }
+            }
         }
-      }
 
       // Highlight the rate if the project person has a non-zero rate and it doesn't match the item's rate
-      if ($default_rate) {
-        if ($timeSheetItem->get_value('rate') != $default_rate['rate'] ||
-          $timeSheetItem->get_value('timeSheetItemDurationUnitID') != $default_rate['unit']) {
-            $row_messages []= "<em class='faint warn nobr'>[ Modified rate ]</em>";
-          }
-      }
+        if ($default_rate) {
+            if ($timeSheetItem->get_value('rate') != $default_rate['rate'] ||
+            $timeSheetItem->get_value('timeSheetItemDurationUnitID') != $default_rate['unit']) {
+                $row_messages []= "<em class='faint warn nobr'>[ Modified rate ]</em>";
+            }
+        }
 
-      if ($row_messages) {
-        $TPL["timeSheetItem_status"] = implode("<br />", $row_messages);
-        $TPL["timeSheetItem_class"] = "panel loud";
-      }
+        if ($row_messages) {
+            $TPL["timeSheetItem_status"] = implode("<br />", $row_messages);
+            $TPL["timeSheetItem_class"] = "panel loud";
+        }
 
-      include_template($template);
-
+        include_template($template);
     }
 
     $TPL["summary_totals"] = $timeSheet->pay_info["summary_unit_totals"];
-
-  }
+}
   
-  function show_new_timeSheet($template) {
+function show_new_timeSheet($template)
+{
     global $TPL;
     global $timeSheet;
     global $timeSheetID;
@@ -317,103 +321,103 @@ if (!$current_user->is_employee()) {
 
     // Don't show entry form for new timeSheet.
     if (!$timeSheetID) {
-      return;
-    } 
+        return;
+    }
 
 
     if (is_object($timeSheet) && ($timeSheet->get_value("status") == 'edit' || $timeSheet->get_value("status") == 'rejected')
     && ($timeSheet->get_value("personID") == $current_user->get_id() || $timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS))) {
-
-      $TPL["currency"] = page::money($timeSheet->get_value("currencyTypeID"),'',"%S");
+        $TPL["currency"] = page::money($timeSheet->get_value("currencyTypeID"), '', "%S");
       // If we are editing an existing timeSheetItem
-      $timeSheetItem_edit = $_POST["timeSheetItem_edit"] or $timeSheetItem_edit = $_GET["timeSheetItem_edit"];
-      $timeSheetItemID = $_POST["timeSheetItemID"] or $timeSheetItemID = $_GET["timeSheetItemID"];
-      if ($timeSheetItemID && $timeSheetItem_edit) {
-        $timeSheetItem = new timeSheetItem();
-        $timeSheetItem->currency = $timeSheet->get_value("currencyTypeID");
-        $timeSheetItem->set_id($timeSheetItemID);
-        $timeSheetItem->select();
-        $timeSheetItem->set_values("tsi_");
-        $TPL["tsi_rate"] = $timeSheetItem->get_value("rate",DST_HTML_DISPLAY);
-        $taskID = $timeSheetItem->get_value("taskID");
-        $TPL["tsi_buttons"] = '
+        $timeSheetItem_edit = $_POST["timeSheetItem_edit"] or $timeSheetItem_edit = $_GET["timeSheetItem_edit"];
+        $timeSheetItemID = $_POST["timeSheetItemID"] or $timeSheetItemID = $_GET["timeSheetItemID"];
+        if ($timeSheetItemID && $timeSheetItem_edit) {
+            $timeSheetItem = new timeSheetItem();
+            $timeSheetItem->currency = $timeSheet->get_value("currencyTypeID");
+            $timeSheetItem->set_id($timeSheetItemID);
+            $timeSheetItem->select();
+            $timeSheetItem->set_values("tsi_");
+            $TPL["tsi_rate"] = $timeSheetItem->get_value("rate", DST_HTML_DISPLAY);
+            $taskID = $timeSheetItem->get_value("taskID");
+            $TPL["tsi_buttons"] = '
          <button type="submit" name="timeSheetItem_delete" value="1" class="delete_button">Delete<i class="icon-trash"></i></button>
          <button type="submit" name="timeSheetItem_save" value="1" class="save_button default">Save Item<i class="icon-ok-sign"></i></button>
          ';
 
-        $timeSheetItemDurationUnitID = $timeSheetItem->get_value("timeSheetItemDurationUnitID");
-        $TPL["tsi_commentPrivate"] and $TPL["commentPrivateChecked"] = " checked";
+            $timeSheetItemDurationUnitID = $timeSheetItem->get_value("timeSheetItemDurationUnitID");
+            $TPL["tsi_commentPrivate"] and $TPL["commentPrivateChecked"] = " checked";
 
-        $TPL["ts_rate_editable"] = $timeSheet->can_edit_rate();
+            $TPL["ts_rate_editable"] = $timeSheet->can_edit_rate();
 
-        $timeSheetItemMultiplier = $timeSheetItem->get_value("multiplier");
+            $timeSheetItemMultiplier = $timeSheetItem->get_value("multiplier");
 
       // Else default values for creating a new timeSheetItem
-      } else {
-        $TPL["tsi_buttons"] = '<button type="submit" name="timeSheetItem_save" value="1" class="save_button">Add Item<i class="icon-plus-sign"></i></button>';
+        } else {
+            $TPL["tsi_buttons"] = '<button type="submit" name="timeSheetItem_save" value="1" class="save_button">Add Item<i class="icon-plus-sign"></i></button>';
 
-        $TPL["tsi_personID"] = $current_user->get_id();
-        $timeSheet->load_pay_info();
-        $TPL["tsi_rate"] = $timeSheet->pay_info["project_rate"];
-	      $timeSheetItemDurationUnitID = $timeSheet->pay_info["project_rateUnitID"];
-	      $TPL["ts_rate_editable"] = $timeSheet->can_edit_rate();
-      }
+            $TPL["tsi_personID"] = $current_user->get_id();
+            $timeSheet->load_pay_info();
+            $TPL["tsi_rate"] = $timeSheet->pay_info["project_rate"];
+            $timeSheetItemDurationUnitID = $timeSheet->pay_info["project_rateUnitID"];
+            $TPL["ts_rate_editable"] = $timeSheet->can_edit_rate();
+        }
 
-      $taskID or $taskID = $_GET["taskID"];
+        $taskID or $taskID = $_GET["taskID"];
 
-      $TPL["taskListDropdown_taskID"] = $taskID;
-      $TPL["taskListDropdown"] = $timeSheet->get_task_list_dropdown("mine",$timeSheet->get_id(),$taskID);
-      $TPL["tsi_timeSheetID"] = $timeSheet->get_id();
+        $TPL["taskListDropdown_taskID"] = $taskID;
+        $TPL["taskListDropdown"] = $timeSheet->get_task_list_dropdown("mine", $timeSheet->get_id(), $taskID);
+        $TPL["tsi_timeSheetID"] = $timeSheet->get_id();
 
-      $timeUnit = new timeUnit();
-      $unit_array = $timeUnit->get_assoc_array("timeUnitID","timeUnitLabelA");
-      $TPL["tsi_unit_options"] = page::select_options($unit_array, $timeSheetItemDurationUnitID);
-      $timeSheetItemDurationUnitID and $TPL["tsi_unit_label"] = $unit_array[$timeSheetItemDurationUnitID];
+        $timeUnit = new timeUnit();
+        $unit_array = $timeUnit->get_assoc_array("timeUnitID", "timeUnitLabelA");
+        $TPL["tsi_unit_options"] = page::select_options($unit_array, $timeSheetItemDurationUnitID);
+        $timeSheetItemDurationUnitID and $TPL["tsi_unit_label"] = $unit_array[$timeSheetItemDurationUnitID];
 
-      $m = new meta("timeSheetItemMultiplier");
-      $tsMultipliers = $m->get_list();
+        $m = new meta("timeSheetItemMultiplier");
+        $tsMultipliers = $m->get_list();
 
-      foreach ($tsMultipliers as $k => $v) {
-        $multiplier_array[$k] = $v["timeSheetItemMultiplierName"];
-      }
-      $TPL["tsi_multiplier_options"] = page::select_options($multiplier_array, $timeSheetItemMultiplier);
+        foreach ($tsMultipliers as $k => $v) {
+            $multiplier_array[$k] = $v["timeSheetItemMultiplierName"];
+        }
+        $TPL["tsi_multiplier_options"] = page::select_options($multiplier_array, $timeSheetItemMultiplier);
 
-      include_template($template);
+        include_template($template);
     }
-  }
+}
 
-  function show_comments() {
+function show_comments()
+{
     global $timeSheetID;
     global $TPL;
     global $timeSheet;
     if ($timeSheetID) {
-      $TPL["commentsR"] = comment::util_get_comments("timeSheet",$timeSheetID);
-      $TPL["class_new_comment"] = "hidden";
-      $TPL["allParties"] = $timeSheet->get_all_parties($timeSheet->get_value("projectID")) or $TPL["allParties"] = array();
-      $TPL["entity"] = "timeSheet";
-      $TPL["entityID"] = $timeSheet->get_id();
-      $p = $timeSheet->get_foreign_object('project');
-      $TPL["clientID"] = $p->get_value("clientID");
-      $commentTemplate = new commentTemplate();
-      $ops = $commentTemplate->get_assoc_array("commentTemplateID","commentTemplateName","",array("commentTemplateType"=>"timeSheet"));
-      $TPL["commentTemplateOptions"] = "<option value=\"\">Comment Templates</option>".page::select_options($ops);
+        $TPL["commentsR"] = comment::util_get_comments("timeSheet", $timeSheetID);
+        $TPL["class_new_comment"] = "hidden";
+        $TPL["allParties"] = $timeSheet->get_all_parties($timeSheet->get_value("projectID")) or $TPL["allParties"] = array();
+        $TPL["entity"] = "timeSheet";
+        $TPL["entityID"] = $timeSheet->get_id();
+        $p = $timeSheet->get_foreign_object('project');
+        $TPL["clientID"] = $p->get_value("clientID");
+        $commentTemplate = new commentTemplate();
+        $ops = $commentTemplate->get_assoc_array("commentTemplateID", "commentTemplateName", "", array("commentTemplateType"=>"timeSheet"));
+        $TPL["commentTemplateOptions"] = "<option value=\"\">Comment Templates</option>".page::select_options($ops);
 
-      $timeSheetPrintOptions = config::get_config_item("timeSheetPrintOptions");
-      $timeSheetPrint = config::get_config_item("timeSheetPrint");
-      $ops = array(""=>"Format as...");
-      foreach ($timeSheetPrint as $value) {
-        $ops[$value] = $timeSheetPrintOptions[$value];
-      }
-      $TPL["attach_extra_files"] = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
-      $TPL["attach_extra_files"].= "Attach Time Sheet ";
-      $TPL["attach_extra_files"].= '<select name="attach_timeSheet">'.page::select_options($ops).'</select><br>';
-      include_template("../comment/templates/commentM.tpl");
+        $timeSheetPrintOptions = config::get_config_item("timeSheetPrintOptions");
+        $timeSheetPrint = config::get_config_item("timeSheetPrint");
+        $ops = array(""=>"Format as...");
+        foreach ($timeSheetPrint as $value) {
+            $ops[$value] = $timeSheetPrintOptions[$value];
+        }
+        $TPL["attach_extra_files"] = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
+        $TPL["attach_extra_files"].= "Attach Time Sheet ";
+        $TPL["attach_extra_files"].= '<select name="attach_timeSheet">'.page::select_options($ops).'</select><br>';
+        include_template("../comment/templates/commentM.tpl");
     }
-  }
+}
 
 
 
-// ============ END FUNCTIONS 
+// ============ END FUNCTIONS
 
 global $timeSheet;
 global $timeSheetItem;
@@ -429,46 +433,46 @@ $db = new db_alloc();
 $timeSheet = new timeSheet();
 
 if ($timeSheetID) {
-  $timeSheet = new timeSheet();
-  $timeSheet->set_id($timeSheetID);
-  $timeSheet->select();
-  $timeSheet->set_values();
-} 
+    $timeSheet = new timeSheet();
+    $timeSheet->set_id($timeSheetID);
+    $timeSheet->select();
+    $timeSheet->set_values();
+}
 
 
 // Manually update the Client Billing field
 if ($_REQUEST["updateCB"] && $timeSheet->get_id() && $timeSheet->can_edit_rate()) {
-  $project = new project();
-  $project->set_id($timeSheet->get_value("projectID"));
-  $project->select();
-  $timeSheet->set_value("customerBilledDollars",page::money($project->get_value("currencyTypeID"),$project->get_value("customerBilledDollars"),"%mo"));
-  $timeSheet->set_value("currencyTypeID",$project->get_value("currencyTypeID"));
-  $timeSheet->save();
+    $project = new project();
+    $project->set_id($timeSheet->get_value("projectID"));
+    $project->select();
+    $timeSheet->set_value("customerBilledDollars", page::money($project->get_value("currencyTypeID"), $project->get_value("customerBilledDollars"), "%mo"));
+    $timeSheet->set_value("currencyTypeID", $project->get_value("currencyTypeID"));
+    $timeSheet->save();
 }
 // Manually update the person's rate
 if ($_REQUEST["updateRate"] && $timeSheet->get_id() && $timeSheet->can_edit_rate()) {
-  $row_projectPerson = projectPerson::get_projectPerson_row($timeSheet->get_value("projectID"), $timeSheet->get_value("personID"));
-  if (!$row_projectPerson) {
-    alloc_error("The person has not been added to the project.");
-  } else {
-    $q = prepare("SELECT timeSheetItemID from timeSheetItem WHERE timeSheetID = %d",$timeSheet->get_id()); 
-    $db = new db_alloc();
-    $db->query($q);
-    while ($row = $db->row()) {
-      $tsi = new timeSheetItem();
-      $tsi->set_id($row["timeSheetItemID"]);
-      $tsi->select();
-      if ($row_projectPerson["rateUnitID"]) {
-        $v = $row_projectPerson["rateUnitID"];
-      } else {
-        $v = "";
-      }
-      $tsi->set_value("timeSheetItemDurationUnitID", $v);
-      $tsi->set_value("rate",page::money($timeSheet->get_value("currencyTypeID"),$row_projectPerson["rate"],"%mo"));
-      $tsi->skip_tsi_status_check = true;
-      $tsi->save();
+    $row_projectPerson = projectPerson::get_projectPerson_row($timeSheet->get_value("projectID"), $timeSheet->get_value("personID"));
+    if (!$row_projectPerson) {
+        alloc_error("The person has not been added to the project.");
+    } else {
+        $q = prepare("SELECT timeSheetItemID from timeSheetItem WHERE timeSheetID = %d", $timeSheet->get_id());
+        $db = new db_alloc();
+        $db->query($q);
+        while ($row = $db->row()) {
+            $tsi = new timeSheetItem();
+            $tsi->set_id($row["timeSheetItemID"]);
+            $tsi->select();
+            if ($row_projectPerson["rateUnitID"]) {
+                $v = $row_projectPerson["rateUnitID"];
+            } else {
+                $v = "";
+            }
+            $tsi->set_value("timeSheetItemDurationUnitID", $v);
+            $tsi->set_value("rate", page::money($timeSheet->get_value("currencyTypeID"), $row_projectPerson["rate"], "%mo"));
+            $tsi->skip_tsi_status_check = true;
+            $tsi->save();
+        }
     }
-  }
 }
 
 
@@ -478,104 +482,98 @@ if ($_POST["save"]
 || $_POST["save_and_returnToProject"]
 || $_POST["save_and_MoveForward"]
 || $_POST["save_and_MoveBack"]) {
-
   // Saving a record
-  $timeSheet->read_globals();
-  $timeSheet->read_globals("timeSheet_");
+    $timeSheet->read_globals();
+    $timeSheet->read_globals("timeSheet_");
 
-  $projectID = $timeSheet->get_value("projectID");
+    $projectID = $timeSheet->get_value("projectID");
 
-  if ($projectID != 0) {
-    $project = new project();
-    $project->set_id($projectID);
-    $project->select();
+    if ($projectID != 0) {
+        $project = new project();
+        $project->set_id($projectID);
+        $project->select();
 
-    $projectManagers = $project->get_timeSheetRecipients();
+        $projectManagers = $project->get_timeSheetRecipients();
 
-    if (!$timeSheet->get_id()) {
-      $timeSheet->set_value("customerBilledDollars",page::money($project->get_value("currencyTypeID"),$project->get_value("customerBilledDollars"),"%mo"));
-      $timeSheet->set_value("currencyTypeID",$project->get_value("currencyTypeID"));
+        if (!$timeSheet->get_id()) {
+            $timeSheet->set_value("customerBilledDollars", page::money($project->get_value("currencyTypeID"), $project->get_value("customerBilledDollars"), "%mo"));
+            $timeSheet->set_value("currencyTypeID", $project->get_value("currencyTypeID"));
+        }
+    } else {
+        $save_error=true;
+        $TPL["message_help"][] = "Begin a Time Sheet by selecting a Project and clicking the Create Time Sheet button. A manager must add you to the project before you can create time sheets for it.";
+        alloc_error("Please select a Project and then click the Create Time Sheet button.");
     }
-  } else {
-    $save_error=true;
-    $TPL["message_help"][] = "Begin a Time Sheet by selecting a Project and clicking the Create Time Sheet button. A manager must add you to the project before you can create time sheets for it.";
-    alloc_error("Please select a Project and then click the Create Time Sheet button.");
-  }
 
   // If it's a Pre-paid project, join this time sheet onto an invoice
-  if (is_object($project) && $project->get_id() && $project->get_value("projectType") == "Prepaid") {
-    $invoiceID = $project->get_prepaid_invoice();
+    if (is_object($project) && $project->get_id() && $project->get_value("projectType") == "Prepaid") {
+        $invoiceID = $project->get_prepaid_invoice();
 
-    if (!$invoiceID) {
-      $save_error = true;
-      alloc_error("Unable to find a Pre-paid Invoice for this Project or Client.");
-    } else if (!$timeSheet->get_id()) {
-      $add_timeSheet_to_invoiceID = $invoiceID;
+        if (!$invoiceID) {
+            $save_error = true;
+            alloc_error("Unable to find a Pre-paid Invoice for this Project or Client.");
+        } else if (!$timeSheet->get_id()) {
+            $add_timeSheet_to_invoiceID = $invoiceID;
+        }
     }
-  }
 
-  if ($_POST["save_and_MoveForward"]) {
-    $msg.= $timeSheet->change_status("forwards");
-  } else if ($_POST["save_and_MoveBack"]) {
-    $msg.= $timeSheet->change_status("backwards");
-  }
-
-  $timeSheet->set_value("billingNote",rtrim($timeSheet->get_value("billingNote")));
-
-  if ($TPL['message'] || $save_error) {
-    // don't save or sql will complain
-    $url = $TPL["url_alloc_timeSheet"];
-
-  } else if (!$timeSheet->get_value("personID") && $timeSheetID) {
-    //if TS ID is set but person ID is not, it's an existing timesheet this
-    // user doesn't have access to (and will overwrite). Don't proceed.
-    $url = $TPL["url_alloc_timeSheet"];
-  } else if (!$TPL['message'] && $timeSheet->save()) {
-
-    if ($add_timeSheet_to_invoiceID) {
-      $invoice = new invoice();
-      $invoice->set_id($add_timeSheet_to_invoiceID);
-      $invoice->add_timeSheet($timeSheet->get_id());
+    if ($_POST["save_and_MoveForward"]) {
+        $msg.= $timeSheet->change_status("forwards");
+    } else if ($_POST["save_and_MoveBack"]) {
+        $msg.= $timeSheet->change_status("backwards");
     }
-    if ($_POST["save_and_new"]) {
-      $url = $TPL["url_alloc_timeSheet"];
-    } else if ($_POST["save_and_returnToList"]) {
-      $url = $TPL["url_alloc_timeSheetList"];
-    } else if ($_POST["save_and_returnToProject"]) {
-      $url = $TPL["url_alloc_project"]."projectID=".$timeSheet->get_value("projectID");
-    } else {
-      $msg = page::htmlentities(urlencode($msg));
-      $url = $TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheet->get_id()."&msg=".$msg."&dont_send_email=".$_POST["dont_send_email"];
-      # Pass the taskID forward if we came from a task
-      $url .= "&taskID=".$_POST["taskID"];
-    }
-    alloc_redirect($url);
-    exit();
-  }
 
+    $timeSheet->set_value("billingNote", rtrim($timeSheet->get_value("billingNote")));
+
+    if ($TPL['message'] || $save_error) {
+      // don't save or sql will complain
+        $url = $TPL["url_alloc_timeSheet"];
+    } else if (!$timeSheet->get_value("personID") && $timeSheetID) {
+      //if TS ID is set but person ID is not, it's an existing timesheet this
+      // user doesn't have access to (and will overwrite). Don't proceed.
+        $url = $TPL["url_alloc_timeSheet"];
+    } else if (!$TPL['message'] && $timeSheet->save()) {
+        if ($add_timeSheet_to_invoiceID) {
+            $invoice = new invoice();
+            $invoice->set_id($add_timeSheet_to_invoiceID);
+            $invoice->add_timeSheet($timeSheet->get_id());
+        }
+        if ($_POST["save_and_new"]) {
+            $url = $TPL["url_alloc_timeSheet"];
+        } else if ($_POST["save_and_returnToList"]) {
+            $url = $TPL["url_alloc_timeSheetList"];
+        } else if ($_POST["save_and_returnToProject"]) {
+            $url = $TPL["url_alloc_project"]."projectID=".$timeSheet->get_value("projectID");
+        } else {
+            $msg = page::htmlentities(urlencode($msg));
+            $url = $TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheet->get_id()."&msg=".$msg."&dont_send_email=".$_POST["dont_send_email"];
+          # Pass the taskID forward if we came from a task
+            $url .= "&taskID=".$_POST["taskID"];
+        }
+        alloc_redirect($url);
+        exit();
+    }
 } else if ($_POST["delete"]) {
   // Deleting a record
-  $timeSheet->read_globals();
-  $timeSheet->select();
-  $timeSheet->delete();
-  if (!$TPL["message"]) {
-    alloc_redirect($TPL["url_alloc_timeSheetList"]);
-  }
-
-
+    $timeSheet->read_globals();
+    $timeSheet->select();
+    $timeSheet->delete();
+    if (!$TPL["message"]) {
+        alloc_redirect($TPL["url_alloc_timeSheetList"]);
+    }
 } else if ($timeSheetID) {
   // Displaying a record
-  $timeSheet->set_id($timeSheetID);
-  $timeSheet->select();
+    $timeSheet->set_id($timeSheetID);
+    $timeSheet->select();
 } else {
   // create a new record
-  $timeSheet->read_globals();
-  $timeSheet->read_globals("timeSheet_");
-  $timeSheet->set_value("status", "edit");
-  $TPL["message_help"] = "Begin a Time Sheet by selecting a Project and clicking the Create Time Sheet button. A manager must add you to the project before you can create time sheets for it.";
+    $timeSheet->read_globals();
+    $timeSheet->read_globals("timeSheet_");
+    $timeSheet->set_value("status", "edit");
+    $TPL["message_help"] = "Begin a Time Sheet by selecting a Project and clicking the Create Time Sheet button. A manager must add you to the project before you can create time sheets for it.";
 }
 
-// THAT'S THE END OF THE BIG SAVE.  
+// THAT'S THE END OF THE BIG SAVE.
 
 
 
@@ -584,49 +582,47 @@ $TPL["timeSheet_personName"] = $person->get_name();
 $timeSheet->set_values("timeSheet_");
 
 if (!$timeSheetID) {
-  $timeSheet->set_value("personID", $current_user->get_id());
-} 
+    $timeSheet->set_value("personID", $current_user->get_id());
+}
 
 
 if ($_POST["create_transactions_default"] && $timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
-  $msg.= $timeSheet->createTransactions();
-
+    $msg.= $timeSheet->createTransactions();
 } else if ($_POST["delete_all_transactions"] && $timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
-  $msg.= $timeSheet->destroyTransactions();
-} 
+    $msg.= $timeSheet->destroyTransactions();
+}
 
 
 
 
 // Take care of saving transactions
 if (($_POST["p_button"] || $_POST["a_button"] || $_POST["r_button"]) && $timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
+    if ($_POST["p_button"]) {
+        $status = "pending";
+    } else if ($_POST["a_button"]) {
+        $status = "approved";
+    } else if ($_POST["r_button"]) {
+        $status = "rejected";
+    }
 
-  if ($_POST["p_button"]) {
-    $status = "pending";
-  } else if ($_POST["a_button"]) {
-    $status = "approved";
-  } else if ($_POST["r_button"]) {
-    $status = "rejected";
-  }
-
-  $query = prepare("UPDATE transaction SET status = '%s' WHERE timeSheetID = %d AND transactionType != 'invoice'", $status, $timeSheet->get_id());
-  $db = new db_alloc();
-  $db->query($query);
+    $query = prepare("UPDATE transaction SET status = '%s' WHERE timeSheetID = %d AND transactionType != 'invoice'", $status, $timeSheet->get_id());
+    $db = new db_alloc();
+    $db->query($query);
 
 // Take care of the transaction line items on an invoiced timesheet created by admin
 } else if (($_POST["transaction_save"] || $_POST["transaction_delete"]) && $timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
-  $transaction = new transaction();
-  $transaction->read_globals();
-  $transaction->read_globals("transaction_");
-  if ($_POST["transaction_save"]) {
-    if (is_numeric($_POST["percent_dropdown"])) {
-      $transaction->set_value("amount", $_POST["percent_dropdown"]);
+    $transaction = new transaction();
+    $transaction->read_globals();
+    $transaction->read_globals("transaction_");
+    if ($_POST["transaction_save"]) {
+        if (is_numeric($_POST["percent_dropdown"])) {
+            $transaction->set_value("amount", $_POST["percent_dropdown"]);
+        }
+        $transaction->set_value("currencyTypeID", $timeSheet->get_value("currencyTypeID"));
+        $transaction->save();
+    } else if ($_POST["transaction_delete"]) {
+        $transaction->delete();
     }
-    $transaction->set_value("currencyTypeID",$timeSheet->get_value("currencyTypeID"));
-    $transaction->save();
-  } else if ($_POST["transaction_delete"]) {
-    $transaction->delete();
-  }
 }
 
 
@@ -634,28 +630,28 @@ if (($_POST["p_button"] || $_POST["a_button"] || $_POST["r_button"]) && $timeShe
 $person = new person();
 
 if ($timeSheet->get_value("approvedByManagerPersonID")) {
-  $person_approvedByManager = new person();
-  $person_approvedByManager->set_id($timeSheet->get_value("approvedByManagerPersonID"));
-  $person_approvedByManager->select();
-  $TPL["timeSheet_approvedByManagerPersonID_username"] = $person_approvedByManager->get_name();
-  $TPL["timeSheet_approvedByManagerPersonID"] = $timeSheet->get_value("approvedByManagerPersonID");
+    $person_approvedByManager = new person();
+    $person_approvedByManager->set_id($timeSheet->get_value("approvedByManagerPersonID"));
+    $person_approvedByManager->select();
+    $TPL["timeSheet_approvedByManagerPersonID_username"] = $person_approvedByManager->get_name();
+    $TPL["timeSheet_approvedByManagerPersonID"] = $timeSheet->get_value("approvedByManagerPersonID");
 }
 
 if ($timeSheet->get_value("approvedByAdminPersonID")) {
-  $person_approvedByAdmin = new person();
-  $person_approvedByAdmin->set_id($timeSheet->get_value("approvedByAdminPersonID"));
-  $person_approvedByAdmin->select();
-  $TPL["timeSheet_approvedByAdminPersonID_username"] = $person_approvedByAdmin->get_name();
-  $TPL["timeSheet_approvedByAdminPersonID"] = $timeSheet->get_value("approvedByAdminPersonID");
+    $person_approvedByAdmin = new person();
+    $person_approvedByAdmin->set_id($timeSheet->get_value("approvedByAdminPersonID"));
+    $person_approvedByAdmin->select();
+    $TPL["timeSheet_approvedByAdminPersonID_username"] = $person_approvedByAdmin->get_name();
+    $TPL["timeSheet_approvedByAdminPersonID"] = $timeSheet->get_value("approvedByAdminPersonID");
 }
 
 // display the project name.
 if (($timeSheet->get_value("status") == 'edit' || $timeSheet->get_value("status") == 'rejected') && !$timeSheet->get_value("projectID")) {
-  $query = prepare("SELECT * FROM project WHERE projectStatus = 'Current' ORDER by projectName");
+    $query = prepare("SELECT * FROM project WHERE projectStatus = 'Current' ORDER by projectName");
     #.prepare("  LEFT JOIN projectPerson on projectPerson.projectID = project.projectID ")
     #.prepare("WHERE projectPerson.personID = '%d' ORDER BY projectName", $current_user->get_id());
 } else {
-  $query = prepare("SELECT * FROM project ORDER by projectName");
+    $query = prepare("SELECT * FROM project ORDER by projectName");
 }
 
 // This needs to be just above the newTimeSheet_projectID logic
@@ -663,25 +659,24 @@ $projectID = $timeSheet->get_value("projectID");
 
 // If we are entering the page from a project link: New time sheet
 if ($_GET["newTimeSheet_projectID"] && !$projectID) {
-  
-  $_GET["taskID"] and $tid = "&taskID=".$_GET["taskID"];
+    $_GET["taskID"] and $tid = "&taskID=".$_GET["taskID"];
 
-  $projectID = $_GET["newTimeSheet_projectID"];
-  $db = new db_alloc();
-  $q = prepare("SELECT * FROM timeSheet WHERE status = 'edit' AND personID = %d AND projectID = %d",$current_user->get_id(),$projectID);
-  $db->query($q);
-  if ($db->next_record()) {
-    alloc_redirect($TPL["url_alloc_timeSheet"]."timeSheetID=".$db->f("timeSheetID").$tid);
-  }
+    $projectID = $_GET["newTimeSheet_projectID"];
+    $db = new db_alloc();
+    $q = prepare("SELECT * FROM timeSheet WHERE status = 'edit' AND personID = %d AND projectID = %d", $current_user->get_id(), $projectID);
+    $db->query($q);
+    if ($db->next_record()) {
+        alloc_redirect($TPL["url_alloc_timeSheet"]."timeSheetID=".$db->f("timeSheetID").$tid);
+    }
 }
 
-if ($_GET["newTimeSheet_projectID"] && !$db->qr("SELECT * FROM projectPerson WHERE personID = %d AND projectID = %d",$current_user->get_id(),$_GET["newTimeSheet_projectID"])) {
-  alloc_error("You are not a member of the project (id:".page::htmlentities($_GET["newTimeSheet_projectID"])."), please get a manager to add you to the project.");
+if ($_GET["newTimeSheet_projectID"] && !$db->qr("SELECT * FROM projectPerson WHERE personID = %d AND projectID = %d", $current_user->get_id(), $_GET["newTimeSheet_projectID"])) {
+    alloc_error("You are not a member of the project (id:".page::htmlentities($_GET["newTimeSheet_projectID"])."), please get a manager to add you to the project.");
 }
 
 $db->query($query);
 while ($db->row()) {
-  $project_array[$db->f("projectID")] = $db->f("projectName");
+    $project_array[$db->f("projectID")] = $db->f("projectName");
 }
 $TPL["timeSheet_projectName"] = $project_array[$projectID];
 $TPL["timeSheet_projectID"] = $projectID;
@@ -692,36 +687,35 @@ $TPL["taskID"] = $_GET["taskID"];
 
 // Get the project record to determine which button for the edit status.
 if ($projectID != 0) {
-  $project = new project();
-  $project->set_id($projectID);
-  $project->select();
+    $project = new project();
+    $project->set_id($projectID);
+    $project->select();
 
   
-  $projectManagers = $project->get_timeSheetRecipients();
+    $projectManagers = $project->get_timeSheetRecipients();
 
-  if (!$projectManagers) {
-    $TPL["managers"] = "N/A";
-    $TPL["timeSheet_dateSubmittedToManager"] = "N/A";
-    $TPL["timeSheet_approvedByManagerPersonID_username"] = "N/A";
-  } else {
-    count($projectManagers)>1 and $TPL["manager_plural"] = "s";
-    $people =& get_cached_table("person");
-    foreach ($projectManagers as $pID) {
-      $TPL["managers"].= $commar.$people[$pID]["name"];
-      $commar = ", ";
+    if (!$projectManagers) {
+        $TPL["managers"] = "N/A";
+        $TPL["timeSheet_dateSubmittedToManager"] = "N/A";
+        $TPL["timeSheet_approvedByManagerPersonID_username"] = "N/A";
+    } else {
+        count($projectManagers)>1 and $TPL["manager_plural"] = "s";
+        $people =& get_cached_table("person");
+        foreach ($projectManagers as $pID) {
+            $TPL["managers"].= $commar.$people[$pID]["name"];
+            $commar = ", ";
+        }
     }
 
-  }
-
-  $clientID = $project->get_value("clientID");
-  $projectID = $project->get_id();
+    $clientID = $project->get_value("clientID");
+    $projectID = $project->get_id();
 
 
   // Get client name
-  $client = $project->get_foreign_object("client");
-  $TPL["clientName"] = $client_link;
-  $TPL["clientID"] = $clientID = $client->get_id();
-  $TPL["show_client_options"] = $client_link;
+    $client = $project->get_foreign_object("client");
+    $TPL["clientName"] = $client_link;
+    $TPL["clientID"] = $clientID = $client->get_id();
+    $TPL["show_client_options"] = $client_link;
 }
 
 list($client_select, $client_link, $project_select, $project_link)
@@ -731,34 +725,32 @@ list($client_select, $client_link, $project_select, $project_link)
 $TPL["invoice_link"] = $timeSheet->get_invoice_link();
 list($amount_used,$amount_allocated) = $timeSheet->get_amount_allocated();
 if ($amount_allocated) {
-  $TPL["amount_allocated_label"] = "Amount Used / Allocated:";
-  $TPL["amount_allocated"] = $amount_allocated;
-  $TPL["amount_used"] = $amount_used." / ";
+    $TPL["amount_allocated_label"] = "Amount Used / Allocated:";
+    $TPL["amount_allocated"] = $amount_allocated;
+    $TPL["amount_used"] = $amount_used." / ";
 }
 
 
 if (!$timeSheet->get_id() || $timeSheet->get_value("status") == "edit" || $timeSheet->get_value("status") == "rejected") {
-  $TPL["show_project_options"] = $project_select;
-  $TPL["show_client_options"] = $client_select;
-
+    $TPL["show_project_options"] = $project_select;
+    $TPL["show_client_options"] = $client_select;
 } else {
-  $TPL["show_project_options"] = $project_link;
-  $TPL["show_client_options"] = $client_link;
+    $TPL["show_project_options"] = $project_link;
+    $TPL["show_client_options"] = $client_link;
 }
 
 
 if (is_object($timeSheet) && $timeSheet->get_id() && $timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS) && !$timeSheet->get_invoice_link() && $timeSheet->get_value("status") != "finished") {
-
-  $p = $timeSheet->get_foreign_object("project");  
-  $ops["invoiceStatus"] = "edit";
-  $ops["clientID"] = $p->get_value("clientID");
-  $ops["return"] = "dropdown_options";
-  $invoice_list = invoice::get_list($ops);
-  $q = prepare("SELECT * FROM invoiceItem WHERE timeSheetID = %d",$timeSheet->get_id());
-  $db = new db_alloc();
-  $db->query($q);
-  $row = $db->row();
-  $sel_invoice = $row["invoiceID"];
+    $p = $timeSheet->get_foreign_object("project");
+    $ops["invoiceStatus"] = "edit";
+    $ops["clientID"] = $p->get_value("clientID");
+    $ops["return"] = "dropdown_options";
+    $invoice_list = invoice::get_list($ops);
+    $q = prepare("SELECT * FROM invoiceItem WHERE timeSheetID = %d", $timeSheet->get_id());
+    $db = new db_alloc();
+    $db->query($q);
+    $row = $db->row();
+    $sel_invoice = $row["invoiceID"];
   #$TPL["attach_to_invoice_button"] = "<select name=\"attach_to_invoiceID\">";
   #$TPL["attach_to_invoice_button"].= "<option value=\"create_new\">Create New Invoice</option>";
   #$TPL["attach_to_invoice_button"].= page::select_options($invoice_list,$sel_invoice)."</select>";
@@ -772,13 +764,14 @@ $msg and $TPL["message_good"][] = $msg;
 
 global $percent_array;
 if ($_POST["dont_send_email"]) {
-  $TPL["dont_send_email_checked"] = " checked";
+    $TPL["dont_send_email_checked"] = " checked";
 } else {
   // if this is the invoice -> completed step it should be checked by default
-  if ($timeSheet->get_value("status") == 'invoiced')
-    $TPL["dont_send_email_checked"] = " checked";
-  else
-    $TPL["dont_send_email_checked"] = "";
+    if ($timeSheet->get_value("status") == 'invoiced') {
+        $TPL["dont_send_email_checked"] = " checked";
+    } else {
+        $TPL["dont_send_email_checked"] = "";
+    }
 }
 
 $timeSheet->load_pay_info();
@@ -799,8 +792,8 @@ $percent_array = array(""=>"Calculate %",
                        "C"=>"Commission",
                        sprintf("%0.2f", $timeSheet->pay_info["total_dollars"] * 0.050)=>"5.0%",
                        sprintf("%0.2f", $timeSheet->pay_info["total_dollars"] * 0.025)=>"2.5%",
-                       "D"=>"Old Rates", 
-                       sprintf("%0.2f", $timeSheet->pay_info["total_dollars"] * 0.772)=>"77.2%", 
+                       "D"=>"Old Rates",
+                       sprintf("%0.2f", $timeSheet->pay_info["total_dollars"] * 0.772)=>"77.2%",
                        sprintf("%0.2f", $timeSheet->pay_info["total_dollars"] * 0.722)=>"72.2%",
                        sprintf("%0.2f", $timeSheet->pay_info["total_dollars"] * 0.228)=>"22.8%");
 
@@ -809,7 +802,7 @@ $percent_array = array(""=>"Calculate %",
 // display the buttons to move timesheet forward and backward.
 
 if (!$timeSheet->get_id()) {
-  $TPL["timeSheet_ChangeStatusButton"] = '<button type="submit" name="save" value="1" class="save_button">Create Time Sheet<i class="icon-ok-sign"></i></button>';
+    $TPL["timeSheet_ChangeStatusButton"] = '<button type="submit" name="save" value="1" class="save_button">Create Time Sheet<i class="icon-ok-sign"></i></button>';
 }
 
 $radio_email = "<input type=\"checkbox\" id=\"dont_send_email\" name=\"dont_send_email\" value=\"1\"".$TPL["dont_send_email_checked"]."> <label for=\"dont_send_email\">Don't send email</label><br>";
@@ -817,90 +810,85 @@ $radio_email = "<input type=\"checkbox\" id=\"dont_send_email\" name=\"dont_send
 $statii = timeSheet::get_timeSheet_statii();
 
 if (!$projectManagers) {
-  unset($statii["manager"]);
+    unset($statii["manager"]);
 }
 
 foreach ($statii as $s => $label) {
-  unset($pre,$suf);// prefix and suffix
-  $status = $timeSheet->get_value("status");
-  unset($red);
-  $status == "rejected" and $red = true;
-  $status == "rejected" and $status = "edit";
-  if (!$timeSheet->get_id()) {
-    $status = "create";
-  } 
+    unset($pre, $suf);// prefix and suffix
+    $status = $timeSheet->get_value("status");
+    unset($red);
+    $status == "rejected" and $red = true;
+    $status == "rejected" and $status = "edit";
+    if (!$timeSheet->get_id()) {
+        $status = "create";
+    }
   
-  if ($s == $status) {
-    $red and $red = ' class="warn"';
-    $pre = "<b".$red.">";
-    $suf = "</b>";
-  }
-  if ($s == "rejected") continue;
-  $TPL["timeSheet_status_text"].= $sep.$pre.$label.$suf;
-  $sep = "&nbsp;&nbsp;|&nbsp;&nbsp;";
+    if ($s == $status) {
+        $red and $red = ' class="warn"';
+        $pre = "<b".$red.">";
+        $suf = "</b>";
+    }
+    if ($s == "rejected") {
+        continue;
+    }
+    $TPL["timeSheet_status_text"].= $sep.$pre.$label.$suf;
+    $sep = "&nbsp;&nbsp;|&nbsp;&nbsp;";
 }
 
 
 switch ($timeSheet->get_value("status")) {
-
-case 'edit':
-case 'rejected':
-  if (($timeSheet->get_value("personID") == $current_user->get_id() || $timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) && ($timeSheetID)) {
-
-    $destlabel = "Admin";
-    $projectManagers and $destlabel = "Manager";
-    $TPL["timeSheet_ChangeStatusButton"] = '
+    case 'edit':
+    case 'rejected':
+        if (($timeSheet->get_value("personID") == $current_user->get_id() || $timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) && ($timeSheetID)) {
+            $destlabel = "Admin";
+            $projectManagers and $destlabel = "Manager";
+            $TPL["timeSheet_ChangeStatusButton"] = '
         <button type="submit" name="delete" value="1" class="delete_button">Delete<i class="icon-trash"></i></button>
         <button type="submit" name="save" value="1" class="save_button">Save<i class="icon-ok-sign"></i></button>
         <button type="submit" name="save_and_MoveForward" value="1" class="save_button">Time Sheet to '.$destlabel.'<i class="icon-arrow-right"></i></button>';
+        }
+        break;
 
-  }
-  break;
-
-case 'manager':
-  if (in_array($current_user->get_id(),$projectManagers)
-      || ($timeSheet->have_perm(PERM_TIME_APPROVE_TIMESHEETS))) {
-
-    $TPL["timeSheet_ChangeStatusButton"] = '
+    case 'manager':
+        if (in_array($current_user->get_id(), $projectManagers)
+          || ($timeSheet->have_perm(PERM_TIME_APPROVE_TIMESHEETS))) {
+            $TPL["timeSheet_ChangeStatusButton"] = '
         <button type="submit" name="save_and_MoveBack" value="1" class="save_button"><i class="icon-arrow-left" style="margin:0px; margin-right:5px"></i>Back</button>
         <button type="submit" name="save" value="1" class="save_button">Save<i class="icon-ok-sign"></i></button>
         <button type="submit" name="save_and_MoveForward" value="1" class="save_button">Time Sheet to Admin<i class="icon-arrow-right"></i></button>';
 
-    $TPL["radio_email"] = $radio_email;
-  }
-  break;
+            $TPL["radio_email"] = $radio_email;
+        }
+        break;
 
-case 'admin':
-  if ($timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
-    $TPL["timeSheet_ChangeStatusButton"] = '
+    case 'admin':
+        if ($timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
+            $TPL["timeSheet_ChangeStatusButton"] = '
         <button type="submit" name="save_and_MoveBack" value="1" class="save_button"><i class="icon-arrow-left" style="margin:0px; margin-right:5px"></i>Back</button>
         <button type="submit" name="save" value="1" class="save_button">Save<i class="icon-ok-sign"></i></button>
         <button type="submit" name="save_and_MoveForward" value="1" class="save_button">Time Sheet to Invoiced<i class="icon-arrow-right"></i></button>';
 
-    $TPL["radio_email"] = $radio_email;
+            $TPL["radio_email"] = $radio_email;
+        }
+        break;
 
-  }
-  break;
-
-case 'invoiced':
-  if ($timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
-    $TPL["timeSheet_ChangeStatusButton"] = '
+    case 'invoiced':
+        if ($timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
+            $TPL["timeSheet_ChangeStatusButton"] = '
         <button type="submit" name="save_and_MoveBack" value="1" class="save_button"><i class="icon-arrow-left" style="margin:0px; margin-right:5px"></i>Back</button>
         <button type="submit" name="save" value="1" class="save_button">Save<i class="icon-ok-sign"></i></button>
         <button type="submit" name="save_and_MoveForward" value="1" class="save_button">Time Sheet Complete<i class="icon-arrow-right"></i></button>';
 
-    $TPL["radio_email"] = $radio_email;
-  }
-  break;
+            $TPL["radio_email"] = $radio_email;
+        }
+        break;
 
-case 'finished':
-  if ($timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
-    $TPL["timeSheet_ChangeStatusButton"] = '
+    case 'finished':
+        if ($timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS)) {
+            $TPL["timeSheet_ChangeStatusButton"] = '
         <button type="submit" name="save_and_MoveBack" value="1" class="save_button"><i class="icon-arrow-left" style="margin:0px; margin-right:5px"></i>Back</button>';
-
-  }
-  break;
-
+        }
+        break;
 }
 
 
@@ -908,46 +896,44 @@ case 'finished':
 // Get recipient_tfID
 
 if ($timeSheet->get_value("status") == "edit") {
+    $tf_db = new db_alloc();
+    $tf_db->query("select preferred_tfID from person where personID = %d", $timeSheet->get_value("personID"));
+    $tf_db->next_record();
 
-  $tf_db = new db_alloc();
-  $tf_db->query("select preferred_tfID from person where personID = %d",$timeSheet->get_value("personID"));
-  $tf_db->next_record();
-
-  if ($preferred_tfID = $tf_db->f("preferred_tfID")) {
-
-    $tf_db->query("SELECT * 
+    if ($preferred_tfID = $tf_db->f("preferred_tfID")) {
+        $tf_db->query(
+            "SELECT * 
                      FROM tfPerson 
                     WHERE personID = %d 
-                      AND tfID = %d"
-                 ,$timeSheet->get_value("personID"), $preferred_tfID);
+                      AND tfID = %d",
+            $timeSheet->get_value("personID"),
+            $preferred_tfID
+        );
 
-    if ($tf_db->next_record()) {        // The person has a preferred TF, and is a tfPerson for it too
-      $TPL["recipient_tfID_name"] = tf::get_name($tf_db->f("tfID"));
-      $TPL["recipient_tfID"] = $tf_db->f("tfID");
+        if ($tf_db->next_record()) {        // The person has a preferred TF, and is a tfPerson for it too
+            $TPL["recipient_tfID_name"] = tf::get_name($tf_db->f("tfID"));
+            $TPL["recipient_tfID"] = $tf_db->f("tfID");
+        }
+    } else {
+        $TPL["recipient_tfID_name"] = "No Preferred Payment TF nominated.";
+        $TPL["recipient_tfID"] = "";
+        $TPL["recipient_tfID_class"] = "bad";
     }
-  } else {
-    $TPL["recipient_tfID_name"] = "No Preferred Payment TF nominated.";
-    $TPL["recipient_tfID"] = "";
-    $TPL["recipient_tfID_class"] = "bad";
-  }
-
 } else {
-  $TPL["recipient_tfID_name"] = tf::get_name($timeSheet->get_value("recipient_tfID"));
-  $TPL["recipient_tfID"] = $timeSheet->get_value("recipient_tfID");
+    $TPL["recipient_tfID_name"] = tf::get_name($timeSheet->get_value("recipient_tfID"));
+    $TPL["recipient_tfID"] = $timeSheet->get_value("recipient_tfID");
 }
 
 
 $timeSheet->load_pay_info();
 if ($timeSheet->pay_info["total_customerBilledDollars"]) {
-  $TPL["total_customerBilledDollars"] = page::money($timeSheet->get_value("currencyTypeID"),$timeSheet->pay_info["total_customerBilledDollars"],"%s%m %c");
-  config::get_config_item("taxPercent") and 
+    $TPL["total_customerBilledDollars"] = page::money($timeSheet->get_value("currencyTypeID"), $timeSheet->pay_info["total_customerBilledDollars"], "%s%m %c");
+    config::get_config_item("taxPercent") and
 
-$TPL["ex_gst"] = " (".$timeSheet->pay_info["currency"].$timeSheet->pay_info["total_customerBilledDollars_minus_gst"]." excl ".config::get_config_item("taxPercent")."% ".config::get_config_item("taxName").")";
-
-
+    $TPL["ex_gst"] = " (".$timeSheet->pay_info["currency"].$timeSheet->pay_info["total_customerBilledDollars_minus_gst"]." excl ".config::get_config_item("taxPercent")."% ".config::get_config_item("taxName").")";
 }
 if ($timeSheet->pay_info["total_dollars"]) {
-  $TPL["total_dollars"] = page::money($timeSheet->get_value("currencyTypeID"),$timeSheet->pay_info["total_dollars"],"%s%m %c");
+    $TPL["total_dollars"] = page::money($timeSheet->get_value("currencyTypeID"), $timeSheet->pay_info["total_dollars"], "%s%m %c");
 }
 
 $TPL["total_units"] = $timeSheet->pay_info["summary_unit_totals"];
@@ -955,21 +941,19 @@ $TPL["total_units"] = $timeSheet->pay_info["summary_unit_totals"];
 
 
 if ($timeSheetID) {
-  $TPL["period"] = $timeSheet->get_value("dateFrom")." to ".$timeSheet->get_value("dateTo");
+    $TPL["period"] = $timeSheet->get_value("dateFrom")." to ".$timeSheet->get_value("dateTo");
 
-  if ($timeSheet->get_value("status") == "edit" && $db->f("count") == 0) {
-    $TPL["message_help"][] = "Enter Time Sheet Items and click the Add Time Sheet Item Button.";
-
-  } else if ($timeSheet->get_value("status") == "edit" && $db->f("count") > 0) {
-    $TPL["message_help"][] = "When finished adding Time Sheet Line Items, click the To Manager/Admin button to submit this Time Sheet.";
-  }
-
+    if ($timeSheet->get_value("status") == "edit" && $db->f("count") == 0) {
+        $TPL["message_help"][] = "Enter Time Sheet Items and click the Add Time Sheet Item Button.";
+    } else if ($timeSheet->get_value("status") == "edit" && $db->f("count") > 0) {
+        $TPL["message_help"][] = "When finished adding Time Sheet Line Items, click the To Manager/Admin button to submit this Time Sheet.";
+    }
 }
 
 if ($timeSheetID) {
-  $TPL["main_alloc_title"] = "Time Sheet " . $timeSheet->get_id() . " - ".APPLICATION_NAME;
+    $TPL["main_alloc_title"] = "Time Sheet " . $timeSheet->get_id() . " - ".APPLICATION_NAME;
 } else {
-  $TPL["main_alloc_title"] = "New Time Sheet - ".APPLICATION_NAME;
+    $TPL["main_alloc_title"] = "New Time Sheet - ".APPLICATION_NAME;
 }
 
 $TPL["taxName"] = config::get_config_item("taxName");
@@ -979,5 +963,3 @@ $TPL["is_manager"] = $timeSheet->have_perm(PERM_TIME_APPROVE_TIMESHEETS);
 $TPL["is_admin"] = $timeSheet->have_perm(PERM_TIME_INVOICE_TIMESHEETS);
 
 include_template("templates/timeSheetFormM.tpl");
-
-?>

--- a/time/timeSheetGraph.php
+++ b/time/timeSheetGraph.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -24,12 +24,13 @@ require_once("../alloc.php");
 
 $current_user =& singleton("current_user");
 
-function show_filter() {
-  global $TPL;
-  global $defaults;
-  $arr = timeSheetGraph::load_filter($defaults);
-  is_array($arr) and $TPL = array_merge($TPL,$arr);
-  include_template("templates/timeSheetGraphFilterS.tpl");
+function show_filter()
+{
+    global $TPL;
+    global $defaults;
+    $arr = timeSheetGraph::load_filter($defaults);
+    is_array($arr) and $TPL = array_merge($TPL, $arr);
+    include_template("templates/timeSheetGraphFilterS.tpl");
 }
 
 $defaults = array("url_form_action"=>$TPL["url_alloc_timeSheetGraph"]
@@ -42,9 +43,9 @@ $defaults = array("url_form_action"=>$TPL["url_alloc_timeSheetGraph"]
 $_FORM = timeSheetGraph::load_filter($defaults);
 
 if ($_FORM["groupBy"] == "day") {
-  $TPL["chart1"] = timeSheetItem::get_total_hours_worked_per_day($_FORM["personID"],$_FORM["dateFrom"],$_FORM["dateTo"]);
+    $TPL["chart1"] = timeSheetItem::get_total_hours_worked_per_day($_FORM["personID"], $_FORM["dateFrom"], $_FORM["dateTo"]);
 } else if ($_FORM["groupBy"] == "month") {
-  $TPL["chart1"] = timeSheetItem::get_total_hours_worked_per_month($_FORM["personID"],$_FORM["dateFrom"],$_FORM["dateTo"]);
+    $TPL["chart1"] = timeSheetItem::get_total_hours_worked_per_month($_FORM["personID"], $_FORM["dateFrom"], $_FORM["dateTo"]);
 }
 
 $TPL["dateFrom"] = $_FORM["dateFrom"];
@@ -52,5 +53,3 @@ $TPL["dateTo"] = $_FORM["dateTo"];
 $TPL["groupBy"] = $_FORM["groupBy"];
 
 include_template("templates/timeSheetGraphM.tpl");
-
-?>

--- a/time/timeSheetItem.php
+++ b/time/timeSheetItem.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,47 +23,39 @@
 require_once("../alloc.php");
 
 if (!$current_user->is_employee()) {
-  alloc_error("You do not have permission to access time sheets",true);
+    alloc_error("You do not have permission to access time sheets", true);
 }
 
 $timeSheetID = $_POST["timeSheetID"];
 $timeSheetItemID = $_POST["timeSheetItem_timeSheetItemID"];
 
 if (($_POST["timeSheetItem_save"] || $_POST["timeSheetItem_edit"] || $_POST["timeSheetItem_delete"]) && $timeSheetID) {
+    $timeSheet = new timeSheet();
+    $timeSheet->set_id($timeSheetID);
+    $timeSheet->select();
+    $timeSheet->load_pay_info();
 
-  $timeSheet = new timeSheet();
-  $timeSheet->set_id($timeSheetID);
-  $timeSheet->select();
-  $timeSheet->load_pay_info();
-
-  $timeSheetItem = new timeSheetItem();
-  if ($timeSheetItemID) {
-    $timeSheetItem->set_id($timeSheetItemID);
-    $timeSheetItem->select();
-  }
-  $timeSheetItem->read_globals();
-  $timeSheetItem->read_globals("timeSheetItem_");
-
-  if ($_POST["timeSheetItem_save"]) {
+    $timeSheetItem = new timeSheetItem();
+    if ($timeSheetItemID) {
+        $timeSheetItem->set_id($timeSheetItemID);
+        $timeSheetItem->select();
+    }
     $timeSheetItem->read_globals();
     $timeSheetItem->read_globals("timeSheetItem_");
-    $rtn = $timeSheetItem->save();
-    $rtn and $TPL["message_good"][] = "Time Sheet Item saved.";
-    $_POST["timeSheetItem_taskID"] and $t = "&taskID=".$_POST["timeSheetItem_taskID"];
-    alloc_redirect($TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheetID.$t);
 
-  } else if ($_POST["timeSheetItem_edit"]) {
-    alloc_redirect($TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheetID."&timeSheetItem_edit=true&timeSheetItemID=".$timeSheetItem->get_id());
-
-  } else if ($_POST["timeSheetItem_delete"]) {
-    $timeSheetItem->select();
-    $timeSheetItem->delete();
-    $TPL["message_good"][] = "Time Sheet Item deleted.";
-    alloc_redirect($TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheetID);
-  }
+    if ($_POST["timeSheetItem_save"]) {
+        $timeSheetItem->read_globals();
+        $timeSheetItem->read_globals("timeSheetItem_");
+        $rtn = $timeSheetItem->save();
+        $rtn and $TPL["message_good"][] = "Time Sheet Item saved.";
+        $_POST["timeSheetItem_taskID"] and $t = "&taskID=".$_POST["timeSheetItem_taskID"];
+        alloc_redirect($TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheetID.$t);
+    } else if ($_POST["timeSheetItem_edit"]) {
+        alloc_redirect($TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheetID."&timeSheetItem_edit=true&timeSheetItemID=".$timeSheetItem->get_id());
+    } else if ($_POST["timeSheetItem_delete"]) {
+        $timeSheetItem->select();
+        $timeSheetItem->delete();
+        $TPL["message_good"][] = "Time Sheet Item deleted.";
+        alloc_redirect($TPL["url_alloc_timeSheet"]."timeSheetID=".$timeSheetID);
+    }
 }
-
-
-
-
-?>

--- a/time/timeSheetList.php
+++ b/time/timeSheetList.php
@@ -3,32 +3,33 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function show_filter() {
-  global $TPL;
-  global $defaults;
-  $_FORM = timeSheet::load_form_data($defaults);
-  $arr = timeSheet::load_timeSheet_filter($_FORM);
-  is_array($arr) and $TPL = array_merge($TPL,$arr);
-  include_template("templates/timeSheetListFilterS.tpl");
+function show_filter()
+{
+    global $TPL;
+    global $defaults;
+    $_FORM = timeSheet::load_form_data($defaults);
+    $arr = timeSheet::load_timeSheet_filter($_FORM);
+    is_array($arr) and $TPL = array_merge($TPL, $arr);
+    include_template("templates/timeSheetListFilterS.tpl");
 }
 
 $defaults = array("url_form_action"=>$TPL["url_alloc_timeSheetList"]
@@ -44,7 +45,7 @@ $TPL["timeSheetListRows"] = $rtn["rows"];
 $TPL["timeSheetListExtra"] = $rtn["extra"];
 
 if (!$current_user->prefs["timeSheetList_filter"]) {
-  $TPL["message_help"][] = "
+    $TPL["message_help"][] = "
 
 allocPSA allows you to record the time that you've worked on various
 Projects using Time Sheets. This page allows you to view a list of Time Sheets. 
@@ -62,4 +63,3 @@ in the top-right hand corner of the box below.";
 
 $TPL["main_alloc_title"] = "Timesheet List - ".APPLICATION_NAME;
 include_template("templates/timeSheetListM.tpl");
-?>

--- a/time/timeSheetPrint.php
+++ b/time/timeSheetPrint.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,7 +23,7 @@
 require_once("../alloc.php");
 
 if (!$current_user->is_employee()) {
-  alloc_error("You do not have permission to access time sheets",true);
+    alloc_error("You do not have permission to access time sheets", true);
 }
 
 $timeSheetID = $_POST["timeSheetID"] or $timeSheetID = $_GET["timeSheetID"];
@@ -32,6 +32,4 @@ $printDesc = $_GET["printDesc"];
 $format = $_GET["format"];
 
 $t = new timeSheetPrint();
-$t->get_printable_timeSheet_file($timeSheetID,$timeSheetPrintMode,$printDesc,$format);
-
-?>
+$t->get_printable_timeSheet_file($timeSheetID, $timeSheetPrintMode, $printDesc, $format);

--- a/time/updateProjectListByClient.php
+++ b/time/updateProjectListByClient.php
@@ -3,31 +3,27 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 
 usleep(400000);
-echo "<select id=\"projectID\" name=\"projectID\"><option></option>".page::select_options(project::get_list_by_client($_GET["clientID"],$_GET["onlymine"]))."</select>";
-
-
-
-?>
+echo "<select id=\"projectID\" name=\"projectID\"><option></option>".page::select_options(project::get_list_by_client($_GET["clientID"], $_GET["onlymine"]))."</select>";

--- a/time/updateProjectListByStatus.php
+++ b/time/updateProjectListByStatus.php
@@ -3,36 +3,33 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 usleep(400000);
 
 $db = new db_alloc();
 if ($_GET['current']) {
-  $filter = " WHERE projectStatus = 'Current'"; 
+    $filter = " WHERE projectStatus = 'Current'";
 }
 $query = prepare("SELECT projectID AS value, projectName AS label FROM project $filter ORDER by projectName");
 
-echo '<select name="projectID[]" multiple="true" style="width:100%">'.page::select_options($query, null,70).'</select>';
-
-?>
-
+echo '<select name="projectID[]" multiple="true" style="width:100%">'.page::select_options($query, null, 70).'</select>';

--- a/time/updateTimeGraph.php
+++ b/time/updateTimeGraph.php
@@ -3,31 +3,29 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 $current_user =& singleton("current_user");
 $num_days_back = 28;
-$start = date("Y-m-d",mktime() - (60*60*24*$num_days_back));
-$points = timeSheetItem::get_total_hours_worked_per_day($current_user->get_id(),$start);
+$start = date("Y-m-d", mktime() - (60*60*24*$num_days_back));
+$points = timeSheetItem::get_total_hours_worked_per_day($current_user->get_id(), $start);
 print alloc_json_encode(array("status"=>"good","points"=>$points));
-
-?>

--- a/time/updateTimeSheetHome.php
+++ b/time/updateTimeSheetHome.php
@@ -3,25 +3,25 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 //usleep(1000);
@@ -29,33 +29,33 @@ require_once("../alloc.php");
 $t = timeSheetItem::parse_time_string($_REQUEST["time_item"]);
 
 $timeUnit = new timeUnit();
-$units = $timeUnit->get_assoc_array("timeUnitID","timeUnitLabelA");
+$units = $timeUnit->get_assoc_array("timeUnitID", "timeUnitLabelA");
 
 $timeSheetItemMultiplier = new meta("timeSheetItemMultiplier");
 $tsims = $timeSheetItemMultiplier->get_list();
 
 
 
-foreach ($t as $k=>$v) {
-  if ($v) {
-    if ($k == "taskID") {
-      $task = new task();
-      $task->set_id($v);
-      if ($task->select()) {
-        $v = $task->get_id()." ".$task->get_link();
-      } else {
-        $v = "Task ".$v." not found.";
-      }
-    } else if ($k == "unit") {
-      $v = $units[$v];
-    } else if ($k == "multiplier") {
-      $v = $tsims[sprintf("%0.2f",$v)]["timeSheetItemMultiplierName"];
-    } 
-    $rtn[$k] = $v;
-  }
+foreach ($t as $k => $v) {
+    if ($v) {
+        if ($k == "taskID") {
+            $task = new task();
+            $task->set_id($v);
+            if ($task->select()) {
+                $v = $task->get_id()." ".$task->get_link();
+            } else {
+                $v = "Task ".$v." not found.";
+            }
+        } else if ($k == "unit") {
+            $v = $units[$v];
+        } else if ($k == "multiplier") {
+            $v = $tsims[sprintf("%0.2f", $v)]["timeSheetItemMultiplierName"];
+        }
+        $rtn[$k] = $v;
+    }
 }
 
-//2010-10-01  1 Days x Double Time  
+//2010-10-01  1 Days x Double Time
 //Task: 102 This is the task
 //Comment: This is the comment
 $str[] = "<tr><td>".$rtn["date"]." </td><td class='nobr bold'> ".$rtn["duration"]." ".$rtn["unit"]."</td><td class='nobr'>&times; ".$rtn["multiplier"]."</td></tr>";
@@ -63,34 +63,31 @@ $rtn["taskID"]  and $str[] = "<tr><td colspan='3'>".$rtn["taskID"]."</td></tr>";
 $rtn["comment"] and $str[] = "<tr><td colspan='3'>".$rtn["comment"]."</td></tr>";
 
 if (isset($_REQUEST["save"]) && isset($_REQUEST["time_item"])) {
-  $t = timeSheetItem::parse_time_string($_REQUEST["time_item"]);
+    $t = timeSheetItem::parse_time_string($_REQUEST["time_item"]);
 
-  if (!is_numeric($t["duration"])) {
-    $status = "bad";
-    $extra = "Time not added. Duration not found.";
-  } else if (!is_numeric($t["taskID"])) {
-    $status = "bad";
-    $extra = "Time not added. Task not found.";
-  }
-
-  if ($status != "bad") {
-    $timeSheet = new timeSheet();
-    $tsi_row = $timeSheet->add_timeSheetItem($t);
-
-    if ($TPL["message"]) {
-      $status = "bad";
-      $extra = "Time not added.<br>".implode("<br>",$TPL["message"]);
-
-    } else {
-      $status = "good";
-      $tsid = $tsi_row["message"];
-      $extra = "Added time to time sheet <a href='".$TPL["url_alloc_timeSheet"]."timeSheetID=".$tsid."'>#".$tsid."</a>";
+    if (!is_numeric($t["duration"])) {
+        $status = "bad";
+        $extra = "Time not added. Duration not found.";
+    } else if (!is_numeric($t["taskID"])) {
+        $status = "bad";
+        $extra = "Time not added. Task not found.";
     }
-  }
+
+    if ($status != "bad") {
+        $timeSheet = new timeSheet();
+        $tsi_row = $timeSheet->add_timeSheetItem($t);
+
+        if ($TPL["message"]) {
+            $status = "bad";
+            $extra = "Time not added.<br>".implode("<br>", $TPL["message"]);
+        } else {
+            $status = "good";
+            $tsid = $tsi_row["message"];
+            $extra = "Added time to time sheet <a href='".$TPL["url_alloc_timeSheet"]."timeSheetID=".$tsid."'>#".$tsid."</a>";
+        }
+    }
 }
 
 #$extra and array_unshift($str, "<tr><td colspan='3' class='".$status." bold'>".$extra."</td></tr>");
 $extra and $str[] = "<tr><td colspan='3' class='".$status." bold'>".$extra."</td></tr>";
-print alloc_json_encode(array("status"=>$status,"table"=>"<table class='".$status."'>".implode("\n",$str)."</table>"));
-
-?>
+print alloc_json_encode(array("status"=>$status,"table"=>"<table class='".$status."'>".implode("\n", $str)."</table>"));

--- a/time/updateTimeSheetTaskList.php
+++ b/time/updateTimeSheetTaskList.php
@@ -3,31 +3,28 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 if ($_GET["task_type"] && $_GET["timeSheetID"]) {
-  usleep(400000);
-  echo timeSheet::get_task_list_dropdown($_GET["task_type"], $_GET["timeSheetID"], $_GET["taskID"]);
+    usleep(400000);
+    echo timeSheet::get_task_list_dropdown($_GET["task_type"], $_GET["timeSheetID"], $_GET["taskID"]);
 }
-
-
-?>

--- a/time/updateTsiHintHome.php
+++ b/time/updateTsiHintHome.php
@@ -3,25 +3,25 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 //usleep(1000);
@@ -30,24 +30,24 @@ $t = tsiHint::parse_tsiHint_string($_REQUEST["tsiHint_item"]);
 
 $people = person::get_people_by_username();
 
-foreach ($t as $k=>$v) {
-  if ($v) {
-    if ($k == "taskID") {
-      $task = new task();
-      $task->set_id($v);
-      if ($task->select()) {
-        $v = $task->get_id()." ".$task->get_link();
-      } else {
-        $v = "Task ".$v." not found.";
-      }
-    } else if ($k == "username") {
-      $name = $people[$v]["name"] or $name = $people[$v]["username"];
+foreach ($t as $k => $v) {
+    if ($v) {
+        if ($k == "taskID") {
+            $task = new task();
+            $task->set_id($v);
+            if ($task->select()) {
+                $v = $task->get_id()." ".$task->get_link();
+            } else {
+                $v = "Task ".$v." not found.";
+            }
+        } else if ($k == "username") {
+            $name = $people[$v]["name"] or $name = $people[$v]["username"];
+        }
+        $rtn[$k] = $v;
     }
-    $rtn[$k] = $v;
-  }
 }
 
-//2010-10-01  1 Days x Double Time  
+//2010-10-01  1 Days x Double Time
 //Task: 102 This is the task
 //Comment: This is the comment
 
@@ -58,9 +58,4 @@ $rtn["taskID"]  and $str[] = "<tr><td colspan='3'>".$rtn["taskID"]."</td></tr>";
 $rtn["comment"] and $str[] = "<tr><td colspan='3'>".$rtn["comment"]."</td></tr>";
 $str[] = "</table>";
 
-print implode("\n",$str);
-
-
-
-
-?>
+print implode("\n", $str);

--- a/time/weeklyTime.php
+++ b/time/weeklyTime.php
@@ -3,78 +3,80 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-function show_days($template_name) {
-  global $date_to_view;
-  global $TPL;
+function show_days($template_name)
+{
+    global $date_to_view;
+    global $TPL;
 
-  for ($day_offset = 0; $day_offset < 7; $day_offset++) {
-    $TPL["timesheet_date"] = date("Y-m-d (D)", $date_to_view);
-    $TPL["daily_hours_total"] = 0;
-    include_template($template_name);
-    $date_to_view = mktime(0, 0, 0, date("m", $date_to_view), date("d", $date_to_view) + 1, date("Y", $date_to_view));
-  }
+    for ($day_offset = 0; $day_offset < 7; $day_offset++) {
+        $TPL["timesheet_date"] = date("Y-m-d (D)", $date_to_view);
+        $TPL["daily_hours_total"] = 0;
+        include_template($template_name);
+        $date_to_view = mktime(0, 0, 0, date("m", $date_to_view), date("d", $date_to_view) + 1, date("Y", $date_to_view));
+    }
 }
 
-function show_timeSheetItems($template_name) {
-  global $date_to_view;
-  $current_user = &singleton("current_user");
-  global $TPL;
-  $query = prepare("SELECT * 
+function show_timeSheetItems($template_name)
+{
+    global $date_to_view;
+    $current_user = &singleton("current_user");
+    global $TPL;
+    $query = prepare("SELECT * 
                       FROM timeSheetItem 
                            LEFT JOIN timeSheet ON timeSheetItem.timeSheetID = timeSheet.timeSheetID
                            LEFT JOIN project ON timeSheet.projectID = project.projectID
                       WHERE dateTimeSheetItem='%s'
                             AND timeSheet.personID=%d", date("Y-m-d", $date_to_view), $current_user->get_id());
-  $db = new db_alloc();
-  $db->query($query);
-  while ($db->next_record()) {
-    $timeSheetItem = new timeSheetItem();
-    $timeSheetItem->read_db_record($db);
-    $timeSheetItem->set_values();
-    if ($timeSheetItem->get_value("unit") == "Hour") {
-      $TPL["daily_hours_total"] += $timeSheetItem->get_value("timeSheetItemDuration");
-    }
+    $db = new db_alloc();
+    $db->query($query);
+    while ($db->next_record()) {
+        $timeSheetItem = new timeSheetItem();
+        $timeSheetItem->read_db_record($db);
+        $timeSheetItem->set_values();
+        if ($timeSheetItem->get_value("unit") == "Hour") {
+            $TPL["daily_hours_total"] += $timeSheetItem->get_value("timeSheetItemDuration");
+        }
 
-    $project = new project();
-    $project->read_db_record($db);
-    $project->set_values();
-    if ($project->get_value("projectShortName")) {
-      $TPL["item_description"] = $project->get_value("projectShortName");
-    } else {
-      $TPL["item_description"] = $project->get_value("projectName");
-    }
+        $project = new project();
+        $project->read_db_record($db);
+        $project->set_values();
+        if ($project->get_value("projectShortName")) {
+            $TPL["item_description"] = $project->get_value("projectShortName");
+        } else {
+            $TPL["item_description"] = $project->get_value("projectName");
+        }
 
-    include_template($template_name);
-  }
+        include_template($template_name);
+    }
 }
 
 if (isset($start_date)) {
-  $date_to_view = $start_date;
+    $date_to_view = $start_date;
 } else {
-  $date_to_view = mktime(0, 0, 0);
+    $date_to_view = mktime(0, 0, 0);
 }
 
 while (date("D", $date_to_view) != "Sun") {
-  $date_to_view = mktime(0, 0, 0, date("m", $date_to_view), date("d", $date_to_view) - 1, date("Y", $date_to_view));
+    $date_to_view = mktime(0, 0, 0, date("m", $date_to_view), date("d", $date_to_view) - 1, date("Y", $date_to_view));
 }
 
 $TPL["timesheet_date"] = date("Y-m-d (D)", $date_to_view);
@@ -85,5 +87,3 @@ $TPL["next_week_url"] = $TPL["url_alloc_weeklyTime"]."start_date=$next_week";
 
 $TPL["main_alloc_title"] = "Weekly Timesheet View - ".APPLICATION_NAME;
 include_template("templates/weeklyTimeM.tpl");
-
-?>

--- a/tools/backup.php
+++ b/tools/backup.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -27,7 +27,7 @@ $db = new db_alloc();
 # End of functions
 
 if (!$current_user->have_role("god")) {
-  alloc_error("Insufficient permissions. Backups may only be performed by super-users.",true);
+    alloc_error("Insufficient permissions. Backups may only be performed by super-users.", true);
 }
 
 $backup = new backups();
@@ -35,44 +35,42 @@ $backup = new backups();
 
 
 if ($_POST["create_backup"]) {
-  $backup->backup();
+    $backup->backup();
 }
 
 if ($_POST["restore_backup"]) {
-  $backup->backup();
-  if ($backup->restore($_POST["file"])) {
-    $TPL["message_good"][] = "Backup restored successfully: " . $_POST["file"];
-    $TPL["message_good"][] = "You will now need to manually import the installation/db_triggers.sql file into your database. THIS IS VERY IMPORTANT.";
-  } else {
-    alloc_error("Error restoring backup: " . $_POST["file"]);
-  }
+    $backup->backup();
+    if ($backup->restore($_POST["file"])) {
+        $TPL["message_good"][] = "Backup restored successfully: " . $_POST["file"];
+        $TPL["message_good"][] = "You will now need to manually import the installation/db_triggers.sql file into your database. THIS IS VERY IMPORTANT.";
+    } else {
+        alloc_error("Error restoring backup: " . $_POST["file"]);
+    }
 }
 
 if ($_POST["delete_backup"]) {
   # Can't go through the normal del_attachments thing because this isn't a real entity
 
-  $file = $_POST["file"];
+    $file = $_POST["file"];
 
-  if (bad_filename($file)) {
-    alloc_error("File delete error: Name contains slashes.");
-  }
-  $path = ATTACHMENTS_DIR . "backups" . DIRECTORY_SEPARATOR . "0" . DIRECTORY_SEPARATOR. $file;
-  if (!is_file($path)) {
-    alloc_error("File delete error: Not a file.");
-  }
-  if (dirname(ATTACHMENTS_DIR . "backups" . DIRECTORY_SEPARATOR . "0" . DIRECTORY_SEPARATOR.".") != dirname($path)) {
-    alloc_error("File delete error: Bad path.");
-  }
+    if (bad_filename($file)) {
+        alloc_error("File delete error: Name contains slashes.");
+    }
+    $path = ATTACHMENTS_DIR . "backups" . DIRECTORY_SEPARATOR . "0" . DIRECTORY_SEPARATOR. $file;
+    if (!is_file($path)) {
+        alloc_error("File delete error: Not a file.");
+    }
+    if (dirname(ATTACHMENTS_DIR . "backups" . DIRECTORY_SEPARATOR . "0" . DIRECTORY_SEPARATOR.".") != dirname($path)) {
+        alloc_error("File delete error: Bad path.");
+    }
 
-  unlink($path);
+    unlink($path);
 }
 
 if ($_POST["save_attachment"]) {
-  move_attachment("backups", 0);
+    move_attachment("backups", 0);
 }
 
 
 $TPL["main_alloc_title"] = "Database Backups - ".APPLICATION_NAME;
 include_template("templates/backupM.tpl");
-
-?>

--- a/tools/lib/backups.inc.php
+++ b/tools/lib/backups.inc.php
@@ -3,139 +3,148 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class backups {
+class backups
+{
 
-  var $folders = array();
+    var $folders = array();
 
-  function __construct() {
-    global $external_storage_directories;
+    function __construct()
+    {
+        global $external_storage_directories;
 
-    ini_set('max_execution_time',900); // max time 15 minutes
-    ini_set('memory_limit',"256M"); // max memory_limit
+        ini_set('max_execution_time', 900); // max time 15 minutes
+        ini_set('memory_limit', "256M"); // max memory_limit
 
-    // externally_stored_directories is set in alloc.php
-    foreach ($external_storage_directories as $folder) {
-      $folder != "backups" and $folders[] = $folder;
-    }
-    $this->folders = $folders;
-  }
-
-  function set_id() { // dummy so can re-use the get_attachment.php script
-    return true;
-  }
-
-  function select() { // dummy so can re-use the get_attachment.php script
-    return true;
-  }
-
-  function has_attachment_permission($person) {
-    return $person->have_role("god");
-  }
-
-  function empty_dir($dir) {
-    if (is_dir($dir)) {
-      $handle = opendir($dir);
-
-      while (false !== ($file = readdir($handle))) {
-        if ($file != "." && $file != "..") {
-          $path = $dir . DIRECTORY_SEPARATOR . $file;
-          if (is_dir($path)) {
-            $this->empty_dir($path);
-            rmdir($path);
-          } else {
-            unlink($path);
-          }
+      // externally_stored_directories is set in alloc.php
+        foreach ($external_storage_directories as $folder) {
+            $folder != "backups" and $folders[] = $folder;
         }
-      }
-    }
-  }
-
-  function backup() {
-    global $TPL; 
-
-    if (!is_dir(ATTACHMENTS_DIR . "backups" . DIRECTORY_SEPARATOR . "0")) {
-      mkdir(ATTACHMENTS_DIR . "backups" . DIRECTORY_SEPARATOR . "0", 0777);
+        $this->folders = $folders;
     }
 
-    $archivename = "backup_" . date("Ymd_His") . ".zip";
-    $zipfile = ATTACHMENTS_DIR . "backups" . DIRECTORY_SEPARATOR . "0" . DIRECTORY_SEPARATOR . $archivename;
-    $dumpfile = ATTACHMENTS_DIR . "database.sql";
-    is_file($dumpfile) && unlink($dumpfile);
+    function set_id()
+    {
+ // dummy so can re-use the get_attachment.php script
+        return true;
+    }
 
-    $archive = new PclZip($zipfile);
+    function select()
+    {
+ // dummy so can re-use the get_attachment.php script
+        return true;
+    }
 
-    $db = new db_alloc();
-    $db->dump_db($dumpfile);
+    function has_attachment_permission($person)
+    {
+        return $person->have_role("god");
+    }
 
-    if (!file_exists($dumpfile)) { 
-      alloc_error("Couldn't backup database to ".$dumpfile);
-    } else {
+    function empty_dir($dir)
+    {
+        if (is_dir($dir)) {
+            $handle = opendir($dir);
 
-      // database dump
-      $files[] = $dumpfile;
+            while (false !== ($file = readdir($handle))) {
+                if ($file != "." && $file != "..") {
+                    $path = $dir . DIRECTORY_SEPARATOR . $file;
+                    if (is_dir($path)) {
+                        $this->empty_dir($path);
+                        rmdir($path);
+                    } else {
+                        unlink($path);
+                    }
+                }
+            }
+        }
+    }
+
+    function backup()
+    {
+        global $TPL;
+
+        if (!is_dir(ATTACHMENTS_DIR . "backups" . DIRECTORY_SEPARATOR . "0")) {
+            mkdir(ATTACHMENTS_DIR . "backups" . DIRECTORY_SEPARATOR . "0", 0777);
+        }
+
+        $archivename = "backup_" . date("Ymd_His") . ".zip";
+        $zipfile = ATTACHMENTS_DIR . "backups" . DIRECTORY_SEPARATOR . "0" . DIRECTORY_SEPARATOR . $archivename;
+        $dumpfile = ATTACHMENTS_DIR . "database.sql";
+        is_file($dumpfile) && unlink($dumpfile);
+
+        $archive = new PclZip($zipfile);
+
+        $db = new db_alloc();
+        $db->dump_db($dumpfile);
+
+        if (!file_exists($dumpfile)) {
+            alloc_error("Couldn't backup database to ".$dumpfile);
+        } else {
+          // database dump
+            $files[] = $dumpfile;
     
-      // load up all the attachment dirs
-      foreach ($this->folders as $folder) {
-        $files[] = ATTACHMENTS_DIR.$folder;
-      }
+          // load up all the attachment dirs
+            foreach ($this->folders as $folder) {
+                $files[] = ATTACHMENTS_DIR.$folder;
+            }
 
-      // add everything to the archive
-      $archive->add($files,
-                    PCLZIP_OPT_REMOVE_PATH, ATTACHMENTS_DIR); // again, nuke leading path
+          // add everything to the archive
+            $archive->add(
+                $files,
+                PCLZIP_OPT_REMOVE_PATH,
+                ATTACHMENTS_DIR
+            ); // again, nuke leading path
 
-      is_file($dumpfile) && unlink($dumpfile);
-      $TPL["message_good"][] = "Backup created: " . $archivename;
-    }
-  }
-
-  function restore($archivename) {
-    global $TPL;
-
-    $file = ATTACHMENTS_DIR . "backups" . DIRECTORY_SEPARATOR . "0" . DIRECTORY_SEPARATOR. $archivename;
-
-    $archive = new PclZip($file);
-
-    # Clear out the folder list
-    foreach($this->folders as $folder) {
-      $this->empty_dir(ATTACHMENTS_DIR . $folder);
+            is_file($dumpfile) && unlink($dumpfile);
+            $TPL["message_good"][] = "Backup created: " . $archivename;
+        }
     }
 
-    $archive->extract(ATTACHMENTS_DIR);
+    function restore($archivename)
+    {
+        global $TPL;
 
-    list($sql, $commends) = parse_sql_file(ATTACHMENTS_DIR . "database.sql");
+        $file = ATTACHMENTS_DIR . "backups" . DIRECTORY_SEPARATOR . "0" . DIRECTORY_SEPARATOR. $archivename;
 
-    $db = new db_alloc();
-    foreach($sql as $q) {
-      if (!$db->query($q)) {
-        $errors[] = "Error! (".$db->get_error().").";
-      }
+        $archive = new PclZip($file);
+
+      # Clear out the folder list
+        foreach ($this->folders as $folder) {
+            $this->empty_dir(ATTACHMENTS_DIR . $folder);
+        }
+
+        $archive->extract(ATTACHMENTS_DIR);
+
+        list($sql, $commends) = parse_sql_file(ATTACHMENTS_DIR . "database.sql");
+
+        $db = new db_alloc();
+        foreach ($sql as $q) {
+            if (!$db->query($q)) {
+                $errors[] = "Error! (".$db->get_error().").";
+            }
+        }
+
+        is_array($errors) and alloc_error(implode("<br>", $errors));
+        unlink(ATTACHMENTS_DIR . "database.sql");
+        if (!count($errors)) {
+            return true;
+        }
     }
-
-    is_array($errors) and alloc_error(implode("<br>",$errors));
-    unlink(ATTACHMENTS_DIR . "database.sql");
-    if (!count($errors)) {
-      return true;
-    }
-  }
 }
-
-
-?>

--- a/tools/lib/init.php
+++ b/tools/lib/init.php
@@ -3,25 +3,25 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class tools_module extends module {
-  var $module = "tools";
+class tools_module extends module
+{
+    var $module = "tools";
 }
-?>

--- a/tools/lib/stats.inc.php
+++ b/tools/lib/stats.inc.php
@@ -3,27 +3,28 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class stats {
-  var $classname = "stats";
+class stats
+{
+    var $classname = "stats";
 
-  var $projects = array("all"=>array("total"=>array( /* <date>=> <number> */ )
+    var $projects = array("all"=>array("total"=>array( /* <date>=> <number> */ )
                                        // <uid>=> array( <date>=> <number>, .. ),
                         ), "new"=>array("total"=>array( /* <date>=> <number> */ )
                                           // <uid>=> array( <date>=> <number>, .. ),
@@ -31,266 +32,268 @@ class stats {
                         "archived"=>array("total"=>0 /* <uid>=> <number>, .. */ ),
                         "total"=>array("total"=>0)
     );
-  var $tasks = array("all"=>array("total"=>array( /* <date>=> <number> */ )
+    var $tasks = array("all"=>array("total"=>array( /* <date>=> <number> */ )
                                     // <uid>=> array( <date>=> <number>, .. ),
                      ), "new"=>array("total"=>array( /* <date>=> <number> */ )
                                        // <uid>=> array( <date>=> <number>, .. ),
                      ), "current"=>array("total"=>0), "completed"=>array("total"=>0), "total"=>array("total"=>0)
     );
-  var $comments = array("all"=>array("total"=>array( /* <date>=> <number> */ )
+    var $comments = array("all"=>array("total"=>array( /* <date>=> <number> */ )
                                        // <uid>=> array( <date>=> <number>, .. ),
                         ), "new"=>array("total"=>array( /* <date>=> <number> */ )
                                           // <uid>=> array( <date>=> <number>, .. ),
                         ), "total"=>array("total"=>0)
     );
-  var $persons = array();
+    var $persons = array();
 
-  function stats() {
-  }
+    function stats()
+    {
+    }
 
-  function project_stats() {
-    // date from which a project is counted as being new. if monday then date back to friday, else the previous day
-    $days = date("w") == 1 ? 3 : 1;
-    $date = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d") - $days, date("Y")));
+    function project_stats()
+    {
+      // date from which a project is counted as being new. if monday then date back to friday, else the previous day
+        $days = date("w") == 1 ? 3 : 1;
+        $date = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d") - $days, date("Y")));
 
-    $query = "SELECT * FROM project";
-    $db = new db_alloc();
-    $db_sub = new db_alloc();
-    $db->query($query);
-    while ($db->next_record()) {
-      $project = new project();
-      $project->read_db_record($db);
-      $this->projects["total"]["total"]++;
+        $query = "SELECT * FROM project";
+        $db = new db_alloc();
+        $db_sub = new db_alloc();
+        $db->query($query);
+        while ($db->next_record()) {
+            $project = new project();
+            $project->read_db_record($db);
+            $this->projects["total"]["total"]++;
 
-      switch ($project->get_value("projectStatus")) {
-      case ("current"):
-      case ("overdue"):
-        $this->projects["current"]["total"]++;
-        break;
-      case ("archived"):
-        $this->projects["archived"]["total"]++;
-        break;
-      }
-
-      $query = prepare("SELECT * FROM projectPerson WHERE projectID=%d", $project->get_id());
-      $db_sub->query($query);
-      while ($db_sub->next_record()) {
-        $projectPerson = new projectPerson();
-        $projectPerson->read_db_record($db_sub);
-        $this->projects["total"][$projectPerson->get_value("personID")]++;
-        switch ($project->get_value("projectStatus")) {
-          case ("current"):
-          case ("overdue"):
-            $this->projects["current"][$projectPerson->get_value("personID")]++;
-          break;
-          case ("archived"):
-            $this->projects["archived"][$projectPerson->get_value("personID")]++;
-          break;
-        }
-        if ($project->get_value("dateActualStart") != "") {
-          if (!isset($this->projects["all"][$projectPerson->get_value("personID")])) {
-            $this->projects["all"][$projectPerson->get_value("personID")] = array();
-          }
-          $this->projects["all"][$projectPerson->get_value("personID")][$project->get_value("dateActualStart")]++;
-          $this->projects["all"][$projectPerson->get_value("personID")]["total"]++;
-          $this->projects["all"]["total"][$project->get_value("dateActualStart")]++;
-
-          if (strcmp($date, $project->get_value("dateActualStart")) <= 0) {
-            if (!isset($this->projects["new"][$projectPerson->get_value("personID")])) {
-              $this->projects["new"][$projectPerson->get_value("personID")] = array();
+            switch ($project->get_value("projectStatus")) {
+                case ("current"):
+                case ("overdue"):
+                    $this->projects["current"]["total"]++;
+                    break;
+                case ("archived"):
+                    $this->projects["archived"]["total"]++;
+                    break;
             }
-            $this->projects["new"][$projectPerson->get_value("personID")][$project->get_value("dateActualStart")]++;
-            $this->projects["new"][$projectPerson->get_value("personID")]["total"]++;
-            $this->projects["new"]["total"][$project->get_value("dateActualStart")]++;
-          }
+
+            $query = prepare("SELECT * FROM projectPerson WHERE projectID=%d", $project->get_id());
+            $db_sub->query($query);
+            while ($db_sub->next_record()) {
+                $projectPerson = new projectPerson();
+                $projectPerson->read_db_record($db_sub);
+                $this->projects["total"][$projectPerson->get_value("personID")]++;
+                switch ($project->get_value("projectStatus")) {
+                    case ("current"):
+                    case ("overdue"):
+                        $this->projects["current"][$projectPerson->get_value("personID")]++;
+                        break;
+                    case ("archived"):
+                        $this->projects["archived"][$projectPerson->get_value("personID")]++;
+                        break;
+                }
+                if ($project->get_value("dateActualStart") != "") {
+                    if (!isset($this->projects["all"][$projectPerson->get_value("personID")])) {
+                        $this->projects["all"][$projectPerson->get_value("personID")] = array();
+                    }
+                    $this->projects["all"][$projectPerson->get_value("personID")][$project->get_value("dateActualStart")]++;
+                    $this->projects["all"][$projectPerson->get_value("personID")]["total"]++;
+                    $this->projects["all"]["total"][$project->get_value("dateActualStart")]++;
+
+                    if (strcmp($date, $project->get_value("dateActualStart")) <= 0) {
+                        if (!isset($this->projects["new"][$projectPerson->get_value("personID")])) {
+                            $this->projects["new"][$projectPerson->get_value("personID")] = array();
+                        }
+                        $this->projects["new"][$projectPerson->get_value("personID")][$project->get_value("dateActualStart")]++;
+                        $this->projects["new"][$projectPerson->get_value("personID")]["total"]++;
+                        $this->projects["new"]["total"][$project->get_value("dateActualStart")]++;
+                    }
+                }
+            }
         }
-      }
+        return $this->projects;
     }
-    return $this->projects;
-  }
 
-  function task_stats() {
-    $db = new db_alloc();
+    function task_stats()
+    {
+        $db = new db_alloc();
 
-    list($ts_open,$ts_pending,$ts_closed) = task::get_task_status_in_set_sql();
-    // Get total amount of current tasks for every person
-    $q = "SELECT person.personID, person.username, count(taskID) as tally
+        list($ts_open,$ts_pending,$ts_closed) = task::get_task_status_in_set_sql();
+      // Get total amount of current tasks for every person
+        $q = "SELECT person.personID, person.username, count(taskID) as tally
             FROM task 
        LEFT JOIN person ON task.personID = person.personID 
            WHERE task.taskStatus NOT IN (".$ts_closed.")
         GROUP BY person.personID";
 
-    $db->query($q);
-    while ($db->next_record()) {
-      $this->tasks["current"][$db->f("personID")] = $db->f("tally");
-      $this->tasks["current"]["total"] += $db->f("tally");
-    }
+        $db->query($q);
+        while ($db->next_record()) {
+            $this->tasks["current"][$db->f("personID")] = $db->f("tally");
+            $this->tasks["current"]["total"] += $db->f("tally");
+        }
     
-    // Get total amount of completed tasks for every person
-    $q = "SELECT person.personID, person.username, count(taskID) as tally
+      // Get total amount of completed tasks for every person
+        $q = "SELECT person.personID, person.username, count(taskID) as tally
             FROM task 
        LEFT JOIN person ON task.personID = person.personID 
            WHERE task.taskStatus NOT IN (".$ts_closed.")
         GROUP BY person.personID";
 
-    $db->query($q);
-    while ($db->next_record()) {
-      $this->tasks["completed"][$db->f("personID")] = $db->f("tally");
-      $this->tasks["completed"]["total"] += $db->f("tally");
-    }
+        $db->query($q);
+        while ($db->next_record()) {
+            $this->tasks["completed"][$db->f("personID")] = $db->f("tally");
+            $this->tasks["completed"]["total"] += $db->f("tally");
+        }
 
 
-    // Get total amount of all tasks for every person
-    $q = "SELECT person.personID, person.username, count(taskID) as tally
+      // Get total amount of all tasks for every person
+        $q = "SELECT person.personID, person.username, count(taskID) as tally
             FROM task 
        LEFT JOIN person ON task.personID = person.personID 
         GROUP BY person.personID";
 
-    $db->query($q);
-    while ($db->next_record()) {
-      $this->tasks["total"][$db->f("personID")] = $db->f("tally");
-      $this->tasks["total"]["total"] += $db->f("tally");
-    }
+        $db->query($q);
+        while ($db->next_record()) {
+            $this->tasks["total"][$db->f("personID")] = $db->f("tally");
+            $this->tasks["total"]["total"] += $db->f("tally");
+        }
 
-    // date from which a task is counted as being new. if monday then date back to friday, else the previous day
-    $days = date("w") == 1 ? 3 : 1;
-    $date = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d") - $days, date("Y")));
-    // Get total amount of completed tasks for every person
-    $q = prepare("SELECT person.personID, person.username, count(taskID) as tally, task.dateCreated
+      // date from which a task is counted as being new. if monday then date back to friday, else the previous day
+        $days = date("w") == 1 ? 3 : 1;
+        $date = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d") - $days, date("Y")));
+      // Get total amount of completed tasks for every person
+        $q = prepare("SELECT person.personID, person.username, count(taskID) as tally, task.dateCreated
             FROM task 
        LEFT JOIN person ON task.personID = person.personID 
            WHERE ('%s' <= task.dateCreated)
-        GROUP BY person.personID",$date);
+        GROUP BY person.personID", $date);
 
-    $db->query($q);
-    while ($db->next_record()) {
-      $d = format_date("Y-m-d", $db->f("dateCreated"));
-      $this->tasks["new"][$db->f("personID")][$d] = $db->f("tally");
-      $v += $db->f("tally");  
-      $this->tasks["new"]["total"][$d] = $v;
-    }
+        $db->query($q);
+        while ($db->next_record()) {
+            $d = format_date("Y-m-d", $db->f("dateCreated"));
+            $this->tasks["new"][$db->f("personID")][$d] = $db->f("tally");
+            $v += $db->f("tally");
+            $this->tasks["new"]["total"][$d] = $v;
+        }
    
                 
 
-    return $this->tasks;
-  }
+        return $this->tasks;
+    }
 
-  function comment_stats() {
-    // date from which a comment is counted as being new. if monday then date back to friday, else the previous day
-    $days = date("w") == 1 ? 3 : 1;
-    $date = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d") - $days, date("Y")));
+    function comment_stats()
+    {
+      // date from which a comment is counted as being new. if monday then date back to friday, else the previous day
+        $days = date("w") == 1 ? 3 : 1;
+        $date = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d") - $days, date("Y")));
 
-    $query = "SELECT * FROM comment";
-    $db = new db_alloc();
-    $db->query($query);
-    while ($db->next_record()) {
-      $comment = new comment();
-      $comment->read_db_record($db);
-      $this->comments["total"][$comment->get_value("commentModifiedUser")]++;
-      $this->comments["total"]["total"]++;
-      if ($comment->get_value("commentModifiedTime") != "") {
-        if (!isset($this->comments["all"][$comment->get_value("commentModifiedUser")])) {
-          $this->comments["all"][$comment->get_value("commentModifiedUser")] = array();
+        $query = "SELECT * FROM comment";
+        $db = new db_alloc();
+        $db->query($query);
+        while ($db->next_record()) {
+            $comment = new comment();
+            $comment->read_db_record($db);
+            $this->comments["total"][$comment->get_value("commentModifiedUser")]++;
+            $this->comments["total"]["total"]++;
+            if ($comment->get_value("commentModifiedTime") != "") {
+                if (!isset($this->comments["all"][$comment->get_value("commentModifiedUser")])) {
+                    $this->comments["all"][$comment->get_value("commentModifiedUser")] = array();
+                }
+                $this->comments["all"][$comment->get_value("commentModifiedUser")][date("Y-m-d", strtotime($comment->get_value("commentModifiedTime")))]++;
+                $this->comments["all"][$comment->get_value("commentModifiedUser")]["total"]++;
+                $this->comments["all"]["total"][date("Y-m-d", strtotime($comment->get_value("commentModifiedTime")))]++;
+
+                if (strcmp($date, $comment->get_value("commentModifiedTime")) <= 0) {
+                    if (!isset($this->comments["new"][$comment->get_value("commentModifiedUser")])) {
+                        $this->comments["new"][$comment->get_value("commentModifiedUser")] = array();
+                    }
+                    $this->comments["new"][$comment->get_value("commentModifiedUser")][date("Y-m-d", strtotime($comment->get_value("commentModifiedTime")))]++;
+                    $this->comments["new"][$comment->get_value("commentModifiedUser")]["total"]++;
+                    $this->comments["new"]["total"][date("Y-m-d", strtotime($comment->get_value("commentModifiedTime")))]++;
+                }
+            }
         }
-        $this->comments["all"][$comment->get_value("commentModifiedUser")][date("Y-m-d", strtotime($comment->get_value("commentModifiedTime")))]++;
-        $this->comments["all"][$comment->get_value("commentModifiedUser")]["total"]++;
-        $this->comments["all"]["total"][date("Y-m-d", strtotime($comment->get_value("commentModifiedTime")))]++;
+        return $this->comments;
+    }
 
-        if (strcmp($date, $comment->get_value("commentModifiedTime")) <= 0) {
-          if (!isset($this->comments["new"][$comment->get_value("commentModifiedUser")])) {
-            $this->comments["new"][$comment->get_value("commentModifiedUser")] = array();
-          }
-          $this->comments["new"][$comment->get_value("commentModifiedUser")][date("Y-m-d", strtotime($comment->get_value("commentModifiedTime")))]++;
-          $this->comments["new"][$comment->get_value("commentModifiedUser")]["total"]++;
-          $this->comments["new"]["total"][date("Y-m-d", strtotime($comment->get_value("commentModifiedTime")))]++;
+    function compare($a, $b)
+    {
+        if ($a["count_back"] == $b["count_back"]) {
+          // if last added item was added on the same day then look at how many were added on that day
+            if ($a["value"] == $b["value"]) {
+                // if the same number of items added on same day then sort alphabetically
+                return strcmp($a["username"], $b["username"]);
+            } else {
+                return ($a["value"] < $b["value"]) ? 1 : -1;
+            }
+        } else {
+            return ($a["count_back"] < $b["count_back"]) ? -1 : 1;
         }
-      }
     }
-    return $this->comments;
-  }
 
-  function compare($a, $b) {
-    if ($a["count_back"] == $b["count_back"]) {
-      // if last added item was added on the same day then look at how many were added on that day
-      if ($a["value"] == $b["value"]) {
-        // if the same number of items added on same day then sort alphabetically
-        return strcmp($a["username"], $b["username"]);
-      } else {
-        return ($a["value"] < $b["value"]) ? 1 : -1;
-      }
-    } else {
-      return ($a["count_back"] < $b["count_back"]) ? -1 : 1;
-    }
-  }
+    function order_by_most_frequent_use()
+    {
+        $max_search_back = 90;      // maximum number of days to go back when sorting
 
-  function order_by_most_frequent_use() {
-    $max_search_back = 90;      // maximum number of days to go back when sorting
+        $query = "SELECT * FROM person ORDER BY username";
+        $db = new db_alloc();
+        $db->query($query);
+        while ($db->next_record()) {
+            $person = new person();
+            $person->read_db_record($db);
 
-    $query = "SELECT * FROM person ORDER BY username";
-    $db = new db_alloc();
-    $db->query($query);
-    while ($db->next_record()) {
-      $person = new person();
-      $person->read_db_record($db);
-
-      for ($value = 0, $i = 0; $value == 0 && $i < $max_search_back; $i++) {
-        $date = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d") - $i, date("Y")));
-        $value = $this->tasks["all"][$person->get_id()][$date];
-        // + $this->projects["all"][$person->get_id()][$date]
-        // + $this->comments["all"][$person->get_id()][$date];
-        if ($value > 0) {
-          array_push($this->persons, array("id"=>$person->get_id(), "username"=>$person->get_value('username'), "count_back"=>$i, "value"=>$value));
+            for ($value = 0, $i = 0; $value == 0 && $i < $max_search_back; $i++) {
+                $date = date("Y-m-d", mktime(0, 0, 0, date("m"), date("d") - $i, date("Y")));
+                $value = $this->tasks["all"][$person->get_id()][$date];
+                // + $this->projects["all"][$person->get_id()][$date]
+                // + $this->comments["all"][$person->get_id()][$date];
+                if ($value > 0) {
+                    array_push($this->persons, array("id"=>$person->get_id(), "username"=>$person->get_value('username'), "count_back"=>$i, "value"=>$value));
+                }
+            }
         }
-      }
+
+        usort($this->persons, array($this, "compare"));
     }
 
-    usort($this->persons, array($this, "compare"));
-  }
+    function get_stats_for_email($format)
+    {
 
-  function get_stats_for_email($format) {
+        if ($format == "html") {
+            $msg = "<br><br><h4>Alloc Stats For Today</h4>";
+            $msg.= sprintf("%d New and %d Active Projects<br><br>", $this->projects["new"]["total"], $this->projects["current"]["total"]);
+            $msg.= "<table >";
+        } else {
+            $msg = "\n- - - - - - - - - -\n";
+            $msg.= "Alloc Stats For Today\n";
+            $msg.= "\n";
+            $msg.= sprintf("%d New and %d Active Projects\n", $this->projects["new"]["total"], $this->projects["current"]["total"]);
+            $msg.= "\n";
+            $msg.= "Top Users:\n";
+        }
 
-    if ($format == "html") {
-      $msg = "<br><br><h4>Alloc Stats For Today</h4>";
-      $msg.= sprintf("%d New and %d Active Projects<br><br>", $this->projects["new"]["total"], $this->projects["current"]["total"]);
-      $msg.= "<table >";
-    } else {
-      $msg = "\n- - - - - - - - - -\n";
-      $msg.= "Alloc Stats For Today\n";
-      $msg.= "\n";
-      $msg.= sprintf("%d New and %d Active Projects\n", $this->projects["new"]["total"], $this->projects["current"]["total"]);
-      $msg.= "\n";
-      $msg.= "Top Users:\n";
+        $num_users = 3;
+        for ($i = 0; $i < $num_users && $i < count($this->persons); $i++) {
+            $person = new person();
+            $person->set_id($this->persons[$i]["id"]);
+            $person->select();
+
+            if ($format == "html") {
+                $msg.= "<tr>";
+                $msg.= sprintf("<td>%s has</td>", $person->get_value("username"));
+                $msg.= sprintf("<td>%d New and</td>", $this->tasks["new"][$person->get_id()]["total"]);
+                $msg.= sprintf("<td>%d Active Tasks</td>", $this->tasks["current"][$person->get_id()]);
+                $msg.= "</tr>";
+            } else {
+                $msg.= sprintf("* %-15s %-15s %s\n", sprintf("%s has", $person->get_value("username")), sprintf("%d New and", $this->tasks["new"][$person->get_id()]["total"]), sprintf("%d Active Tasks", $this->tasks["current"][$person->get_id()]));
+            }
+        }
+
+        if ($format == "html") {
+            $msg.= "<hr />\nTo disable these daily emails, change the \"Daily Email\" setting on the Personal page.\n";
+            $msg.= "</table>";
+        } else {
+            $msg.= "\n- - - - - - - - - -\nTo disable these daily emails, change the \"Daily Email\" setting on the Personal page.\n";
+        }
+
+        return $msg;
     }
-
-    $num_users = 3;
-    for ($i = 0; $i < $num_users && $i < count($this->persons); $i++) {
-      $person = new person();
-      $person->set_id($this->persons[$i]["id"]);
-      $person->select();
-
-      if ($format == "html") {
-        $msg.= "<tr>";
-        $msg.= sprintf("<td>%s has</td>", $person->get_value("username"));
-        $msg.= sprintf("<td>%d New and</td>", $this->tasks["new"][$person->get_id()]["total"]);
-        $msg.= sprintf("<td>%d Active Tasks</td>", $this->tasks["current"][$person->get_id()]);
-        $msg.= "</tr>";
-      } else {
-        $msg.= sprintf("* %-15s %-15s %s\n", sprintf("%s has", $person->get_value("username")), sprintf("%d New and", $this->tasks["new"][$person->get_id()]["total"]), sprintf("%d Active Tasks", $this->tasks["current"][$person->get_id()]));
-      }
-    }
-
-    if ($format == "html") {
-      $msg.= "<hr />\nTo disable these daily emails, change the \"Daily Email\" setting on the Personal page.\n";
-      $msg.= "</table>";
-    } else {
-      $msg.= "\n- - - - - - - - - -\nTo disable these daily emails, change the \"Daily Email\" setting on the Personal page.\n";
-    }
-
-    return $msg;
-  }
-
 }
-
-
-
-?>

--- a/tools/lib/whatsnew.inc.php
+++ b/tools/lib/whatsnew.inc.php
@@ -3,43 +3,47 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class whatsnew {
+class whatsnew
+{
 
-  var $folders = array();
+    var $folders = array();
 
-  function __construct() {
-  }
+    function __construct()
+    {
+    }
 
-  function set_id() { // dummy so can re-use the get_attachment.php script
-    return true;
-  }
+    function set_id()
+    {
+ // dummy so can re-use the get_attachment.php script
+        return true;
+    }
 
-  function select() { // dummy so can re-use the get_attachment.php script
-    return true;
-  }
+    function select()
+    {
+ // dummy so can re-use the get_attachment.php script
+        return true;
+    }
 
-  function has_attachment_permission($person) {
-    return true;
-  }
+    function has_attachment_permission($person)
+    {
+        return true;
+    }
 }
-
-
-?>

--- a/tools/menu.php
+++ b/tools/menu.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -40,9 +40,10 @@ $misc_options = array(array("url"=>"reminderList"            ,"text"=>"Reminders
 
   //,array("url"=>"stats"                   ,"text"=>"allocPSA Statistics"   ,"entity"=>"config"             ,"action"=>PERM_UPDATE)
 
-function user_is_admin() {
-  $current_user = &singleton("current_user");
-  return $current_user->have_role("admin");
+function user_is_admin()
+{
+    $current_user = &singleton("current_user");
+    return $current_user->have_role("admin");
 }
 
 
@@ -62,72 +63,74 @@ $finance_options = array(array("url"=>"tf"                   ,"text"=>"New Tagge
 
                         #,array("url"=>"reconciliationReport", "params"=>"", "text"=>"Reconciliation Report", "entity"=>"transaction", "action"=>true, "function"=>"user_is_admin")
 
-function has_whatsnew_files() {
- $rows = get_attachments("whatsnew", 0);
-  if (count($rows)) {
-    return true;
-  }
-}
-
-
-function show_misc_options($template) {
-  global $misc_options;
-  global $TPL;
-
-  $TPL["br"] = "<br>\n";
-  reset($misc_options);
-  while (list(, $option) = each($misc_options)) {
-    if ($option["entity"] != "") {
-      if (have_entity_perm($option["entity"], $option["action"], $current_user, true)) {
-        $TPL["url"] = $TPL["url_alloc_".$option["url"]];
-        $TPL["params"] = $option["params"];
-        $TPL["text"] = $option["text"];
-        include_template($template);
-      }
-    } else if ($option["function"]){
-      $f = $option["function"];
-      if ($f()) {
-        $TPL["url"] = $TPL["url_alloc_".$option["url"]];
-        $TPL["params"] = $option["params"];
-        $TPL["text"] = $option["text"];
-        include_template($template);
-      }
-    } else {
-      $TPL["url"] = $TPL["url_alloc_".$option["url"]];
-      $TPL["params"] = $option["params"];
-      $TPL["text"] = $option["text"];
-      include_template($template);
+function has_whatsnew_files()
+{
+    $rows = get_attachments("whatsnew", 0);
+    if (count($rows)) {
+        return true;
     }
-  }
 }
 
-function show_finance_options($template) {
-  global $finance_options;
-  global $TPL;
-  foreach ($finance_options as $option) {
-    if ($option["entity"] != "") {
-      if (have_entity_perm($option["entity"], $option["action"], $current_user, true)) {
-        $TPL["url"] = $TPL["url_alloc_".$option["url"]];
-        $TPL["params"] = $option["params"];
-        $TPL["text"] = $option["text"];
-        $TPL["br"] = "<br>\n";
-        $option["br"] and $TPL["br"] = "<br><br>\n";
 
-        include_template($template);
-      }
-    } else if ($option["function"]){
-      $f = $option["function"];
-      if ($f()) {
-        $TPL["url"] = $TPL["url_alloc_".$option["url"]];
-        $TPL["params"] = $option["params"];
-        $TPL["text"] = $option["text"];
-        $TPL["br"] = "<br>\n";
-        $option["br"] and $TPL["br"] = "<br><br>\n";
-        include_template($template);
-      }
-    } 
+function show_misc_options($template)
+{
+    global $misc_options;
+    global $TPL;
 
-  }
+    $TPL["br"] = "<br>\n";
+    reset($misc_options);
+    while (list(, $option) = each($misc_options)) {
+        if ($option["entity"] != "") {
+            if (have_entity_perm($option["entity"], $option["action"], $current_user, true)) {
+                $TPL["url"] = $TPL["url_alloc_".$option["url"]];
+                $TPL["params"] = $option["params"];
+                $TPL["text"] = $option["text"];
+                include_template($template);
+            }
+        } else if ($option["function"]) {
+            $f = $option["function"];
+            if ($f()) {
+                $TPL["url"] = $TPL["url_alloc_".$option["url"]];
+                $TPL["params"] = $option["params"];
+                $TPL["text"] = $option["text"];
+                include_template($template);
+            }
+        } else {
+            $TPL["url"] = $TPL["url_alloc_".$option["url"]];
+            $TPL["params"] = $option["params"];
+            $TPL["text"] = $option["text"];
+            include_template($template);
+        }
+    }
+}
+
+function show_finance_options($template)
+{
+    global $finance_options;
+    global $TPL;
+    foreach ($finance_options as $option) {
+        if ($option["entity"] != "") {
+            if (have_entity_perm($option["entity"], $option["action"], $current_user, true)) {
+                $TPL["url"] = $TPL["url_alloc_".$option["url"]];
+                $TPL["params"] = $option["params"];
+                $TPL["text"] = $option["text"];
+                $TPL["br"] = "<br>\n";
+                $option["br"] and $TPL["br"] = "<br><br>\n";
+
+                include_template($template);
+            }
+        } else if ($option["function"]) {
+            $f = $option["function"];
+            if ($f()) {
+                $TPL["url"] = $TPL["url_alloc_".$option["url"]];
+                $TPL["params"] = $option["params"];
+                $TPL["text"] = $option["text"];
+                $TPL["br"] = "<br>\n";
+                $option["br"] and $TPL["br"] = "<br><br>\n";
+                include_template($template);
+            }
+        }
+    }
 }
 
 
@@ -135,7 +138,3 @@ function show_finance_options($template) {
 $TPL["main_alloc_title"] = "Tools - ".APPLICATION_NAME;
 
 include_template("templates/menuM.tpl");
-
-
-
-?>

--- a/tools/sourceCodeList.php
+++ b/tools/sourceCodeList.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,52 +23,53 @@
 require_once("../alloc.php");
 
 
-function get_all_source_files($dir="") {
-  global $TPL;
-  $dir or $dir = ALLOC_MOD_DIR;
+function get_all_source_files($dir = "")
+{
+    global $TPL;
+    $dir or $dir = ALLOC_MOD_DIR;
 
-  if (path_under_path($dir,ALLOC_MOD_DIR) && is_dir($dir)) {
+    if (path_under_path($dir, ALLOC_MOD_DIR) && is_dir($dir)) {
+        $dir = realpath($dir);
+        $handle = opendir($dir);
+        while (false !== ($file = readdir($handle))) {
+            clearstatcache();
 
-    $dir = realpath($dir);
-    $handle = opendir($dir);
-    while (false !== ($file = readdir($handle))) {
-      clearstatcache();
+            if ($file == ".") {
+                continue;
+            }
+            if ($file == ".." && realpath($dir) == realpath(ALLOC_MOD_DIR)) {
+                continue;
+            }
 
-      if ($file == ".") continue;
-      if ($file == ".." && realpath($dir) == realpath(ALLOC_MOD_DIR)) continue;
-
-      if (is_file($dir.DIRECTORY_SEPARATOR.$file)) {
-        $image = "<img border=\"0\" alt=\"icon\" src=\"".$TPL["url_alloc_images"]."/fileicons/unknown.gif\">";
-        $files[$file] = "<a href=\"".$TPL["url_alloc_sourceCodeView"]."dir=".urlencode($dir)."&file=".urlencode($file)."\">".$image.$file."</a>";
-      } else if (is_dir($dir.DIRECTORY_SEPARATOR.$file)) {
-        $image = "<img border=\"0\" alt=\"icon\" src=\"".$TPL["url_alloc_images"]."/fileicons/directory.gif\">";
-        $dirs[$file] = "<a href=\"".$TPL["url_alloc_sourceCodeList"]."dir=".urlencode($dir.DIRECTORY_SEPARATOR.$file)."\">".$image.$file."</a>";
-      } else { 
-        #echo "<br>wtf: ".$dir.DIRECTORY_SEPARATOR.$file;
-      }
-
+            if (is_file($dir.DIRECTORY_SEPARATOR.$file)) {
+                $image = "<img border=\"0\" alt=\"icon\" src=\"".$TPL["url_alloc_images"]."/fileicons/unknown.gif\">";
+                $files[$file] = "<a href=\"".$TPL["url_alloc_sourceCodeView"]."dir=".urlencode($dir)."&file=".urlencode($file)."\">".$image.$file."</a>";
+            } else if (is_dir($dir.DIRECTORY_SEPARATOR.$file)) {
+                $image = "<img border=\"0\" alt=\"icon\" src=\"".$TPL["url_alloc_images"]."/fileicons/directory.gif\">";
+                $dirs[$file] = "<a href=\"".$TPL["url_alloc_sourceCodeList"]."dir=".urlencode($dir.DIRECTORY_SEPARATOR.$file)."\">".$image.$file."</a>";
+            } else {
+                #echo "<br>wtf: ".$dir.DIRECTORY_SEPARATOR.$file;
+            }
+        }
     }
-  }
   
 
-  $files or $files = array();
-  $dirs or $dirs = array();
-  asort($files);
-  asort($dirs);
-  $rtn = array_merge($dirs, $files);
-  return $rtn;
+    $files or $files = array();
+    $dirs or $dirs = array();
+    asort($files);
+    asort($dirs);
+    $rtn = array_merge($dirs, $files);
+    return $rtn;
 }
 
 
 $files = get_all_source_files($_GET["dir"]);
 if (is_array($files)) {
-  foreach ($files as $file => $link) {
-    $TPL["results"].= "<p style=\"padding:0px; margin:4px\">".$link."</p>";
-  }
+    foreach ($files as $file => $link) {
+        $TPL["results"].= "<p style=\"padding:0px; margin:4px\">".$link."</p>";
+    }
 }
 
 
 
 include_template("templates/sourceCodeListM.tpl");
-
-?>

--- a/tools/sourceCodeView.php
+++ b/tools/sourceCodeView.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -25,14 +25,12 @@ require_once("../alloc.php");
 $prohibited[] = "alloc_config.php";
 
 if ($_GET["dir"] && $_GET["file"]) {
-  $path = realpath($_GET["dir"].DIRECTORY_SEPARATOR.$_GET["file"]);
-  $TPL["path"] = $path;
-  if (path_under_path($path,ALLOC_MOD_DIR) && is_file($path) && !in_array(basename($path),$prohibited)) {
-    $TPL["results"] = page::htmlentities(file_get_contents($path));
-  }
+    $path = realpath($_GET["dir"].DIRECTORY_SEPARATOR.$_GET["file"]);
+    $TPL["path"] = $path;
+    if (path_under_path($path, ALLOC_MOD_DIR) && is_file($path) && !in_array(basename($path), $prohibited)) {
+        $TPL["results"] = page::htmlentities(file_get_contents($path));
+    }
 }
 
 
 include_template("templates/sourceCodeView.tpl");
-
-?>

--- a/tools/stats.php
+++ b/tools/stats.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -43,76 +43,67 @@ include_template("templates/statsM.tpl");
 
 
 /* order array of userids from most actions to least actions */
-function compare($a, $b) {
-  global $projects;
-  global $tasks;
-  global $comments;
+function compare($a, $b)
+{
+    global $projects;
+    global $tasks;
+    global $comments;
 
-  for ($i = 0, $a_value = 0, $b_value = 0; $a_value == $b_value && $i < 30; $i++) {
-    $date = mktime(0, 0, 0, date("m"), date("d") - $i, date("Y"));
-    $a_value = $comments["new"][$a][date("Y-m-d", $date)] + $projects["new"][$a][date("Y-m-d", $date)]
-      + $tasks["new"][$a][date("Y-m-d", $date)];
-    $b_value = $comments["new"][$b][date("Y-m-d", $date)] + $projects["new"][$b][date("Y-m-d", $date)]
-      + $tasks["new"][$b][date("Y-m-d", $date)];
-  }
-  if ($a_value == $b_value)
-    return 0;
-  return ($a_value < $b_value) ? 1 : -1;
-}
-
-function show_users_stats($template) {
-  global $TPL;
-  global $db;
-  $stats = new stats();
-  $projects = $stats->project_stats();
-  $tasks = $stats->task_stats();
-  $comments = $stats->comment_stats();
-
-  $persons = array();
-
-  $query = "SELECT * FROM person ORDER BY username";
-  $db->query($query);
-  while ($db->next_record()) {
-    $person = new person();
-    $person->read_db_record($db);
-    array_push($persons, $person->get_id());
-  }
-
-  usort($persons, "compare");
-
-  for ($i = 0; $i < count($persons); $i++) {
-    $person = new person();
-    $person->set_id($persons[$i]);
-    $person->select();
-
-    $TPL["user_username"] = $person->get_value("username");
-
-    $TPL["user_projects_current"] = $projects["current"][$person->get_id()] + 0;
-    $TPL["user_projects_total"] = $projects["current"][$person->get_id()] + $projects["archived"][$person->get_id()];
-
-    $TPL["user_tasks_current"] = $tasks["current"][$person->get_id()] + 0;
-    $TPL["user_tasks_total"] = $tasks["current"][$person->get_id()] + $tasks["completed"][$person->get_id()];
-
-    $TPL["user_comments_total"] = $comments["total"][$person->get_id()] + 0;
-
-    $TPL["user_graph"] = "<a href=\"".$TPL["url_alloc_statsImage"]."id=".$person->get_id()."&width=640&multiplier=8&labels=true\">";
-    $TPL["user_graph"].= "<img alt=\"User graph\" src=\"".$TPL["url_alloc_statsImage"]."id=".$person->get_id()."&width=400&multiplier=2\"></a>";
-
-    if ($TPL["user_projects_total"] + $TPL["user_tasks_total"] + $TPL["user_comments_total"] > 0) {
-      $TPL["odd_even"] = $TPL["odd_even"] == "odd" ? "even" : "odd";
-      include_template($template);
+    for ($i = 0, $a_value = 0, $b_value = 0; $a_value == $b_value && $i < 30; $i++) {
+        $date = mktime(0, 0, 0, date("m"), date("d") - $i, date("Y"));
+        $a_value = $comments["new"][$a][date("Y-m-d", $date)] + $projects["new"][$a][date("Y-m-d", $date)]
+        + $tasks["new"][$a][date("Y-m-d", $date)];
+        $b_value = $comments["new"][$b][date("Y-m-d", $date)] + $projects["new"][$b][date("Y-m-d", $date)]
+        + $tasks["new"][$b][date("Y-m-d", $date)];
     }
-  }
+    if ($a_value == $b_value) {
+        return 0;
+    }
+    return ($a_value < $b_value) ? 1 : -1;
 }
 
+function show_users_stats($template)
+{
+    global $TPL;
+    global $db;
+    $stats = new stats();
+    $projects = $stats->project_stats();
+    $tasks = $stats->task_stats();
+    $comments = $stats->comment_stats();
 
+    $persons = array();
 
+    $query = "SELECT * FROM person ORDER BY username";
+    $db->query($query);
+    while ($db->next_record()) {
+        $person = new person();
+        $person->read_db_record($db);
+        array_push($persons, $person->get_id());
+    }
 
+    usort($persons, "compare");
 
+    for ($i = 0; $i < count($persons); $i++) {
+        $person = new person();
+        $person->set_id($persons[$i]);
+        $person->select();
 
+        $TPL["user_username"] = $person->get_value("username");
 
+        $TPL["user_projects_current"] = $projects["current"][$person->get_id()] + 0;
+        $TPL["user_projects_total"] = $projects["current"][$person->get_id()] + $projects["archived"][$person->get_id()];
 
+        $TPL["user_tasks_current"] = $tasks["current"][$person->get_id()] + 0;
+        $TPL["user_tasks_total"] = $tasks["current"][$person->get_id()] + $tasks["completed"][$person->get_id()];
 
+        $TPL["user_comments_total"] = $comments["total"][$person->get_id()] + 0;
 
+        $TPL["user_graph"] = "<a href=\"".$TPL["url_alloc_statsImage"]."id=".$person->get_id()."&width=640&multiplier=8&labels=true\">";
+        $TPL["user_graph"].= "<img alt=\"User graph\" src=\"".$TPL["url_alloc_statsImage"]."id=".$person->get_id()."&width=400&multiplier=2\"></a>";
 
-?>
+        if ($TPL["user_projects_total"] + $TPL["user_tasks_total"] + $TPL["user_comments_total"] > 0) {
+            $TPL["odd_even"] = $TPL["odd_even"] == "odd" ? "even" : "odd";
+            include_template($template);
+        }
+    }
+}

--- a/tools/statsImage.php
+++ b/tools/statsImage.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -45,28 +45,28 @@ $left_margin = 0;
 $right_margin = 0;
 
 for ($date = $start_date; $date < time(); $date += 86400) {
-  $count = ($projects["new"][$id][date("Y-m-d", $date)]
+    $count = ($projects["new"][$id][date("Y-m-d", $date)]
             + $tasks["new"][$id][date("Y-m-d", $date)]
             + $comments["new"][$id][date("Y-m-d", $date)]);
-  if ($height < $count) {
-    $height = $count;
-  }
+    if ($height < $count) {
+        $height = $count;
+    }
 }
 if ($labels) {
-  if ($height > 0) {
-    $left_margin = strlen($height) * 5 + 10;
-  } else {
-    $left_margin = 5;
-  }
-  $right_margin = 5;
-  $top_margin = 5;
-  $bottom_margin = 10;
+    if ($height > 0) {
+        $left_margin = strlen($height) * 5 + 10;
+    } else {
+        $left_margin = 5;
+    }
+    $right_margin = 5;
+    $top_margin = 5;
+    $bottom_margin = 10;
 }
 $disp_height = $height;
 $height *= $multiplier;
 $height += ($top_margin + $bottom_margin);
 if ($height < 18) {
-  $height = 18;
+    $height = 18;
 }
 
 $segment_size = ($width - $left_margin - $right_margin) / ((($date - $start_date) / 86400) - 1);
@@ -90,19 +90,19 @@ $comments_points = array(0=>$left_margin, 1=>$height - $bottom_margin - 1);
 $count = 2;
 $x_pos = $left_margin;
 for ($date = $start_date; $date < time(); $date += 86400) {
-  $projects_points[$count] = $x_pos;
-  $tasks_points[$count] = $x_pos;
-  $comments_points[$count] = $x_pos;
-  $x_pos += $segment_size;
-  $count++;
+    $projects_points[$count] = $x_pos;
+    $tasks_points[$count] = $x_pos;
+    $comments_points[$count] = $x_pos;
+    $x_pos += $segment_size;
+    $count++;
 
-  $y_pos = $height - $bottom_margin - 1 - ($projects["new"][$id][date("Y-m-d", $date)] * $multiplier);
-  $projects_points[$count] = $y_pos;
-  $y_pos -= ($tasks["new"][$id][date("Y-m-d", $date)] * $multiplier);
-  $tasks_points[$count] = $y_pos;
-  $y_pos -= ($comments["new"][$id][date("Y-m-d", $date)] * $multiplier);
-  $comments_points[$count] = $y_pos;
-  $count++;
+    $y_pos = $height - $bottom_margin - 1 - ($projects["new"][$id][date("Y-m-d", $date)] * $multiplier);
+    $projects_points[$count] = $y_pos;
+    $y_pos -= ($tasks["new"][$id][date("Y-m-d", $date)] * $multiplier);
+    $tasks_points[$count] = $y_pos;
+    $y_pos -= ($comments["new"][$id][date("Y-m-d", $date)] * $multiplier);
+    $comments_points[$count] = $y_pos;
+    $count++;
 }
 $projects_points[$count] = $width - $right_margin - 1;
 $projects_points[$count + 1] = $height - $bottom_margin - 1;
@@ -117,22 +117,18 @@ imagefilledpolygon($image, $projects_points, ($count + 2) / 2, $color_projects);
 
 if ($labels) {
   /* baseline */
-  imageline($image, $left_margin, $height - $bottom_margin - 1, $width - $right_margin - 1, $height - $bottom_margin - 1, $color_foreground);
+    imageline($image, $left_margin, $height - $bottom_margin - 1, $width - $right_margin - 1, $height - $bottom_margin - 1, $color_foreground);
   /* dates */
-  imagestring($image, 2, $left_margin, $height - $bottom_margin - 1, date("Y-m-d", $start_date), $color_foreground);
-  imagestring($image, 2, $width - $right_margin - 60, $height - $bottom_margin - 1, date("Y-m-d"), $color_foreground);
+    imagestring($image, 2, $left_margin, $height - $bottom_margin - 1, date("Y-m-d", $start_date), $color_foreground);
+    imagestring($image, 2, $width - $right_margin - 60, $height - $bottom_margin - 1, date("Y-m-d"), $color_foreground);
 
   /* sideline */
-  imageline($image, $left_margin, $height - $bottom_margin - 1, $left_margin, $top_margin - 1, $color_foreground);
+    imageline($image, $left_margin, $height - $bottom_margin - 1, $left_margin, $top_margin - 1, $color_foreground);
   /* max count */
-  if ($disp_height > 0) {
-    imagestring($image, 2, 5, 0, $disp_height, $color_foreground);
-  }
+    if ($disp_height > 0) {
+        imagestring($image, 2, 5, 0, $disp_height, $color_foreground);
+    }
 }
 
 header("Content-type: image/png");
 imagepng($image);
-
-
-
-?>

--- a/tools/whatsnew.php
+++ b/tools/whatsnew.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,5 +23,3 @@
 require_once("../alloc.php");
 $TPL["main_alloc_title"] = "allocPSA Deployment Changelog - ".APPLICATION_NAME;
 include_template("templates/whatsnewM.tpl");
-
-?>

--- a/util/csv_clients.php
+++ b/util/csv_clients.php
@@ -3,26 +3,26 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once("../alloc.php");
 
-/* 
+/*
 ClientName
  Phone Number
  Fax Number
@@ -39,59 +39,54 @@ ClientName
 */
 
 $row = 1;
-if (($handle = fopen("../../David_Clients.csv", "r")) !== FALSE) {
-    while (($data = fgetcsv($handle, 1000, ",")) !== FALSE) {
-
-         foreach( $data as $key => $val ) {
+if (($handle = fopen("../../David_Clients.csv", "r")) !== false) {
+    while (($data = fgetcsv($handle, 1000, ",")) !== false) {
+        foreach ($data as $key => $val) {
             $data[$key] = utf8_encode($data[$key]);
-         }
+        }
 
-        unset($comment_id,$cc_id);
+        unset($comment_id, $cc_id);
         $client = new client();
-        $client->set_value("clientName",$data[0]);
-        $client->set_value("clientPhoneOne",$data[1]);
-        $client->set_value("clientFaxOne",$data[2]);
-        $client->set_value("clientStreetAddressOne",$data[3]);
-        $client->set_value("clientSuburbOne",$data[4]);
-        $client->set_value("clientStateOne",$data[5]);
-        $client->set_value("clientPostcodeOne",$data[6]);
-        $client->set_value("clientStreetAddressTwo",$data[7]);
-        $client->set_value("clientSuburbTwo",$data[8]);
-        $client->set_value("clientStatus","current");
-        $client->set_value("clientModifiedUser",$current_user->get_id());
+        $client->set_value("clientName", $data[0]);
+        $client->set_value("clientPhoneOne", $data[1]);
+        $client->set_value("clientFaxOne", $data[2]);
+        $client->set_value("clientStreetAddressOne", $data[3]);
+        $client->set_value("clientSuburbOne", $data[4]);
+        $client->set_value("clientStateOne", $data[5]);
+        $client->set_value("clientPostcodeOne", $data[6]);
+        $client->set_value("clientStreetAddressTwo", $data[7]);
+        $client->set_value("clientSuburbTwo", $data[8]);
+        $client->set_value("clientStatus", "current");
+        $client->set_value("clientModifiedUser", $current_user->get_id());
         $client->save();
 
         if ($client->get_id()) {
-          if (rtrim($data[9])) {
-            $comment = new comment();
-            $comment->set_value("commentMaster","client");
-            $comment->set_value("commentMasterID",$client->get_id());
-            $comment->set_value("commentType","client");
-            $comment->set_value("commentLinkID",$client->get_id());
-            $comment->set_value("comment",$data[9]);
-            $comment->save();
-            $comment_id = $comment->get_id();
-          }
+            if (rtrim($data[9])) {
+                $comment = new comment();
+                $comment->set_value("commentMaster", "client");
+                $comment->set_value("commentMasterID", $client->get_id());
+                $comment->set_value("commentType", "client");
+                $comment->set_value("commentLinkID", $client->get_id());
+                $comment->set_value("comment", $data[9]);
+                $comment->save();
+                $comment_id = $comment->get_id();
+            }
   
-          if ($data[10] || $data[11]) {
-            $cc = new clientContact();
-            $cc->set_value("clientID",$client->get_id());
-            $cc->set_value("primaryContact",1);
-            $cc->set_value("clientContactName",$data[10]);
-            $cc->set_value("clientContactEmail",$data[11]);
-            $cc->save();
-            $cc_id = $cc->get_id();
-          }
+            if ($data[10] || $data[11]) {
+                $cc = new clientContact();
+                $cc->set_value("clientID", $client->get_id());
+                $cc->set_value("primaryContact", 1);
+                $cc->set_value("clientContactName", $data[10]);
+                $cc->set_value("clientContactEmail", $data[11]);
+                $cc->save();
+                $cc_id = $cc->get_id();
+            }
         }
-      $x++;
-      echo "<br>".$client->get_id()." --- ".$cc_id." --- ".$comment_id;
-      if ($x>4) {
-        //die();
-      }
+        $x++;
+        echo "<br>".$client->get_id()." --- ".$cc_id." --- ".$comment_id;
+        if ($x>4) {
+          //die();
+        }
     }
     fclose($handle);
 }
-
-
-
-?>

--- a/util/csv_people.php
+++ b/util/csv_people.php
@@ -35,36 +35,31 @@ Comments
 $cur = config::get_config_item("currency");
 
 $row = 1;
-if (($handle = fopen("../../David_People.csv", "r")) !== FALSE) {
-    while (($data = fgetcsv($handle, 1000, ",")) !== FALSE) {
+if (($handle = fopen("../../David_People.csv", "r")) !== false) {
+    while (($data = fgetcsv($handle, 1000, ",")) !== false) {
+        foreach ($data as $key => $val) {
+        #  $data[$key] = utf8_encode($data[$key]);
+        }
 
-      foreach( $data as $key => $val ) {
-      #  $data[$key] = utf8_encode($data[$key]);
-      }
+        $person = new person();
+        $person->currency = $cur;
+        $person->set_value("username", $data[0]);
+        $person->set_value("firstName", $data[1]);
+        $person->set_value("surname", $data[2]);
+        $person->set_value("password", password_hash($data[3], PASSWORD_BCRYPT));
+        $person->set_value("emailAddress", $data[4]);
+        $person->set_value("phoneNo1", $data[5]);
+        $person->set_value("comments", $data[6]);
+        $person->set_value("perms", "employee");
+        $person->set_value("personActive", 1);
+        $person->set_value("personModifiedUser", $current_user->get_id());
+        $person->save();
 
-      $person = new person();
-      $person->currency = $cur;
-      $person->set_value("username",$data[0]);
-      $person->set_value("firstName",$data[1]);
-      $person->set_value("surname",$data[2]);
-      $person->set_value("password",password_hash($data[3], PASSWORD_BCRYPT));
-      $person->set_value("emailAddress",$data[4]);
-      $person->set_value("phoneNo1",$data[5]);
-      $person->set_value("comments",$data[6]);
-      $person->set_value("perms","employee");
-      $person->set_value("personActive",1);
-      $person->set_value("personModifiedUser",$current_user->get_id());
-      $person->save();
-
-      $x++;
-      echo "<br>here: ".$person->get_id().$data[0];
-      if ($x>4) {
-        //die();
-      }
+        $x++;
+        echo "<br>here: ".$person->get_id().$data[0];
+        if ($x>4) {
+          //die();
+        }
     }
     fclose($handle);
 }
-
-
-
-?>

--- a/util/rss.php
+++ b/util/rss.php
@@ -1,26 +1,24 @@
 <?php
-
+;
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
 #echo shell_exec('darcs changes --xml --last 10 | xsltproc rss.xslt -');
-
-?>

--- a/wiki/directory.php
+++ b/wiki/directory.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -23,7 +23,7 @@
 require_once("../alloc.php");
 
 
-$dirName = str_replace("..","",$_POST["dirName"]);
+$dirName = str_replace("..", "", $_POST["dirName"]);
 #$dirName = preg_replace("/^[\/\\\]*/","",$dirName);
 
 // Check if we're using a VCS
@@ -32,79 +32,67 @@ $vcs = vcs::get();
 if ($_POST["save"]) {
   // path_under_path(wiki_module::get_wiki_path().$dirName, wiki_module::get_wiki_path(),$dont_check_filesystem=false) or $errors[] = "Bad directory name: ";
   //is_writeable(wiki_module::get_wiki_path().dirname($editName)) or $errors[] = "Path is not writeable.";
-  strlen($dirName) or $errors[] = "Directory name empty.";
-  $dirName and is_dir(wiki_module::get_wiki_path().$dirName) and $errors[] = "Directory already exists.";
+    strlen($dirName) or $errors[] = "Directory name empty.";
+    $dirName and is_dir(wiki_module::get_wiki_path().$dirName) and $errors[] = "Directory already exists.";
 
-  if ($errors) {
-    $error = "<div class='message warn noprint' style='margin-top:0px; margin-bottom:10px; padding:10px;'>";
-    $error.= implode("<br>",$errors);
-    $error.= "</div>";
+    if ($errors) {
+        $error = "<div class='message warn noprint' style='margin-top:0px; margin-bottom:10px; padding:10px;'>";
+        $error.= implode("<br>", $errors);
+        $error.= "</div>";
    
-    $TPL["loadErrorPageDir"] = 1;
-    $TPL["dirName"] = urlencode($dirName);
-    $TPL["msg"] = urlencode($error);
-    include_template("templates/wikiM.tpl");
-
-  } else {
-
-    // If we're using version control
-    if (is_object($vcs)) {
-
-      // Creating a new directory or directories
-      if (!is_dir(wiki_module::get_wiki_path().$dirName)) {
-        $bits = explode("/",$dirName);
-        $str = wiki_module::get_wiki_path();
-        foreach ((array)$bits as $bit) {
-          $str.= $slash.$bit;
-          mkdir($str);
-          $vcs->add($str);
-          $vcs->commit($str, "Added directory.");
-          $slash = "/";
-        }
-        alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode($dirName));
-      }
-
-    // Else non-vcs save
+        $TPL["loadErrorPageDir"] = 1;
+        $TPL["dirName"] = urlencode($dirName);
+        $TPL["msg"] = urlencode($error);
+        include_template("templates/wikiM.tpl");
     } else {
-      // Creating a new directory or directories
-      if (!is_dir(wiki_module::get_wiki_path().$dirName)) {
-        $bits = explode("/",$dirName);
-        $str = wiki_module::get_wiki_path();
-        foreach ((array)$bits as $bit) {
-          $str.= $slash.$bit;
-          mkdir($str);
-          $slash = "/";
+      // If we're using version control
+        if (is_object($vcs)) {
+          // Creating a new directory or directories
+            if (!is_dir(wiki_module::get_wiki_path().$dirName)) {
+                $bits = explode("/", $dirName);
+                $str = wiki_module::get_wiki_path();
+                foreach ((array)$bits as $bit) {
+                    $str.= $slash.$bit;
+                    mkdir($str);
+                    $vcs->add($str);
+                    $vcs->commit($str, "Added directory.");
+                    $slash = "/";
+                }
+                alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode($dirName));
+            }
+
+        // Else non-vcs save
+        } else {
+          // Creating a new directory or directories
+            if (!is_dir(wiki_module::get_wiki_path().$dirName)) {
+                $bits = explode("/", $dirName);
+                $str = wiki_module::get_wiki_path();
+                foreach ((array)$bits as $bit) {
+                    $str.= $slash.$bit;
+                    mkdir($str);
+                    $slash = "/";
+                }
+                $TPL["message_good"][] = "Directory created: ".$dirName;
+                alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode($dirName));
+            }
         }
-        $TPL["message_good"][] = "Directory created: ".$dirName;
-        alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode($dirName));
-      }
     }
-  }
-
-
 } else if ($_REQUEST["newDirectory"]) {
-
-  if ($_REQUEST["p"]) {
-    if (is_file(wiki_module::get_wiki_path().$_REQUEST["p"])) {
-      $_REQUEST["p"] = dirname($_REQUEST["p"]);
-      $_REQUEST["p"] && substr($_REQUEST["p"],-1,1) != DIRECTORY_SEPARATOR and $_REQUEST["p"].="/";
-      $_REQUEST["p"] == ".".DIRECTORY_SEPARATOR and $_REQUEST["p"] = "";
+    if ($_REQUEST["p"]) {
+        if (is_file(wiki_module::get_wiki_path().$_REQUEST["p"])) {
+            $_REQUEST["p"] = dirname($_REQUEST["p"]);
+            $_REQUEST["p"] && substr($_REQUEST["p"], -1, 1) != DIRECTORY_SEPARATOR and $_REQUEST["p"].="/";
+            $_REQUEST["p"] == ".".DIRECTORY_SEPARATOR and $_REQUEST["p"] = "";
+        }
+        $TPL["dirName"] = $_REQUEST["p"];
     }
-    $TPL["dirName"] = $_REQUEST["p"];
-  }
-  include_template("templates/newDirectoryM.tpl");
-
+    include_template("templates/newDirectoryM.tpl");
 } else if ($_REQUEST["loadErrorPageDir"]) {
-  $TPL["loadErrorPageDir"] = $_REQUEST["loadErrorPageDir"];
-  $TPL["dirName"] = $_REQUEST["dirName"];
-  $TPL["msg"] = $_REQUEST["msg"];
-  include_template("templates/newDirectoryM.tpl");
+    $TPL["loadErrorPageDir"] = $_REQUEST["loadErrorPageDir"];
+    $TPL["dirName"] = $_REQUEST["dirName"];
+    $TPL["msg"] = $_REQUEST["msg"];
+    include_template("templates/newDirectoryM.tpl");
 }
 
 
 $TPL["dirName"] = $dirName;
-
-
-
-
-?>

--- a/wiki/file.php
+++ b/wiki/file.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -29,137 +29,123 @@ $TPL["editName"] = $_POST["editName"];
 
 // Decode the wiki document ..
 $text = html_entity_decode($_POST["wikitext"]);
-$text = str_replace("\r\n","\n",$text);
+$text = str_replace("\r\n", "\n", $text);
 
 // Check if we're using a VCS
 $vcs = vcs::get();
 
 if ($_POST["save"]) {
+    path_under_path(wiki_module::get_wiki_path().dirname($editName), wiki_module::get_wiki_path()) or $errors[] = "Bad filename: ".$editName;
+    is_writeable(wiki_module::get_wiki_path().dirname($editName)) or $errors[] = "Path is not writeable.";
+    strlen($_POST["wikitext"]) or $errors[] = "File contents empty.";
+    strlen($editName) or $errors[] = "Filename empty.";
+    strlen($_POST["commit_msg"]) or $errors[] = "No description of changes entered.";
 
-  path_under_path(wiki_module::get_wiki_path().dirname($editName), wiki_module::get_wiki_path()) or $errors[] = "Bad filename: ".$editName;
-  is_writeable(wiki_module::get_wiki_path().dirname($editName)) or $errors[] = "Path is not writeable.";
-  strlen($_POST["wikitext"]) or $errors[] = "File contents empty.";
-  strlen($editName) or $errors[] = "Filename empty.";
-  strlen($_POST["commit_msg"]) or $errors[] = "No description of changes entered.";
-
-  if ($errors) {
-    $error = "<div class='message warn noprint' style='margin-top:0px; margin-bottom:10px; padding:10px;'>";
-    $error.= implode("<br>",$errors);
-    $error.= "</div>";
+    if ($errors) {
+        $error = "<div class='message warn noprint' style='margin-top:0px; margin-bottom:10px; padding:10px;'>";
+        $error.= implode("<br>", $errors);
+        $error.= "</div>";
    
-    $TPL["loadErrorPage"] = 1;
-    $TPL["str"] = urlencode($_POST["wikitext"]);
-    $TPL["commit_msg"] = urlencode($_POST["commit_msg"]);
-    $TPL["file"] = urlencode($editName);
-    $TPL["msg"] = $error;
-    include_template("templates/wikiM.tpl");
-
-  } else {
-
-    // If we're using version control
-    if (is_object($vcs)) {
-
-      // Creating a new file
-      if (!$file) {
-        wiki_module::file_save(wiki_module::get_wiki_path().$editName, $text);
-        $vcs->add(wiki_module::get_wiki_path().$editName);
-        $vcs->commit(wiki_module::get_wiki_path().$editName, $_POST["commit_msg"]);
-        alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode($editName));
-
-      // Moving or renaming the file
-      } else if ($file && $editName && $editName != $file) {
-        wiki_module::file_save(wiki_module::get_wiki_path().$file, $text);
-        $msg = $_POST["commit_msg"]." (".$file. " -> ".$editName.")";
-        $err = $vcs->mv(wiki_module::get_wiki_path().$file, wiki_module::get_wiki_path().$editName, $msg);
-        $TPL["message_good"][] = "File saved: ".$file;
-        $TPL["file"] = $editName;
-        alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode($editName));
-
-      // Else just regular save
-      } else if ($editName == $file) {
-        wiki_module::file_save(wiki_module::get_wiki_path().$file, $text);
-        $vcs->commit(wiki_module::get_wiki_path().$file, $_POST["commit_msg"]);
-        $TPL["message_good"][] = "File saved: ".$file;
-        $TPL["file"] = $file;
-        $TPL["str"] = $text;
-        $TPL["commit_msg"] = $_POST["commit_msg"];
-        alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode($file));
-      }
-
-    // Else non-vcs save
+        $TPL["loadErrorPage"] = 1;
+        $TPL["str"] = urlencode($_POST["wikitext"]);
+        $TPL["commit_msg"] = urlencode($_POST["commit_msg"]);
+        $TPL["file"] = urlencode($editName);
+        $TPL["msg"] = $error;
+        include_template("templates/wikiM.tpl");
     } else {
-      wiki_module::file_save(wiki_module::get_wiki_path().$editName, $text);
-      $TPL["message_good"][] = "File saved: ".$editName;
-      alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode($editName));
-    }
-  }
+      // If we're using version control
+        if (is_object($vcs)) {
+          // Creating a new file
+            if (!$file) {
+                wiki_module::file_save(wiki_module::get_wiki_path().$editName, $text);
+                $vcs->add(wiki_module::get_wiki_path().$editName);
+                $vcs->commit(wiki_module::get_wiki_path().$editName, $_POST["commit_msg"]);
+                alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode($editName));
 
+              // Moving or renaming the file
+            } else if ($file && $editName && $editName != $file) {
+                wiki_module::file_save(wiki_module::get_wiki_path().$file, $text);
+                $msg = $_POST["commit_msg"]." (".$file. " -> ".$editName.")";
+                $err = $vcs->mv(wiki_module::get_wiki_path().$file, wiki_module::get_wiki_path().$editName, $msg);
+                $TPL["message_good"][] = "File saved: ".$file;
+                $TPL["file"] = $editName;
+                alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode($editName));
+
+              // Else just regular save
+            } else if ($editName == $file) {
+                wiki_module::file_save(wiki_module::get_wiki_path().$file, $text);
+                $vcs->commit(wiki_module::get_wiki_path().$file, $_POST["commit_msg"]);
+                $TPL["message_good"][] = "File saved: ".$file;
+                $TPL["file"] = $file;
+                $TPL["str"] = $text;
+                $TPL["commit_msg"] = $_POST["commit_msg"];
+                alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode($file));
+            }
+
+        // Else non-vcs save
+        } else {
+            wiki_module::file_save(wiki_module::get_wiki_path().$editName, $text);
+            $TPL["message_good"][] = "File saved: ".$editName;
+            alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode($editName));
+        }
+    }
 } else if ($_REQUEST["delete"]) {
+    path_under_path(wiki_module::get_wiki_path().dirname($editName), wiki_module::get_wiki_path()) or $errors[] = "Bad filename: ".$editName;
+    is_writeable(wiki_module::get_wiki_path().dirname($file)) or $errors[] = "Path is not writeable.";
+    strlen($file) or $errors[] = "Filename empty.";
+    $_POST["commit_msg"] and $_POST["commit_msg"].= " ";
+    $_POST["commit_msg"].= "File deleted: ".$file;
 
-  path_under_path(wiki_module::get_wiki_path().dirname($editName), wiki_module::get_wiki_path()) or $errors[] = "Bad filename: ".$editName;
-  is_writeable(wiki_module::get_wiki_path().dirname($file)) or $errors[] = "Path is not writeable.";
-  strlen($file) or $errors[] = "Filename empty.";
-  $_POST["commit_msg"] and $_POST["commit_msg"].= " ";
-  $_POST["commit_msg"].= "File deleted: ".$file;
+    if (!$errors && !is_dir(wiki_module::get_wiki_path().$file)) {
+      // If we're using version control
+        if (is_object($vcs)) {
+            wiki_module::file_delete(wiki_module::get_wiki_path().$file);
+            $vcs->rm(wiki_module::get_wiki_path().$file, $_POST["commit_msg"]);
+            $TPL["message_good"][] = "File deleted: ".$file;
+            $TPL["file"] = $file;
+            $TPL["str"] = $text;
+            $TPL["commit_msg"] = $_POST["commit_msg"];
+            alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode(dirname($file)));
 
-  if (!$errors && !is_dir(wiki_module::get_wiki_path().$file)) {
-    // If we're using version control
-    if (is_object($vcs)) {
-      wiki_module::file_delete(wiki_module::get_wiki_path().$file);
-      $vcs->rm(wiki_module::get_wiki_path().$file, $_POST["commit_msg"]);
-      $TPL["message_good"][] = "File deleted: ".$file;
-      $TPL["file"] = $file;
-      $TPL["str"] = $text;
-      $TPL["commit_msg"] = $_POST["commit_msg"];
-      alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode(dirname($file)));
-
-    // Else non-vcs save
-    } else {
-      wiki_module::file_delete(wiki_module::get_wiki_path().$file);
-      $TPL["message_good"][] = "File deleted: ".$file;
-      alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode(dirname($file)));
+        // Else non-vcs save
+        } else {
+            wiki_module::file_delete(wiki_module::get_wiki_path().$file);
+            $TPL["message_good"][] = "File deleted: ".$file;
+            alloc_redirect($TPL["url_alloc_wiki"]."target=".urlencode(dirname($file)));
+        }
     }
-  }
-
 } else if ($_REQUEST["newFile"]) {
-
-  if ($_REQUEST["p"]) {
-    if (is_file(wiki_module::get_wiki_path().$_REQUEST["p"])) {
-      $_REQUEST["p"] = dirname($_REQUEST["p"]);
-      $_REQUEST["p"] && substr($_REQUEST["p"],-1,1) != DIRECTORY_SEPARATOR and $_REQUEST["p"].="/";
-      $_REQUEST["p"] == ".".DIRECTORY_SEPARATOR and $_REQUEST["p"] = "";
+    if ($_REQUEST["p"]) {
+        if (is_file(wiki_module::get_wiki_path().$_REQUEST["p"])) {
+            $_REQUEST["p"] = dirname($_REQUEST["p"]);
+            $_REQUEST["p"] && substr($_REQUEST["p"], -1, 1) != DIRECTORY_SEPARATOR and $_REQUEST["p"].="/";
+            $_REQUEST["p"] == ".".DIRECTORY_SEPARATOR and $_REQUEST["p"] = "";
+        }
+        $TPL["editName"] = $_REQUEST["p"];
     }
-    $TPL["editName"] = $_REQUEST["p"];
-  }
-  if ($_REQUEST["file"]) {
-    $TPL["editName"] = $_REQUEST["file"];
-  }
-  include_template("templates/fileM.tpl");
-
+    if ($_REQUEST["file"]) {
+        $TPL["editName"] = $_REQUEST["file"];
+    }
+    include_template("templates/fileM.tpl");
 } else if ($file && is_file(wiki_module::get_wiki_path().$file) && is_readable(wiki_module::get_wiki_path().$file)) {
-
-  $TPL['current_path'] = dirname($file);
+    $TPL['current_path'] = dirname($file);
   //dirname may return '.' if there's no dirname, need to get rid of it
-  if ($TPL['current_path'] == '.') {
-    $TPL['current_path'] = '';
-  } else {
-    $TPL['current_path'] .= DIRECTORY_SEPARATOR;
-  }
-  $TPL["editName"] = $file;
-  wiki_module::get_file($file, $_GET["rev"]);
-
+    if ($TPL['current_path'] == '.') {
+        $TPL['current_path'] = '';
+    } else {
+        $TPL['current_path'] .= DIRECTORY_SEPARATOR;
+    }
+    $TPL["editName"] = $file;
+    wiki_module::get_file($file, $_GET["rev"]);
 } else if ($_REQUEST["loadErrorPage"]) {
-  $TPL["loadErrorPage"] = $_REQUEST["loadErrorPage"];
-  $TPL["str"] = $_REQUEST["str"];
-  $TPL["commit_msg"] = $_REQUEST["commit_msg"];
-  $TPL["file"] = $_REQUEST["file"];
-  $TPL["editName"] = $_REQUEST["file"];
-  $TPL["msg"] = $_REQUEST["msg"];
-  include_template("templates/fileGetM.tpl");
+    $TPL["loadErrorPage"] = $_REQUEST["loadErrorPage"];
+    $TPL["str"] = $_REQUEST["str"];
+    $TPL["commit_msg"] = $_REQUEST["commit_msg"];
+    $TPL["file"] = $_REQUEST["file"];
+    $TPL["editName"] = $_REQUEST["file"];
+    $TPL["msg"] = $_REQUEST["msg"];
+    include_template("templates/fileGetM.tpl");
 }
 
 
 $TPL["file"] = $file;
-
-
-?>

--- a/wiki/fileDownload.php
+++ b/wiki/fileDownload.php
@@ -3,39 +3,36 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 $file = realpath(wiki_module::get_wiki_path().$_GET["file"]);
 
 if (path_under_path(dirname($file), wiki_module::get_wiki_path())) {
-  $fp = fopen($file, "rb");
-  $mimetype = get_mimetype($file);
-  $disposition = "attachment";
-  preg_match("/jpe?g|gif|png/i",basename($file)) and $disposition = "inline";
-  header('Content-Type: '.$mimetype);
-  header("Content-Length: ".filesize($file));
-  header('Content-Disposition: '.$disposition.'; filename="'.basename($file).'"');
-  fpassthru($fp);
-  exit;
+    $fp = fopen($file, "rb");
+    $mimetype = get_mimetype($file);
+    $disposition = "attachment";
+    preg_match("/jpe?g|gif|png/i", basename($file)) and $disposition = "inline";
+    header('Content-Type: '.$mimetype);
+    header("Content-Length: ".filesize($file));
+    header('Content-Disposition: '.$disposition.'; filename="'.basename($file).'"');
+    fpassthru($fp);
+    exit;
 }
-
-
-?>

--- a/wiki/fileHistory.php
+++ b/wiki/fileHistory.php
@@ -3,24 +3,24 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 $file = $_GET["file"];
@@ -28,28 +28,23 @@ $rev = $_GET["rev"];
 $pathfile = realpath(wiki_module::get_wiki_path().$file);
 
 if (path_under_path(dirname($pathfile), wiki_module::get_wiki_path())) {
-
   // Check if we're using a VCS
-  $vcs = vcs::get();
+    $vcs = vcs::get();
   #$vcs->debug = true;
-  if (is_object($vcs)) {
-    $logs = $vcs->log($pathfile);
-    $logs = $vcs->format_log($logs);
-    foreach ($logs as $id => $bits) {
-      unset($class);
-      if (is_file($pathfile)) {
-        $rev == $id and $class = "highlighted";
-        !$rev && !$done and $done = $class = "highlighted";
-      }
-      echo "<div class=\"".$class."\" style=\"padding:3px; margin-bottom:10px;\">";
-      is_file($pathfile) and print sprintf("<a href='%starget=%s&rev=%s'>",$TPL["url_alloc_wiki"],urlencode($file),urlencode($id));
-      echo $bits["author"]." ".$bits["date"]."<br>".$bits["msg"];
-      is_file($pathfile) and print "</a>";
-      echo "</div>";
+    if (is_object($vcs)) {
+        $logs = $vcs->log($pathfile);
+        $logs = $vcs->format_log($logs);
+        foreach ($logs as $id => $bits) {
+            unset($class);
+            if (is_file($pathfile)) {
+                $rev == $id and $class = "highlighted";
+                !$rev && !$done and $done = $class = "highlighted";
+            }
+            echo "<div class=\"".$class."\" style=\"padding:3px; margin-bottom:10px;\">";
+            is_file($pathfile) and print sprintf("<a href='%starget=%s&rev=%s'>", $TPL["url_alloc_wiki"], urlencode($file), urlencode($id));
+            echo $bits["author"]." ".$bits["date"]."<br>".$bits["msg"];
+            is_file($pathfile) and print "</a>";
+            echo "</div>";
+        }
     }
-  
-  }
-
 }
-
-?>

--- a/wiki/filePreview.php
+++ b/wiki/filePreview.php
@@ -3,31 +3,28 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 $wikiMarkup = config::get_config_item("wikiMarkup");
 $str = '<div class="wikidoc" style="margin:10px 0px; padding:10px 30px 20px 30px;"><h1 style="text-align:center">[ Preview ]</h1>';
-$str.= $wikiMarkup($_REQUEST["data"]); 
+$str.= $wikiMarkup($_REQUEST["data"]);
 $str.= '</div>';
 echo $str;
-
-
-?>

--- a/wiki/fileTree.php
+++ b/wiki/fileTree.php
@@ -3,63 +3,61 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-define("NO_REDIRECT",1);
+define("NO_REDIRECT", 1);
 require_once("../alloc.php");
 
 $dont_print_these_dirs = array(".","..","CVS",".hg",".bzr","_darcs",".git");
 
 
 // relative path
-$DIR = urldecode($_POST['dir']);                                                       
+$DIR = urldecode($_POST['dir']);
 
 // full path
-$PATH = realpath(wiki_module::get_wiki_path().$DIR).DIRECTORY_SEPARATOR; 
+$PATH = realpath(wiki_module::get_wiki_path().$DIR).DIRECTORY_SEPARATOR;
 
 if (path_under_path($PATH, wiki_module::get_wiki_path()) && is_dir($PATH)) {
-  $files = scandir($PATH);
-  natcasesort($files);
-  $str.= "\n<ul class=\"jqueryFileTree\" style=\"display: none;\">";
+    $files = scandir($PATH);
+    natcasesort($files);
+    $str.= "\n<ul class=\"jqueryFileTree\" style=\"display: none;\">";
   // All dirs
-  foreach ($files as $file) {
-    if(!in_array($file, $dont_print_these_dirs) && is_dir($PATH.$file) ) {
-      $str.= "\n  <li class=\"directory collapsed\"><a class=\"file\" href=\"#\" rel=\"".page::htmlentities($DIR.$file.DIRECTORY_SEPARATOR)."\">".page::htmlentities($file)."</a></li>";
+    foreach ($files as $file) {
+        if (!in_array($file, $dont_print_these_dirs) && is_dir($PATH.$file)) {
+            $str.= "\n  <li class=\"directory collapsed\"><a class=\"file\" href=\"#\" rel=\"".page::htmlentities($DIR.$file.DIRECTORY_SEPARATOR)."\">".page::htmlentities($file)."</a></li>";
+        }
     }
-  }
 
   // All files
-  foreach($files as $file) {
-    if(file_exists($PATH.$file) && $file != '.' && $file != '..' && !is_dir($PATH.$file) && is_readable($PATH.$file)) {
-      unset($extra);
-      !is_writable($PATH.$file) and $extra = "(ro) ";
-      $ext = strtolower(preg_replace('/^.*\./', '', $file));
-      $str.= "\n  <li class=\"file ext_$ext nobr\">";
-      $str.= "\n    <a style=\"position:relative;\" class=\"file nobr\" href=\"#x\" rel=\"".page::htmlentities($DIR.$file)."\">".page::htmlentities($file);
-      $str.= "<div class='faint nobr' style='top:0px; position:absolute;'>".$extra.get_filesize_label($PATH.$file)."</div></a>";
-      $str.= "\n  </li>";
+    foreach ($files as $file) {
+        if (file_exists($PATH.$file) && $file != '.' && $file != '..' && !is_dir($PATH.$file) && is_readable($PATH.$file)) {
+            unset($extra);
+            !is_writable($PATH.$file) and $extra = "(ro) ";
+            $ext = strtolower(preg_replace('/^.*\./', '', $file));
+            $str.= "\n  <li class=\"file ext_$ext nobr\">";
+            $str.= "\n    <a style=\"position:relative;\" class=\"file nobr\" href=\"#x\" rel=\"".page::htmlentities($DIR.$file)."\">".page::htmlentities($file);
+            $str.= "<div class='faint nobr' style='top:0px; position:absolute;'>".$extra.get_filesize_label($PATH.$file)."</div></a>";
+            $str.= "\n  </li>";
+        }
     }
-  }
-  $str.= "\n</ul>";	
+    $str.= "\n</ul>";
 
   #echo "<pre>".page::htmlentities($str)."</pre>";
-  echo $str;
+    echo $str;
 }
-
-?>

--- a/wiki/lib/init.php
+++ b/wiki/lib/init.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -24,142 +24,141 @@
 require_once(dirname(__FILE__)."/markdown.inc.php");
 
 
-class wiki_module extends module {
-  var $module = "wiki";
+class wiki_module extends module
+{
+    var $module = "wiki";
 
-  function get_wiki_path() {
-    return realpath(ATTACHMENTS_DIR."wiki").DIRECTORY_SEPARATOR;
-  }
-
-  function file_save($file,$body) {
-    if (is_dir(dirname($file)) && path_under_path(dirname($file), wiki_module::get_wiki_path())) {
-      // Save the file ...
-      $handle = fopen($file,"w+b");
-      fputs($handle,$body);
-      fclose($handle);
-
-      // Update the search index for this file, if any
-      $index = Zend_Search_Lucene::open(ATTACHMENTS_DIR.'search/wiki');
-      $f = str_replace(wiki_module::get_wiki_path(),"",$file);
-      $hits = $index->find('id:' . $f);
-      foreach ($hits as $hit) {
-        $index->delete($hit->id);
-      }
-      wiki_module::update_search_index_doc($index,$f);
-      $index->commit();
+    function get_wiki_path()
+    {
+        return realpath(ATTACHMENTS_DIR."wiki").DIRECTORY_SEPARATOR;
     }
-  }
 
-  function file_delete($file) {
-    // remove the file, and remove the search index info for the file
-    if (is_dir(dirname($file)) && path_under_path(dirname($file), wiki_module::get_wiki_path())) {
+    function file_save($file, $body)
+    {
+        if (is_dir(dirname($file)) && path_under_path(dirname($file), wiki_module::get_wiki_path())) {
+          // Save the file ...
+            $handle = fopen($file, "w+b");
+            fputs($handle, $body);
+            fclose($handle);
 
-      // remove the file
-      if (file_exists($file)) {
-        unlink($file);
-      }
-
-      // Update the search index for this file, if any
-      $index = Zend_Search_Lucene::open(ATTACHMENTS_DIR.'search/wiki');
-      $f = str_replace(wiki_module::get_wiki_path(),"",$file);
-      $hits = $index->find('id:' . $f);
-      foreach ($hits as $hit) {
-        $index->delete($hit->id);
-      }
-      $index->commit();
+          // Update the search index for this file, if any
+            $index = Zend_Search_Lucene::open(ATTACHMENTS_DIR.'search/wiki');
+            $f = str_replace(wiki_module::get_wiki_path(), "", $file);
+            $hits = $index->find('id:' . $f);
+            foreach ($hits as $hit) {
+                $index->delete($hit->id);
+            }
+            wiki_module::update_search_index_doc($index, $f);
+            $index->commit();
+        }
     }
-  }
 
-  function nuke_trailing_spaces_from_all_lines($str) {
-    // for some reason trailing slashes on a line appear to not get saved by
-    // particular vcs's. So when we compare the two files (the one on disk and
-    // the one in version control, we need to nuke trailing spaces, from every
-    // line.
-    $lines or $lines = array();
-    $str = str_replace("\r\n","\n",$str);
-    $bits = explode("\n",$str);
-    foreach($bits as $line) {
-      $lines[] = rtrim($line);
+    function file_delete($file)
+    {
+      // remove the file, and remove the search index info for the file
+        if (is_dir(dirname($file)) && path_under_path(dirname($file), wiki_module::get_wiki_path())) {
+          // remove the file
+            if (file_exists($file)) {
+                unlink($file);
+            }
+
+          // Update the search index for this file, if any
+            $index = Zend_Search_Lucene::open(ATTACHMENTS_DIR.'search/wiki');
+            $f = str_replace(wiki_module::get_wiki_path(), "", $file);
+            $hits = $index->find('id:' . $f);
+            foreach ($hits as $hit) {
+                $index->delete($hit->id);
+            }
+            $index->commit();
+        }
     }
-    return rtrim(implode("\n",$lines));
-  }
 
-  function get_file($file, $rev="") {
-    global $TPL;
+    function nuke_trailing_spaces_from_all_lines($str)
+    {
+      // for some reason trailing slashes on a line appear to not get saved by
+      // particular vcs's. So when we compare the two files (the one on disk and
+      // the one in version control, we need to nuke trailing spaces, from every
+      // line.
+        $lines or $lines = array();
+        $str = str_replace("\r\n", "\n", $str);
+        $bits = explode("\n", $str);
+        foreach ($bits as $line) {
+            $lines[] = rtrim($line);
+        }
+        return rtrim(implode("\n", $lines));
+    }
 
-    $f = realpath(wiki_module::get_wiki_path().$file);
+    function get_file($file, $rev = "")
+    {
+        global $TPL;
 
-    if (path_under_path(dirname($f), wiki_module::get_wiki_path())) {
+        $f = realpath(wiki_module::get_wiki_path().$file);
 
-      $mt = get_mimetype($f);
-      if (strtolower($mt) != "text/plain") {
-        $s = "<h6>Download File</h6>";
-        $s.= "<a href='".$TPL["url_alloc_fileDownload"]."file=".urlencode($file)."'>".$file."</a>";
-        $TPL["str_html"] = $s;
-        include_template("templates/fileGetM.tpl");
-        exit();
-      }
+        if (path_under_path(dirname($f), wiki_module::get_wiki_path())) {
+            $mt = get_mimetype($f);
+            if (strtolower($mt) != "text/plain") {
+                $s = "<h6>Download File</h6>";
+                $s.= "<a href='".$TPL["url_alloc_fileDownload"]."file=".urlencode($file)."'>".$file."</a>";
+                $TPL["str_html"] = $s;
+                include_template("templates/fileGetM.tpl");
+                exit();
+            }
 
-      // Get the regular revision ...
-      $disk_file = file_get_contents($f) or $disk_file = "";
+          // Get the regular revision ...
+            $disk_file = file_get_contents($f) or $disk_file = "";
 
-      $vcs = vcs::get();
-      //$vcs->debug = true;
+            $vcs = vcs::get();
+          //$vcs->debug = true;
 
-      // Get a particular revision
-      if ($vcs) {
-        $vcs_file = $vcs->cat($f, $rev);
-      }
+          // Get a particular revision
+            if ($vcs) {
+                $vcs_file = $vcs->cat($f, $rev);
+            }
 
-      if ($vcs && wiki_module::nuke_trailing_spaces_from_all_lines($disk_file) != wiki_module::nuke_trailing_spaces_from_all_lines($vcs_file)) {
-
-        if (!$vcs_file) {
-          $TPL["msg"] = "<div class='message warn noprint' style='margin-top:0px; margin-bottom:10px; padding:10px;'>
+            if ($vcs && wiki_module::nuke_trailing_spaces_from_all_lines($disk_file) != wiki_module::nuke_trailing_spaces_from_all_lines($vcs_file)) {
+                if (!$vcs_file) {
+                    $TPL["msg"] = "<div class='message warn noprint' style='margin-top:0px; margin-bottom:10px; padding:10px;'>
                           Warning: This file may not be under version control.
                          </div>";
-        } else {
-          $TPL["msg"] = "<div class='message warn noprint' style='margin-top:0px; margin-bottom:10px; padding:10px;'>
+                } else {
+                    $TPL["msg"] = "<div class='message warn noprint' style='margin-top:0px; margin-bottom:10px; padding:10px;'>
                           Warning: This file may not be the latest version.
                          </div>";
+                }
+            }
+
+            if ($rev && $vcs_file) {
+                $TPL["str"] = $vcs_file;
+            } else {
+                $TPL["str"] = $disk_file;
+            }
+
+            $wikiMarkup = config::get_config_item("wikiMarkup");
+            $TPL["str_html"] = $wikiMarkup($TPL["str"]);
+            $TPL["rev"] = urlencode($rev);
+
+            include_template("templates/fileGetM.tpl");
         }
-      }
-
-      if ($rev && $vcs_file) {
-        $TPL["str"] = $vcs_file;
-      } else {
-        $TPL["str"] = $disk_file;
-      }
-
-      $wikiMarkup = config::get_config_item("wikiMarkup");
-      $TPL["str_html"] = $wikiMarkup($TPL["str"]);
-      $TPL["rev"] = urlencode($rev);
-
-      include_template("templates/fileGetM.tpl");
-    }
-  }
-
-  function update_search_index_doc(&$index, $file) {
-    // Attempt to parse pdfs
-    if (strtolower(substr($file,-4)) == ".pdf") {
-      $pdfstr = file_get_contents(wiki_module::get_wiki_path().$file);
-      $pdf_reader = new pdf_reader();
-      $pdfstr = $pdf_reader->pdf2txt($pdfstr);
-
-    // Else regular text
-    } else {
-      $str = file_get_contents(wiki_module::get_wiki_path().$file);
     }
 
-    $doc = new Zend_Search_Lucene_Document();
-    $doc->addField(Zend_Search_Lucene_Field::Keyword('id'   ,$file));
-    $doc->addField(Zend_Search_Lucene_Field::Text('name'    ,$file,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::Text('desc'    ,$str,"utf-8"));
-    $doc->addField(Zend_Search_Lucene_Field::UnStored('pdfstr',$pdfstr,"utf-8"));
-    $index->addDocument($doc);
-  }
+    function update_search_index_doc(&$index, $file)
+    {
+      // Attempt to parse pdfs
+        if (strtolower(substr($file, -4)) == ".pdf") {
+            $pdfstr = file_get_contents(wiki_module::get_wiki_path().$file);
+            $pdf_reader = new pdf_reader();
+            $pdfstr = $pdf_reader->pdf2txt($pdfstr);
+
+        // Else regular text
+        } else {
+            $str = file_get_contents(wiki_module::get_wiki_path().$file);
+        }
+
+        $doc = new Zend_Search_Lucene_Document();
+        $doc->addField(Zend_Search_Lucene_Field::Keyword('id', $file));
+        $doc->addField(Zend_Search_Lucene_Field::Text('name', $file, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::Text('desc', $str, "utf-8"));
+        $doc->addField(Zend_Search_Lucene_Field::UnStored('pdfstr', $pdfstr, "utf-8"));
+        $index->addDocument($doc);
+    }
 }
-
-
-
-
-?>

--- a/wiki/lib/markdown.inc.php
+++ b/wiki/lib/markdown.inc.php
@@ -3,16 +3,16 @@
 # Markdown  -  A text-to-HTML conversion tool for web writers
 #
 # PHP Markdown
-# Copyright (c) 2004-2009 Michel Fortin  
+# Copyright (c) 2004-2009 Michel Fortin
 # <http://michelf.com/projects/php-markdown/>
 #
 # Original Markdown
-# Copyright (c) 2004-2006 John Gruber  
+# Copyright (c) 2004-2006 John Gruber
 # <http://daringfireball.net/projects/markdown/>
 #
 
 
-define( 'MARKDOWN_VERSION',  "1.0.1n" ); # Sat 10 Oct 2009
+define('MARKDOWN_VERSION', "1.0.1n"); # Sat 10 Oct 2009
 
 
 #
@@ -20,10 +20,10 @@ define( 'MARKDOWN_VERSION',  "1.0.1n" ); # Sat 10 Oct 2009
 #
 
 # Change to ">" for HTML output
-@define( 'MARKDOWN_EMPTY_ELEMENT_SUFFIX',  " />");
+@define('MARKDOWN_EMPTY_ELEMENT_SUFFIX', " />");
 
 # Define the width of a tab for code blocks.
-@define( 'MARKDOWN_TAB_WIDTH',     4 );
+@define('MARKDOWN_TAB_WIDTH', 4);
 
 
 #
@@ -31,28 +31,29 @@ define( 'MARKDOWN_VERSION',  "1.0.1n" ); # Sat 10 Oct 2009
 #
 
 # Change to false to remove Markdown from posts and/or comments.
-@define( 'MARKDOWN_WP_POSTS',      true );
-@define( 'MARKDOWN_WP_COMMENTS',   true );
+@define('MARKDOWN_WP_POSTS', true);
+@define('MARKDOWN_WP_COMMENTS', true);
 
 
 
 ### Standard Function Interface ###
 
-@define( 'MARKDOWN_PARSER_CLASS',  'Markdown_Parser' );
+@define('MARKDOWN_PARSER_CLASS', 'Markdown_Parser');
 
-function Markdown($text) {
+function Markdown($text)
+{
 #
 # Initialize the parser and return the result of its transform method.
 #
-	# Setup static parser variable.
-	static $parser;
-	if (!isset($parser)) {
-		$parser_class = MARKDOWN_PARSER_CLASS;
-		$parser = new $parser_class;
-	}
+    # Setup static parser variable.
+    static $parser;
+    if (!isset($parser)) {
+        $parser_class = MARKDOWN_PARSER_CLASS;
+        $parser = new $parser_class;
+    }
 
-	# Transform text using parser.
-	return $parser->transform($text);
+    # Transform text using parser.
+    return $parser->transform($text);
 }
 
 
@@ -60,146 +61,153 @@ function Markdown($text) {
 # Markdown Parser Class
 #
 
-class Markdown_Parser {
+class Markdown_Parser
+{
 
-	# Regex to match balanced [brackets].
-	# Needed to insert a maximum bracked depth while converting to PHP.
-	var $nested_brackets_depth = 6;
-	var $nested_brackets_re;
-	
-	var $nested_url_parenthesis_depth = 4;
-	var $nested_url_parenthesis_re;
+    # Regex to match balanced [brackets].
+    # Needed to insert a maximum bracked depth while converting to PHP.
+    var $nested_brackets_depth = 6;
+    var $nested_brackets_re;
+    
+    var $nested_url_parenthesis_depth = 4;
+    var $nested_url_parenthesis_re;
 
-	# Table of hash values for escaped characters:
-	var $escape_chars = '\`*_{}[]()>#+-.!';
-	var $escape_chars_re;
+    # Table of hash values for escaped characters:
+    var $escape_chars = '\`*_{}[]()>#+-.!';
+    var $escape_chars_re;
 
-	# Change to ">" for HTML output.
-	var $empty_element_suffix = MARKDOWN_EMPTY_ELEMENT_SUFFIX;
-	var $tab_width = MARKDOWN_TAB_WIDTH;
-	
-	# Change to `true` to disallow markup or entities.
-	var $no_markup = true;
-	var $no_entities = true;
-	
-	# Predefined urls and titles for reference links and images.
-	var $predef_urls = array();
-	var $predef_titles = array();
-
-
-	function Markdown_Parser() {
-	#
-	# Constructor function. Initialize appropriate member variables.
-	#
-		$this->_initDetab();
-		$this->prepareItalicsAndBold();
-	
-		$this->nested_brackets_re = 
-			str_repeat('(?>[^\[\]]+|\[', $this->nested_brackets_depth).
-			str_repeat('\])*', $this->nested_brackets_depth);
-	
-		$this->nested_url_parenthesis_re = 
-			str_repeat('(?>[^()\s]+|\(', $this->nested_url_parenthesis_depth).
-			str_repeat('(?>\)))*', $this->nested_url_parenthesis_depth);
-		
-		$this->escape_chars_re = '['.preg_quote($this->escape_chars).']';
-		
-		# Sort document, block, and span gamut in ascendent priority order.
-		asort($this->document_gamut);
-		asort($this->block_gamut);
-		asort($this->span_gamut);
-	}
+    # Change to ">" for HTML output.
+    var $empty_element_suffix = MARKDOWN_EMPTY_ELEMENT_SUFFIX;
+    var $tab_width = MARKDOWN_TAB_WIDTH;
+    
+    # Change to `true` to disallow markup or entities.
+    var $no_markup = true;
+    var $no_entities = true;
+    
+    # Predefined urls and titles for reference links and images.
+    var $predef_urls = array();
+    var $predef_titles = array();
 
 
-	# Internal hashes used during transformation.
-	var $urls = array();
-	var $titles = array();
-	var $html_hashes = array();
-	
-	# Status flag to avoid invalid nesting.
-	var $in_anchor = false;
-	
-	
-	function setup() {
-	#
-	# Called before the transformation process starts to setup parser 
-	# states.
-	#
-		# Clear global hashes.
-		$this->urls = $this->predef_urls;
-		$this->titles = $this->predef_titles;
-		$this->html_hashes = array();
-		
-		$in_anchor = false;
-	}
-	
-	function teardown() {
-	#
-	# Called after the transformation process to clear any variable 
-	# which may be taking up memory unnecessarly.
-	#
-		$this->urls = array();
-		$this->titles = array();
-		$this->html_hashes = array();
-	}
+    function Markdown_Parser()
+    {
+    #
+    # Constructor function. Initialize appropriate member variables.
+    #
+        $this->_initDetab();
+        $this->prepareItalicsAndBold();
+    
+        $this->nested_brackets_re =
+            str_repeat('(?>[^\[\]]+|\[', $this->nested_brackets_depth).
+            str_repeat('\])*', $this->nested_brackets_depth);
+    
+        $this->nested_url_parenthesis_re =
+            str_repeat('(?>[^()\s]+|\(', $this->nested_url_parenthesis_depth).
+            str_repeat('(?>\)))*', $this->nested_url_parenthesis_depth);
+        
+        $this->escape_chars_re = '['.preg_quote($this->escape_chars).']';
+        
+        # Sort document, block, and span gamut in ascendent priority order.
+        asort($this->document_gamut);
+        asort($this->block_gamut);
+        asort($this->span_gamut);
+    }
 
 
-	function transform($text) {
-	#
-	# Main function. Performs some preprocessing on the input text
-	# and pass it through the document gamut.
-	#
-		$this->setup();
-	
-		# Remove UTF-8 BOM and marker character in input, if present.
-		$text = preg_replace('{^\xEF\xBB\xBF|\x1A}', '', $text);
-
-		# Standardize line endings:
-		#   DOS to Unix and Mac to Unix
-		$text = preg_replace('{\r\n?}', "\n", $text);
-
-		# Make sure $text ends with a couple of newlines:
-		$text .= "\n\n";
-
-		# Convert all tabs to spaces.
-		$text = $this->detab($text);
-
-		# Turn block-level HTML blocks into hash entries
-		$text = $this->hashHTMLBlocks($text);
-
-		# Strip any lines consisting only of spaces and tabs.
-		# This makes subsequent regexen easier to write, because we can
-		# match consecutive blank lines with /\n+/ instead of something
-		# contorted like /[ ]*\n+/ .
-		$text = preg_replace('/^[ ]+$/m', '', $text);
-
-		# Run document gamut methods.
-		foreach ($this->document_gamut as $method => $priority) {
-			$text = $this->$method($text);
-		}
-		
-		$this->teardown();
-
-		return $text . "\n";
-	}
-	
-	var $document_gamut = array(
-		# Strip link definitions, store in hashes.
-		"stripLinkDefinitions" => 20,
-		
-		"runBasicBlockGamut"   => 30,
-		);
+    # Internal hashes used during transformation.
+    var $urls = array();
+    var $titles = array();
+    var $html_hashes = array();
+    
+    # Status flag to avoid invalid nesting.
+    var $in_anchor = false;
+    
+    
+    function setup()
+    {
+    #
+    # Called before the transformation process starts to setup parser
+    # states.
+    #
+        # Clear global hashes.
+        $this->urls = $this->predef_urls;
+        $this->titles = $this->predef_titles;
+        $this->html_hashes = array();
+        
+        $in_anchor = false;
+    }
+    
+    function teardown()
+    {
+    #
+    # Called after the transformation process to clear any variable
+    # which may be taking up memory unnecessarly.
+    #
+        $this->urls = array();
+        $this->titles = array();
+        $this->html_hashes = array();
+    }
 
 
-	function stripLinkDefinitions($text) {
-	#
-	# Strips link definitions from text, stores the URLs and titles in
-	# hash references.
-	#
-		$less_than_tab = $this->tab_width - 1;
+    function transform($text)
+    {
+    #
+    # Main function. Performs some preprocessing on the input text
+    # and pass it through the document gamut.
+    #
+        $this->setup();
+    
+        # Remove UTF-8 BOM and marker character in input, if present.
+        $text = preg_replace('{^\xEF\xBB\xBF|\x1A}', '', $text);
 
-		# Link defs are in the form: ^[id]: url "optional title"
-		$text = preg_replace_callback('{
+        # Standardize line endings:
+        #   DOS to Unix and Mac to Unix
+        $text = preg_replace('{\r\n?}', "\n", $text);
+
+        # Make sure $text ends with a couple of newlines:
+        $text .= "\n\n";
+
+        # Convert all tabs to spaces.
+        $text = $this->detab($text);
+
+        # Turn block-level HTML blocks into hash entries
+        $text = $this->hashHTMLBlocks($text);
+
+        # Strip any lines consisting only of spaces and tabs.
+        # This makes subsequent regexen easier to write, because we can
+        # match consecutive blank lines with /\n+/ instead of something
+        # contorted like /[ ]*\n+/ .
+        $text = preg_replace('/^[ ]+$/m', '', $text);
+
+        # Run document gamut methods.
+        foreach ($this->document_gamut as $method => $priority) {
+            $text = $this->$method($text);
+        }
+        
+        $this->teardown();
+
+        return $text . "\n";
+    }
+    
+    var $document_gamut = array(
+        # Strip link definitions, store in hashes.
+        "stripLinkDefinitions" => 20,
+        
+        "runBasicBlockGamut"   => 30,
+        );
+
+
+    function stripLinkDefinitions($text)
+    {
+    #
+    # Strips link definitions from text, stores the URLs and titles in
+    # hash references.
+    #
+        $less_than_tab = $this->tab_width - 1;
+
+        # Link defs are in the form: ^[id]: url "optional title"
+        $text = preg_replace_callback(
+            '{
 							^[ ]{0,'.$less_than_tab.'}\[(.+)\][ ]?:	# id = $1
 							  [ ]*
 							  \n?				# maybe *one* newline
@@ -221,45 +229,50 @@ class Markdown_Parser {
 							)?	# title is optional
 							(?:\n+|\Z)
 			}xm',
-			array(&$this, '_stripLinkDefinitions_callback'),
-			$text);
-		return $text;
-	}
-	function _stripLinkDefinitions_callback($matches) {
-		$link_id = strtolower($matches[1]);
-		$url = $matches[2] == '' ? $matches[3] : $matches[2];
-    $url = str_ireplace("javascript:","",$url); // added by alla
-		$this->urls[$link_id] = $url;
-		$this->titles[$link_id] =& $matches[4];
-		return ''; # String that will replace the block
-	}
+            array(&$this, '_stripLinkDefinitions_callback'),
+            $text
+        );
+        return $text;
+    }
+    function _stripLinkDefinitions_callback($matches)
+    {
+        $link_id = strtolower($matches[1]);
+        $url = $matches[2] == '' ? $matches[3] : $matches[2];
+        $url = str_ireplace("javascript:", "", $url); // added by alla
+        $this->urls[$link_id] = $url;
+        $this->titles[$link_id] =& $matches[4];
+        return ''; # String that will replace the block
+    }
 
 
-	function hashHTMLBlocks($text) {
-		if ($this->no_markup)  return $text;
+    function hashHTMLBlocks($text)
+    {
+        if ($this->no_markup) {
+            return $text;
+        }
 
-		$less_than_tab = $this->tab_width - 1;
+        $less_than_tab = $this->tab_width - 1;
 
-		# Hashify HTML blocks:
-		# We only want to do this for block-level HTML tags, such as headers,
-		# lists, and tables. That's because we still want to wrap <p>s around
-		# "paragraphs" that are wrapped in non-block-level tags, such as anchors,
-		# phrase emphasis, and spans. The list of tags we're looking for is
-		# hard-coded:
-		#
-		# *  List "a" is made of tags which can be both inline or block-level.
-		#    These will be treated block-level when the start tag is alone on 
-		#    its line, otherwise they're not matched here and will be taken as 
-		#    inline later.
-		# *  List "b" is made of tags which are always block-level;
-		#
-		$block_tags_a_re = 'ins|del';
-		$block_tags_b_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|'.
-						   'script|noscript|form|fieldset|iframe|math';
+        # Hashify HTML blocks:
+        # We only want to do this for block-level HTML tags, such as headers,
+        # lists, and tables. That's because we still want to wrap <p>s around
+        # "paragraphs" that are wrapped in non-block-level tags, such as anchors,
+        # phrase emphasis, and spans. The list of tags we're looking for is
+        # hard-coded:
+        #
+        # *  List "a" is made of tags which can be both inline or block-level.
+        #    These will be treated block-level when the start tag is alone on
+        #    its line, otherwise they're not matched here and will be taken as
+        #    inline later.
+        # *  List "b" is made of tags which are always block-level;
+        #
+        $block_tags_a_re = 'ins|del';
+        $block_tags_b_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|'.
+                           'script|noscript|form|fieldset|iframe|math';
 
-		# Regular expression for the content of a block tag.
-		$nested_tags_level = 4;
-		$attr = '
+        # Regular expression for the content of a block tag.
+        $nested_tags_level = 4;
+        $attr = '
 			(?>				# optional tag attributes
 			  \s			# starts with whitespace
 			  (?>
@@ -273,8 +286,8 @@ class Markdown_Parser {
 			  )*
 			)?	
 			';
-		$content =
-			str_repeat('
+        $content =
+            str_repeat('
 				(?>
 				  [^<]+			# content without tag
 				|
@@ -283,30 +296,33 @@ class Markdown_Parser {
 					(?>
 					  />
 					|
-					  >', $nested_tags_level).	# end of opening tag
-					  '.*?'.					# last level nested tag content
-			str_repeat('
+					  >', $nested_tags_level).  # end of opening tag
+                      '.*?'.                    # last level nested tag content
+            str_repeat(
+                '
 					  </\2\s*>	# closing nested tag
 					)
 				  |				
 					<(?!/\2\s*>	# other tags with a different name
 				  )
 				)*',
-				$nested_tags_level);
-		$content2 = str_replace('\2', '\3', $content);
+                $nested_tags_level
+            );
+        $content2 = str_replace('\2', '\3', $content);
 
-		# First, look for nested blocks, e.g.:
-		# 	<div>
-		# 		<div>
-		# 		tags for inner block must be indented.
-		# 		</div>
-		# 	</div>
-		#
-		# The outermost tags must start at the left margin for this to match, and
-		# the inner nested divs must be indented.
-		# We need to do this before the next, more liberal match, because the next
-		# match will start at the first `<div>` and stop at the first `</div>`.
-		$text = preg_replace_callback('{(?>
+        # First, look for nested blocks, e.g.:
+        #   <div>
+        #       <div>
+        #       tags for inner block must be indented.
+        #       </div>
+        #   </div>
+        #
+        # The outermost tags must start at the left margin for this to match, and
+        # the inner nested divs must be indented.
+        # We need to do this before the next, more liberal match, because the next
+        # match will start at the first `<div>` and stop at the first `</div>`.
+        $text = preg_replace_callback(
+            '{(?>
 			(?>
 				(?<=\n\n)		# Starting after a blank line
 				|				# or
@@ -367,97 +383,104 @@ class Markdown_Parser {
 					
 			)
 			)}Sxmi',
-			array(&$this, '_hashHTMLBlocks_callback'),
-			$text);
+            array(&$this, '_hashHTMLBlocks_callback'),
+            $text
+        );
 
-		return $text;
-	}
-	function _hashHTMLBlocks_callback($matches) {
-		$text = $matches[1];
-		$key  = $this->hashBlock($text);
-		return "\n\n$key\n\n";
-	}
-	
-	
-	function hashPart($text, $boundary = 'X') {
-	#
-	# Called whenever a tag must be hashed when a function insert an atomic 
-	# element in the text stream. Passing $text to through this function gives
-	# a unique text-token which will be reverted back when calling unhash.
-	#
-	# The $boundary argument specify what character should be used to surround
-	# the token. By convension, "B" is used for block elements that needs not
-	# to be wrapped into paragraph tags at the end, ":" is used for elements
-	# that are word separators and "X" is used in the general case.
-	#
-		# Swap back any tag hash found in $text so we do not have to `unhash`
-		# multiple times at the end.
-		$text = $this->unhash($text);
-		
-		# Then hash the block.
-		static $i = 0;
-		$key = "$boundary\x1A" . ++$i . $boundary;
-		$this->html_hashes[$key] = $text;
-		return $key; # String that will replace the tag.
-	}
-
-
-	function hashBlock($text) {
-	#
-	# Shortcut function for hashPart with block-level boundaries.
-	#
-		return $this->hashPart($text, 'B');
-	}
+        return $text;
+    }
+    function _hashHTMLBlocks_callback($matches)
+    {
+        $text = $matches[1];
+        $key  = $this->hashBlock($text);
+        return "\n\n$key\n\n";
+    }
+    
+    
+    function hashPart($text, $boundary = 'X')
+    {
+    #
+    # Called whenever a tag must be hashed when a function insert an atomic
+    # element in the text stream. Passing $text to through this function gives
+    # a unique text-token which will be reverted back when calling unhash.
+    #
+    # The $boundary argument specify what character should be used to surround
+    # the token. By convension, "B" is used for block elements that needs not
+    # to be wrapped into paragraph tags at the end, ":" is used for elements
+    # that are word separators and "X" is used in the general case.
+    #
+        # Swap back any tag hash found in $text so we do not have to `unhash`
+        # multiple times at the end.
+        $text = $this->unhash($text);
+        
+        # Then hash the block.
+        static $i = 0;
+        $key = "$boundary\x1A" . ++$i . $boundary;
+        $this->html_hashes[$key] = $text;
+        return $key; # String that will replace the tag.
+    }
 
 
-	var $block_gamut = array(
-	#
-	# These are all the transformations that form block-level
-	# tags like paragraphs, headers, and list items.
-	#
-		"doHeaders"         => 10,
-		"doHorizontalRules" => 20,
-		
-		"doLists"           => 40,
-		"doCodeBlocks"      => 50,
-		"doBlockQuotes"     => 60,
-		);
+    function hashBlock($text)
+    {
+    #
+    # Shortcut function for hashPart with block-level boundaries.
+    #
+        return $this->hashPart($text, 'B');
+    }
 
-	function runBlockGamut($text) {
-	#
-	# Run block gamut tranformations.
-	#
-		# We need to escape raw HTML in Markdown source before doing anything 
-		# else. This need to be done for each block, and not only at the 
-		# begining in the Markdown function since hashed blocks can be part of
-		# list items and could have been indented. Indented blocks would have 
-		# been seen as a code block in a previous pass of hashHTMLBlocks.
-		$text = $this->hashHTMLBlocks($text);
-		
-		return $this->runBasicBlockGamut($text);
-	}
-	
-	function runBasicBlockGamut($text) {
-	#
-	# Run block gamut tranformations, without hashing HTML blocks. This is 
-	# useful when HTML blocks are known to be already hashed, like in the first
-	# whole-document pass.
-	#
-		foreach ($this->block_gamut as $method => $priority) {
-			$text = $this->$method($text);
-		}
-		
-		# Finally form paragraph and restore hashed blocks.
-		$text = $this->formParagraphs($text);
 
-		return $text;
-	}
-	
-	
-	function doHorizontalRules($text) {
-		# Do Horizontal Rules:
-		return preg_replace(
-			'{
+    var $block_gamut = array(
+    #
+    # These are all the transformations that form block-level
+    # tags like paragraphs, headers, and list items.
+    #
+        "doHeaders"         => 10,
+        "doHorizontalRules" => 20,
+        
+        "doLists"           => 40,
+        "doCodeBlocks"      => 50,
+        "doBlockQuotes"     => 60,
+        );
+
+    function runBlockGamut($text)
+    {
+    #
+    # Run block gamut tranformations.
+    #
+        # We need to escape raw HTML in Markdown source before doing anything
+        # else. This need to be done for each block, and not only at the
+        # begining in the Markdown function since hashed blocks can be part of
+        # list items and could have been indented. Indented blocks would have
+        # been seen as a code block in a previous pass of hashHTMLBlocks.
+        $text = $this->hashHTMLBlocks($text);
+        
+        return $this->runBasicBlockGamut($text);
+    }
+    
+    function runBasicBlockGamut($text)
+    {
+    #
+    # Run block gamut tranformations, without hashing HTML blocks. This is
+    # useful when HTML blocks are known to be already hashed, like in the first
+    # whole-document pass.
+    #
+        foreach ($this->block_gamut as $method => $priority) {
+            $text = $this->$method($text);
+        }
+        
+        # Finally form paragraph and restore hashed blocks.
+        $text = $this->formParagraphs($text);
+
+        return $text;
+    }
+    
+    
+    function doHorizontalRules($text)
+    {
+        # Do Horizontal Rules:
+        return preg_replace(
+            '{
 				^[ ]{0,3}	# Leading space
 				([-*_])		# $1: First marker
 				(?>			# Repeated marker group
@@ -467,104 +490,120 @@ class Markdown_Parser {
 				[ ]*		# Tailing spaces
 				$			# End of line.
 			}mx',
-			"\n".$this->hashBlock("<hr$this->empty_element_suffix")."\n", 
-			$text);
-	}
+            "\n".$this->hashBlock("<hr$this->empty_element_suffix")."\n",
+            $text
+        );
+    }
 
 
-	var $span_gamut = array(
-	#
-	# These are all the transformations that occur *within* block-level
-	# tags like paragraphs, headers, and list items.
-	#
+    var $span_gamut = array(
+    #
+    # These are all the transformations that occur *within* block-level
+    # tags like paragraphs, headers, and list items.
+    #
 
-		# Process character escapes, code spans, and inline HTML
-		# in one shot.
-		"parseSpan"           => -30,
+        # Process character escapes, code spans, and inline HTML
+        # in one shot.
+        "parseSpan"           => -30,
 
-		# Process anchor and image tags. Images must come first,
-		# because ![foo][f] looks like an anchor.
-		"doImages"            =>  10,
-		"doAnchors"           =>  20,
-		
-		# Make links out of things like `<http://example.com/>`
-		# Must come after doAnchors, because you can use < and >
-		# delimiters in inline links like [this](<url>).
-		"doAutoLinks"         =>  30,
-		"encodeAmpsAndAngles" =>  40,
+        # Process anchor and image tags. Images must come first,
+        # because ![foo][f] looks like an anchor.
+        "doImages"            =>  10,
+        "doAnchors"           =>  20,
+        
+        # Make links out of things like `<http://example.com/>`
+        # Must come after doAnchors, because you can use < and >
+        # delimiters in inline links like [this](<url>).
+        "doAutoLinks"         =>  30,
+        "encodeAmpsAndAngles" =>  40,
 
                 # Must be before bold and italic
-		"doWikiLinkAnchors"   =>  45,
+        "doWikiLinkAnchors"   =>  45,
 
-		"doItalicsAndBold"    =>  50,
-		"doHardBreaks"        =>  60,
-		);
+        "doItalicsAndBold"    =>  50,
+        "doHardBreaks"        =>  60,
+        );
 
-  function doWikiLinkAnchors($text) {
-  # Turn special WikiLinks [[link]] or [[name|link]] into regular html links
-          $text = preg_replace_callback('/\[\[([\w\._]+\|)?([\w\._\/]+)\]\]/xs',
-                  array(&$this, '_doWikiLinkAnchors_reference_callback'), $text);
+    function doWikiLinkAnchors($text)
+    {
+    # Turn special WikiLinks [[link]] or [[name|link]] into regular html links
+          $text = preg_replace_callback(
+              '/\[\[([\w\._]+\|)?([\w\._\/]+)\]\]/xs',
+              array(&$this, '_doWikiLinkAnchors_reference_callback'),
+              $text
+          );
           return $text;
-  }
+    }
 
-  function _doWikiLinkAnchors_reference_callback($matches) {
-    global $TPL;
+    function _doWikiLinkAnchors_reference_callback($matches)
+    {
+        global $TPL;
 
-    $file = $matches[2];
-    $name = $matches[1];
+        $file = $matches[2];
+        $name = $matches[1];
 
-    $file = str_ireplace("javascript:","",$file); // added by alla
-    $name = str_ireplace("javascript:","",$name);
+        $file = str_ireplace("javascript:", "", $file); // added by alla
+        $name = str_ireplace("javascript:", "", $name);
    
-    if (!empty($name)) {
-        $name = substr($name, 0, -1); //trim the trailing |
-    } else {
-        $name = $file;
+        if (!empty($name)) {
+            $name = substr($name, 0, -1); //trim the trailing |
+        } else {
+            $name = $file;
+        }
+
+        if (file_exists(wiki_module::get_wiki_path().$file.".mdwn")) {
+            return $this->hashPart('<a href="'.$TPL['url_alloc_wiki'].'target='.urlencode($TPL['current_path'].$file).'.mdwn">'.$name.'</a>');
+        } else if (file_exists(wiki_module::get_wiki_path().$file)) {
+            return $this->hashPart('<a href="'.$TPL['url_alloc_wiki'].'target='.urlencode($TPL['current_path'].$file).'">'.$name.'</a>');
+        } else {
+            return $this->hashPart($name.'<a href="?op=new&target='.urlencode($TPL['current_path'].$file).'" title="Click here to create this file.">?</a>');
+        }
+        return $matches[1];
     }
 
-    if (file_exists(wiki_module::get_wiki_path().$file.".mdwn")) {
-      return $this->hashPart('<a href="'.$TPL['url_alloc_wiki'].'target='.urlencode($TPL['current_path'].$file).'.mdwn">'.$name.'</a>');
-    } else if (file_exists(wiki_module::get_wiki_path().$file)) {
-      return $this->hashPart('<a href="'.$TPL['url_alloc_wiki'].'target='.urlencode($TPL['current_path'].$file).'">'.$name.'</a>');
-    } else {
-      return $this->hashPart($name.'<a href="?op=new&target='.urlencode($TPL['current_path'].$file).'" title="Click here to create this file.">?</a>');
+    function runSpanGamut($text)
+    {
+    #
+    # Run span gamut tranformations.
+    #
+        foreach ($this->span_gamut as $method => $priority) {
+            $text = $this->$method($text);
+        }
+
+        return $text;
     }
-    return $matches[1];
-  }
-
-	function runSpanGamut($text) {
-	#
-	# Run span gamut tranformations.
-	#
-		foreach ($this->span_gamut as $method => $priority) {
-			$text = $this->$method($text);
-		}
-
-		return $text;
-	}
-	
-	
-	function doHardBreaks($text) {
-		# Do hard breaks:
-		return preg_replace_callback('/ {2,}\n/', 
-			array(&$this, '_doHardBreaks_callback'), $text);
-	}
-	function _doHardBreaks_callback($matches) {
-		return $this->hashPart("<br$this->empty_element_suffix\n");
-	}
+    
+    
+    function doHardBreaks($text)
+    {
+        # Do hard breaks:
+        return preg_replace_callback(
+            '/ {2,}\n/',
+            array(&$this, '_doHardBreaks_callback'),
+            $text
+        );
+    }
+    function _doHardBreaks_callback($matches)
+    {
+        return $this->hashPart("<br$this->empty_element_suffix\n");
+    }
 
 
-	function doAnchors($text) {
-	#
-	# Turn Markdown link shortcuts into XHTML <a> tags.
-	#
-		if ($this->in_anchor) return $text;
-		$this->in_anchor = true;
-		
-		#
-		# First, handle reference-style links: [link text] [id]
-		#
-		$text = preg_replace_callback('{
+    function doAnchors($text)
+    {
+    #
+    # Turn Markdown link shortcuts into XHTML <a> tags.
+    #
+        if ($this->in_anchor) {
+            return $text;
+        }
+        $this->in_anchor = true;
+        
+        #
+        # First, handle reference-style links: [link text] [id]
+        #
+        $text = preg_replace_callback(
+            '{
 			(					# wrap whole match in $1
 			  \[
 				('.$this->nested_brackets_re.')	# link text = $2
@@ -578,12 +617,15 @@ class Markdown_Parser {
 			  \]
 			)
 			}xs',
-			array(&$this, '_doAnchors_reference_callback'), $text);
+            array(&$this, '_doAnchors_reference_callback'),
+            $text
+        );
 
-		#
-		# Next, inline-style links: [link text](url "optional title")
-		#
-		$text = preg_replace_callback('{
+        #
+        # Next, inline-style links: [link text](url "optional title")
+        #
+        $text = preg_replace_callback(
+            '{
 			(				# wrap whole match in $1
 			  \[
 				('.$this->nested_brackets_re.')	# link text = $2
@@ -605,91 +647,99 @@ class Markdown_Parser {
 			  \)
 			)
 			}xs',
-			array(&$this, '_doAnchors_inline_callback'), $text);
+            array(&$this, '_doAnchors_inline_callback'),
+            $text
+        );
 
-		#
-		# Last, handle reference-style shortcuts: [link text]
-		# These must come last in case you've also got [link text][1]
-		# or [link text](/foo)
-		#
-		$text = preg_replace_callback('{
+        #
+        # Last, handle reference-style shortcuts: [link text]
+        # These must come last in case you've also got [link text][1]
+        # or [link text](/foo)
+        #
+        $text = preg_replace_callback(
+            '{
 			(					# wrap whole match in $1
 			  \[
 				([^\[\]]+)		# link text = $2; can\'t contain [ or ]
 			  \]
 			)
 			}xs',
-			array(&$this, '_doAnchors_reference_callback'), $text);
+            array(&$this, '_doAnchors_reference_callback'),
+            $text
+        );
 
-		$this->in_anchor = false;
-		return $text;
-	}
-	function _doAnchors_reference_callback($matches) {
-		$whole_match =  $matches[1];
-		$link_text   =  $matches[2];
-		$link_id     =& $matches[3];
+        $this->in_anchor = false;
+        return $text;
+    }
+    function _doAnchors_reference_callback($matches)
+    {
+        $whole_match =  $matches[1];
+        $link_text   =  $matches[2];
+        $link_id     =& $matches[3];
 
-		if ($link_id == "") {
-			# for shortcut links like [this][] or [this].
-			$link_id = $link_text;
-		}
-		
-		# lower-case and turn embedded newlines into spaces
-		$link_id = strtolower($link_id);
-		$link_id = preg_replace('{[ ]?\n}', ' ', $link_id);
+        if ($link_id == "") {
+            # for shortcut links like [this][] or [this].
+            $link_id = $link_text;
+        }
+        
+        # lower-case and turn embedded newlines into spaces
+        $link_id = strtolower($link_id);
+        $link_id = preg_replace('{[ ]?\n}', ' ', $link_id);
 
-		if (isset($this->urls[$link_id])) {
-			$url = $this->urls[$link_id];
-      $url = str_ireplace("javascript:","",$url); // added by alla
-			$url = $this->encodeAttribute($url);
-			
-			$result = "<a href=\"$url\"";
-			if ( isset( $this->titles[$link_id] ) ) {
-				$title = $this->titles[$link_id];
-				$title = $this->encodeAttribute($title);
-				$result .=  " title=\"$title\"";
-			}
-		
-			$link_text = $this->runSpanGamut($link_text);
-			$result .= ">$link_text</a>";
-			$result = $this->hashPart($result);
-		}
-		else {
-			$result = $whole_match;
-		}
-		return $result;
-	}
-	function _doAnchors_inline_callback($matches) {
-		$whole_match	=  $matches[1];
-		$link_text		=  $this->runSpanGamut($matches[2]);
-		$url			=  $matches[3] == '' ? $matches[4] : $matches[3];
-		$title			=& $matches[7];
+        if (isset($this->urls[$link_id])) {
+            $url = $this->urls[$link_id];
+            $url = str_ireplace("javascript:", "", $url); // added by alla
+            $url = $this->encodeAttribute($url);
+            
+            $result = "<a href=\"$url\"";
+            if (isset($this->titles[$link_id])) {
+                $title = $this->titles[$link_id];
+                $title = $this->encodeAttribute($title);
+                $result .=  " title=\"$title\"";
+            }
+        
+            $link_text = $this->runSpanGamut($link_text);
+            $result .= ">$link_text</a>";
+            $result = $this->hashPart($result);
+        } else {
+            $result = $whole_match;
+        }
+        return $result;
+    }
+    function _doAnchors_inline_callback($matches)
+    {
+        $whole_match    =  $matches[1];
+        $link_text      =  $this->runSpanGamut($matches[2]);
+        $url            =  $matches[3] == '' ? $matches[4] : $matches[3];
+        $title          =& $matches[7];
 
-    $url = str_ireplace("javascript:","",$url); // added by alla
+        $url = str_ireplace("javascript:", "", $url); // added by alla
 
-		$url = $this->encodeAttribute($url);
+        $url = $this->encodeAttribute($url);
 
-		$result = "<a href=\"$url\"";
-		if (isset($title)) {
-			$title = $this->encodeAttribute($title);
-			$result .=  " title=\"$title\"";
-		}
-		
-		$link_text = $this->runSpanGamut($link_text);
-		$result .= ">$link_text</a>";
+        $result = "<a href=\"$url\"";
+        if (isset($title)) {
+            $title = $this->encodeAttribute($title);
+            $result .=  " title=\"$title\"";
+        }
+        
+        $link_text = $this->runSpanGamut($link_text);
+        $result .= ">$link_text</a>";
 
-		return $this->hashPart($result);
-	}
+        return $this->hashPart($result);
+    }
 
 
-	function doImages($text) {
-	#
-	# Turn Markdown image shortcuts into <img> tags.
-	#
-		#
-		# First, handle reference-style labeled images: ![alt text][id]
-		#
-		$text = preg_replace_callback('{
+    function doImages($text)
+    {
+    #
+    # Turn Markdown image shortcuts into <img> tags.
+    #
+        #
+        # First, handle reference-style labeled images: ![alt text][id]
+        #
+        $text = preg_replace_callback(
+            '{
 			(				# wrap whole match in $1
 			  !\[
 				('.$this->nested_brackets_re.')		# alt text = $2
@@ -703,14 +753,17 @@ class Markdown_Parser {
 			  \]
 
 			)
-			}xs', 
-			array(&$this, '_doImages_reference_callback'), $text);
+			}xs',
+            array(&$this, '_doImages_reference_callback'),
+            $text
+        );
 
-		#
-		# Next, handle inline images:  ![alt text](url "optional title")
-		# Don't forget: encode * and _
-		#
-		$text = preg_replace_callback('{
+        #
+        # Next, handle inline images:  ![alt text](url "optional title")
+        # Don't forget: encode * and _
+        #
+        $text = preg_replace_callback(
+            '{
 			(				# wrap whole match in $1
 			  !\[
 				('.$this->nested_brackets_re.')		# alt text = $2
@@ -733,78 +786,86 @@ class Markdown_Parser {
 			  \)
 			)
 			}xs',
-			array(&$this, '_doImages_inline_callback'), $text);
+            array(&$this, '_doImages_inline_callback'),
+            $text
+        );
 
-		return $text;
-	}
-	function _doImages_reference_callback($matches) {
-		$whole_match = $matches[1];
-		$alt_text    = $matches[2];
-		$link_id     = strtolower($matches[3]);
+        return $text;
+    }
+    function _doImages_reference_callback($matches)
+    {
+        $whole_match = $matches[1];
+        $alt_text    = $matches[2];
+        $link_id     = strtolower($matches[3]);
 
-		if ($link_id == "") {
-			$link_id = strtolower($alt_text); # for shortcut links like ![this][].
-		}
+        if ($link_id == "") {
+            $link_id = strtolower($alt_text); # for shortcut links like ![this][].
+        }
 
-		$alt_text = $this->encodeAttribute($alt_text);
-		if (isset($this->urls[$link_id])) {
-			$url = $this->encodeAttribute($this->urls[$link_id]);
-      $url = str_ireplace("javascript:","",$url); // added by alla
-			$result = "<img src=\"$url\" alt=\"$alt_text\"";
-			if (isset($this->titles[$link_id])) {
-				$title = $this->titles[$link_id];
-				$title = $this->encodeAttribute($title);
-				$result .=  " title=\"$title\"";
-			}
-			$result .= $this->empty_element_suffix;
-			$result = $this->hashPart($result);
-		}
-		else {
-			# If there's no such link ID, leave intact:
-			$result = $whole_match;
-		}
+        $alt_text = $this->encodeAttribute($alt_text);
+        if (isset($this->urls[$link_id])) {
+            $url = $this->encodeAttribute($this->urls[$link_id]);
+            $url = str_ireplace("javascript:", "", $url); // added by alla
+            $result = "<img src=\"$url\" alt=\"$alt_text\"";
+            if (isset($this->titles[$link_id])) {
+                $title = $this->titles[$link_id];
+                $title = $this->encodeAttribute($title);
+                $result .=  " title=\"$title\"";
+            }
+            $result .= $this->empty_element_suffix;
+            $result = $this->hashPart($result);
+        } else {
+            # If there's no such link ID, leave intact:
+            $result = $whole_match;
+        }
 
-		return $result;
-	}
-	function _doImages_inline_callback($matches) {
-		$whole_match	= $matches[1];
-		$alt_text		= $matches[2];
-		$url			= $matches[3] == '' ? $matches[4] : $matches[3];
-    $url = str_ireplace("javascript:","",$url); // added by alla
-		$title			=& $matches[7];
+        return $result;
+    }
+    function _doImages_inline_callback($matches)
+    {
+        $whole_match    = $matches[1];
+        $alt_text       = $matches[2];
+        $url            = $matches[3] == '' ? $matches[4] : $matches[3];
+        $url = str_ireplace("javascript:", "", $url); // added by alla
+        $title          =& $matches[7];
 
-		$alt_text = $this->encodeAttribute($alt_text);
-		$url = $this->encodeAttribute($url);
-		$result = "<img src=\"$url\" alt=\"$alt_text\"";
-		if (isset($title)) {
-			$title = $this->encodeAttribute($title);
-			$result .=  " title=\"$title\""; # $title already quoted
-		}
-		$result .= $this->empty_element_suffix;
+        $alt_text = $this->encodeAttribute($alt_text);
+        $url = $this->encodeAttribute($url);
+        $result = "<img src=\"$url\" alt=\"$alt_text\"";
+        if (isset($title)) {
+            $title = $this->encodeAttribute($title);
+            $result .=  " title=\"$title\""; # $title already quoted
+        }
+        $result .= $this->empty_element_suffix;
 
-		return $this->hashPart($result);
-	}
+        return $this->hashPart($result);
+    }
 
 
-	function doHeaders($text) {
-		# Setext-style headers:
-		#	  Header 1
-		#	  ========
-		#  
-		#	  Header 2
-		#	  --------
-		#
-		$text = preg_replace_callback('{ ^(.+?)[ ]*\n(=+|-+)[ ]*\n+ }mx',
-			array(&$this, '_doHeaders_callback_setext'), $text);
+    function doHeaders($text)
+    {
+        # Setext-style headers:
+        #     Header 1
+        #     ========
+        #
+        #     Header 2
+        #     --------
+        #
+        $text = preg_replace_callback(
+            '{ ^(.+?)[ ]*\n(=+|-+)[ ]*\n+ }mx',
+            array(&$this, '_doHeaders_callback_setext'),
+            $text
+        );
 
-		# atx-style headers:
-		#	# Header 1
-		#	## Header 2
-		#	## Header 2 with closing hashes ##
-		#	...
-		#	###### Header 6
-		#
-		$text = preg_replace_callback('{
+        # atx-style headers:
+        #   # Header 1
+        #   ## Header 2
+        #   ## Header 2 with closing hashes ##
+        #   ...
+        #   ###### Header 6
+        #
+        $text = preg_replace_callback(
+            '{
 				^(\#{1,6})	# $1 = string of #\'s
 				[ ]*
 				(.+?)		# $2 = Header text
@@ -812,45 +873,51 @@ class Markdown_Parser {
 				\#*			# optional closing #\'s (not counted)
 				\n+
 			}xm',
-			array(&$this, '_doHeaders_callback_atx'), $text);
+            array(&$this, '_doHeaders_callback_atx'),
+            $text
+        );
 
-		return $text;
-	}
-	function _doHeaders_callback_setext($matches) {
-		# Terrible hack to check we haven't found an empty list item.
-		if ($matches[2] == '-' && preg_match('{^-(?: |$)}', $matches[1]))
-			return $matches[0];
-		
-		$level = $matches[2]{0} == '=' ? 1 : 2;
-		$block = "<h$level>".$this->runSpanGamut($matches[1])."</h$level>";
-		return "\n" . $this->hashBlock($block) . "\n\n";
-	}
-	function _doHeaders_callback_atx($matches) {
-		$level = strlen($matches[1]);
-		$block = "<h$level>".$this->runSpanGamut($matches[2])."</h$level>";
-		return "\n" . $this->hashBlock($block) . "\n\n";
-	}
+        return $text;
+    }
+    function _doHeaders_callback_setext($matches)
+    {
+        # Terrible hack to check we haven't found an empty list item.
+        if ($matches[2] == '-' && preg_match('{^-(?: |$)}', $matches[1])) {
+            return $matches[0];
+        }
+        
+        $level = $matches[2]{0} == '=' ? 1 : 2;
+        $block = "<h$level>".$this->runSpanGamut($matches[1])."</h$level>";
+        return "\n" . $this->hashBlock($block) . "\n\n";
+    }
+    function _doHeaders_callback_atx($matches)
+    {
+        $level = strlen($matches[1]);
+        $block = "<h$level>".$this->runSpanGamut($matches[2])."</h$level>";
+        return "\n" . $this->hashBlock($block) . "\n\n";
+    }
 
 
-	function doLists($text) {
-	#
-	# Form HTML ordered (numbered) and unordered (bulleted) lists.
-	#
-		$less_than_tab = $this->tab_width - 1;
+    function doLists($text)
+    {
+    #
+    # Form HTML ordered (numbered) and unordered (bulleted) lists.
+    #
+        $less_than_tab = $this->tab_width - 1;
 
-		# Re-usable patterns to match list item bullets and number markers:
-		$marker_ul_re  = '[*+-]';
-		$marker_ol_re  = '\d+[.]';
-		$marker_any_re = "(?:$marker_ul_re|$marker_ol_re)";
+        # Re-usable patterns to match list item bullets and number markers:
+        $marker_ul_re  = '[*+-]';
+        $marker_ol_re  = '\d+[.]';
+        $marker_any_re = "(?:$marker_ul_re|$marker_ol_re)";
 
-		$markers_relist = array(
-			$marker_ul_re => $marker_ol_re,
-			$marker_ol_re => $marker_ul_re,
-			);
+        $markers_relist = array(
+            $marker_ul_re => $marker_ol_re,
+            $marker_ol_re => $marker_ul_re,
+            );
 
-		foreach ($markers_relist as $marker_re => $other_marker_re) {
-			# Re-usable pattern to match any entirel ul or ol list:
-			$whole_list_re = '
+        foreach ($markers_relist as $marker_re => $other_marker_re) {
+            # Re-usable pattern to match any entirel ul or ol list:
+            $whole_list_re = '
 				(								# $1 = whole list
 				  (								# $2
 					([ ]{0,'.$less_than_tab.'})	# $3 = number of spaces
@@ -876,80 +943,88 @@ class Markdown_Parser {
 				  )
 				)
 			'; // mx
-			
-			# We use a different prefix before nested lists than top-level lists.
-			# See extended comment in _ProcessListItems().
-		
-			if ($this->list_level) {
-				$text = preg_replace_callback('{
+            
+            # We use a different prefix before nested lists than top-level lists.
+            # See extended comment in _ProcessListItems().
+        
+            if ($this->list_level) {
+                $text = preg_replace_callback(
+                    '{
 						^
 						'.$whole_list_re.'
 					}mx',
-					array(&$this, '_doLists_callback'), $text);
-			}
-			else {
-				$text = preg_replace_callback('{
+                    array(&$this, '_doLists_callback'),
+                    $text
+                );
+            } else {
+                $text = preg_replace_callback(
+                    '{
 						(?:(?<=\n)\n|\A\n?) # Must eat the newline
 						'.$whole_list_re.'
 					}mx',
-					array(&$this, '_doLists_callback'), $text);
-			}
-		}
+                    array(&$this, '_doLists_callback'),
+                    $text
+                );
+            }
+        }
 
-		return $text;
-	}
-	function _doLists_callback($matches) {
-		# Re-usable patterns to match list item bullets and number markers:
-		$marker_ul_re  = '[*+-]';
-		$marker_ol_re  = '\d+[.]';
-		$marker_any_re = "(?:$marker_ul_re|$marker_ol_re)";
-		
-		$list = $matches[1];
-		$list_type = preg_match("/$marker_ul_re/", $matches[4]) ? "ul" : "ol";
-		
-		$marker_any_re = ( $list_type == "ul" ? $marker_ul_re : $marker_ol_re );
-		
-		$list .= "\n";
-		$result = $this->processListItems($list, $marker_any_re);
-		
-		$result = $this->hashBlock("<$list_type>\n" . $result . "</$list_type>");
-		return "\n". $result ."\n\n";
-	}
+        return $text;
+    }
+    function _doLists_callback($matches)
+    {
+        # Re-usable patterns to match list item bullets and number markers:
+        $marker_ul_re  = '[*+-]';
+        $marker_ol_re  = '\d+[.]';
+        $marker_any_re = "(?:$marker_ul_re|$marker_ol_re)";
+        
+        $list = $matches[1];
+        $list_type = preg_match("/$marker_ul_re/", $matches[4]) ? "ul" : "ol";
+        
+        $marker_any_re = ( $list_type == "ul" ? $marker_ul_re : $marker_ol_re );
+        
+        $list .= "\n";
+        $result = $this->processListItems($list, $marker_any_re);
+        
+        $result = $this->hashBlock("<$list_type>\n" . $result . "</$list_type>");
+        return "\n". $result ."\n\n";
+    }
 
-	var $list_level = 0;
+    var $list_level = 0;
 
-	function processListItems($list_str, $marker_any_re) {
-	#
-	#	Process the contents of a single ordered or unordered list, splitting it
-	#	into individual list items.
-	#
-		# The $this->list_level global keeps track of when we're inside a list.
-		# Each time we enter a list, we increment it; when we leave a list,
-		# we decrement. If it's zero, we're not in a list anymore.
-		#
-		# We do this because when we're not inside a list, we want to treat
-		# something like this:
-		#
-		#		I recommend upgrading to version
-		#		8. Oops, now this line is treated
-		#		as a sub-list.
-		#
-		# As a single paragraph, despite the fact that the second line starts
-		# with a digit-period-space sequence.
-		#
-		# Whereas when we're inside a list (or sub-list), that line will be
-		# treated as the start of a sub-list. What a kludge, huh? This is
-		# an aspect of Markdown's syntax that's hard to parse perfectly
-		# without resorting to mind-reading. Perhaps the solution is to
-		# change the syntax rules such that sub-lists must start with a
-		# starting cardinal number; e.g. "1." or "a.".
-		
-		$this->list_level++;
+    function processListItems($list_str, $marker_any_re)
+    {
+    #
+    #   Process the contents of a single ordered or unordered list, splitting it
+    #   into individual list items.
+    #
+        # The $this->list_level global keeps track of when we're inside a list.
+        # Each time we enter a list, we increment it; when we leave a list,
+        # we decrement. If it's zero, we're not in a list anymore.
+        #
+        # We do this because when we're not inside a list, we want to treat
+        # something like this:
+        #
+        #       I recommend upgrading to version
+        #       8. Oops, now this line is treated
+        #       as a sub-list.
+        #
+        # As a single paragraph, despite the fact that the second line starts
+        # with a digit-period-space sequence.
+        #
+        # Whereas when we're inside a list (or sub-list), that line will be
+        # treated as the start of a sub-list. What a kludge, huh? This is
+        # an aspect of Markdown's syntax that's hard to parse perfectly
+        # without resorting to mind-reading. Perhaps the solution is to
+        # change the syntax rules such that sub-lists must start with a
+        # starting cardinal number; e.g. "1." or "a.".
+        
+        $this->list_level++;
 
-		# trim trailing blank lines:
-		$list_str = preg_replace("/\n{2,}\\z/", "\n", $list_str);
+        # trim trailing blank lines:
+        $list_str = preg_replace("/\n{2,}\\z/", "\n", $list_str);
 
-		$list_str = preg_replace_callback('{
+        $list_str = preg_replace_callback(
+            '{
 			(\n)?							# leading line = $1
 			(^[ ]*)							# leading whitespace = $2
 			('.$marker_any_re.'				# list marker and space = $3
@@ -959,41 +1034,44 @@ class Markdown_Parser {
 			(?:(\n+(?=\n))|\n)				# tailing blank line = $5
 			(?= \n* (\z | \2 ('.$marker_any_re.') (?:[ ]+|(?=\n))))
 			}xm',
-			array(&$this, '_processListItems_callback'), $list_str);
+            array(&$this, '_processListItems_callback'),
+            $list_str
+        );
 
-		$this->list_level--;
-		return $list_str;
-	}
-	function _processListItems_callback($matches) {
-		$item = $matches[4];
-		$leading_line =& $matches[1];
-		$leading_space =& $matches[2];
-		$marker_space = $matches[3];
-		$tailing_blank_line =& $matches[5];
+        $this->list_level--;
+        return $list_str;
+    }
+    function _processListItems_callback($matches)
+    {
+        $item = $matches[4];
+        $leading_line =& $matches[1];
+        $leading_space =& $matches[2];
+        $marker_space = $matches[3];
+        $tailing_blank_line =& $matches[5];
 
-		if ($leading_line || $tailing_blank_line || 
-			preg_match('/\n{2,}/', $item))
-		{
-			# Replace marker with the appropriate whitespace indentation
-			$item = $leading_space . str_repeat(' ', strlen($marker_space)) . $item;
-			$item = $this->runBlockGamut($this->outdent($item)."\n");
-		}
-		else {
-			# Recursion for sub-lists:
-			$item = $this->doLists($this->outdent($item));
-			$item = preg_replace('/\n+$/', '', $item);
-			$item = $this->runSpanGamut($item);
-		}
+        if ($leading_line || $tailing_blank_line ||
+            preg_match('/\n{2,}/', $item)) {
+            # Replace marker with the appropriate whitespace indentation
+            $item = $leading_space . str_repeat(' ', strlen($marker_space)) . $item;
+            $item = $this->runBlockGamut($this->outdent($item)."\n");
+        } else {
+            # Recursion for sub-lists:
+            $item = $this->doLists($this->outdent($item));
+            $item = preg_replace('/\n+$/', '', $item);
+            $item = $this->runSpanGamut($item);
+        }
 
-		return "<li>" . $item . "</li>\n";
-	}
+        return "<li>" . $item . "</li>\n";
+    }
 
 
-	function doCodeBlocks($text) {
-	#
-	#	Process Markdown `<pre><code>` blocks.
-	#
-		$text = preg_replace_callback('{
+    function doCodeBlocks($text)
+    {
+    #
+    #   Process Markdown `<pre><code>` blocks.
+    #
+        $text = preg_replace_callback(
+            '{
 				(?:\n\n|\A\n?)
 				(	            # $1 = the code block -- one or more lines, starting with a space/tab
 				  (?>
@@ -1003,197 +1081,205 @@ class Markdown_Parser {
 				)
 				((?=^[ ]{0,'.$this->tab_width.'}\S)|\Z)	# Lookahead for non-space at line-start, or end of doc
 			}xm',
-			array(&$this, '_doCodeBlocks_callback'), $text);
+            array(&$this, '_doCodeBlocks_callback'),
+            $text
+        );
 
-		return $text;
-	}
-	function _doCodeBlocks_callback($matches) {
-		$codeblock = $matches[1];
+        return $text;
+    }
+    function _doCodeBlocks_callback($matches)
+    {
+        $codeblock = $matches[1];
 
-		$codeblock = $this->outdent($codeblock);
-		$codeblock = htmlspecialchars($codeblock, ENT_NOQUOTES);
+        $codeblock = $this->outdent($codeblock);
+        $codeblock = htmlspecialchars($codeblock, ENT_NOQUOTES);
 
-		# trim leading newlines and trailing newlines
-		$codeblock = preg_replace('/\A\n+|\n+\z/', '', $codeblock);
+        # trim leading newlines and trailing newlines
+        $codeblock = preg_replace('/\A\n+|\n+\z/', '', $codeblock);
 
-		$codeblock = "<pre><code>$codeblock\n</code></pre>";
-		return "\n\n".$this->hashBlock($codeblock)."\n\n";
-	}
-
-
-	function makeCodeSpan($code) {
-	#
-	# Create a code span markup for $code. Called from handleSpanToken.
-	#
-		$code = htmlspecialchars(trim($code), ENT_NOQUOTES);
-		return $this->hashPart("<code>$code</code>");
-	}
+        $codeblock = "<pre><code>$codeblock\n</code></pre>";
+        return "\n\n".$this->hashBlock($codeblock)."\n\n";
+    }
 
 
-	var $em_relist = array(
-		''  => '(?:(?<!\*)\*(?!\*)|(?<!_)_(?!_))(?=\S|$)(?![.,:;]\s)',
-		'*' => '(?<=\S|^)(?<!\*)\*(?!\*)',
-		'_' => '(?<=\S|^)(?<!_)_(?!_)',
-		);
-	var $strong_relist = array(
-		''   => '(?:(?<!\*)\*\*(?!\*)|(?<!_)__(?!_))(?=\S|$)(?![.,:;]\s)',
-		'**' => '(?<=\S|^)(?<!\*)\*\*(?!\*)',
-		'__' => '(?<=\S|^)(?<!_)__(?!_)',
-		);
-	var $em_strong_relist = array(
-		''    => '(?:(?<!\*)\*\*\*(?!\*)|(?<!_)___(?!_))(?=\S|$)(?![.,:;]\s)',
-		'***' => '(?<=\S|^)(?<!\*)\*\*\*(?!\*)',
-		'___' => '(?<=\S|^)(?<!_)___(?!_)',
-		);
-	var $em_strong_prepared_relist;
-	
-	function prepareItalicsAndBold() {
-	#
-	# Prepare regular expressions for searching emphasis tokens in any
-	# context.
-	#
-		foreach ($this->em_relist as $em => $em_re) {
-			foreach ($this->strong_relist as $strong => $strong_re) {
-				# Construct list of allowed token expressions.
-				$token_relist = array();
-				if (isset($this->em_strong_relist["$em$strong"])) {
-					$token_relist[] = $this->em_strong_relist["$em$strong"];
-				}
-				$token_relist[] = $em_re;
-				$token_relist[] = $strong_re;
-				
-				# Construct master expression from list.
-				$token_re = '{('. implode('|', $token_relist) .')}';
-				$this->em_strong_prepared_relist["$em$strong"] = $token_re;
-			}
-		}
-	}
-	
-	function doItalicsAndBold($text) {
-		$token_stack = array('');
-		$text_stack = array('');
-		$em = '';
-		$strong = '';
-		$tree_char_em = false;
-		
-		while (1) {
-			#
-			# Get prepared regular expression for seraching emphasis tokens
-			# in current context.
-			#
-			$token_re = $this->em_strong_prepared_relist["$em$strong"];
-			
-			#
-			# Each loop iteration search for the next emphasis token. 
-			# Each token is then passed to handleSpanToken.
-			#
-			$parts = preg_split($token_re, $text, 2, PREG_SPLIT_DELIM_CAPTURE);
-			$text_stack[0] .= $parts[0];
-			$token =& $parts[1];
-			$text =& $parts[2];
-			
-			if (empty($token)) {
-				# Reached end of text span: empty stack without emitting.
-				# any more emphasis.
-				while ($token_stack[0]) {
-					$text_stack[1] .= array_shift($token_stack);
-					$text_stack[0] .= array_shift($text_stack);
-				}
-				break;
-			}
-			
-			$token_len = strlen($token);
-			if ($tree_char_em) {
-				# Reached closing marker while inside a three-char emphasis.
-				if ($token_len == 3) {
-					# Three-char closing marker, close em and strong.
-					array_shift($token_stack);
-					$span = array_shift($text_stack);
-					$span = $this->runSpanGamut($span);
-					$span = "<strong><em>$span</em></strong>";
-					$text_stack[0] .= $this->hashPart($span);
-					$em = '';
-					$strong = '';
-				} else {
-					# Other closing marker: close one em or strong and
-					# change current token state to match the other
-					$token_stack[0] = str_repeat($token{0}, 3-$token_len);
-					$tag = $token_len == 2 ? "strong" : "em";
-					$span = $text_stack[0];
-					$span = $this->runSpanGamut($span);
-					$span = "<$tag>$span</$tag>";
-					$text_stack[0] = $this->hashPart($span);
-					$$tag = ''; # $$tag stands for $em or $strong
-				}
-				$tree_char_em = false;
-			} else if ($token_len == 3) {
-				if ($em) {
-					# Reached closing marker for both em and strong.
-					# Closing strong marker:
-					for ($i = 0; $i < 2; ++$i) {
-						$shifted_token = array_shift($token_stack);
-						$tag = strlen($shifted_token) == 2 ? "strong" : "em";
-						$span = array_shift($text_stack);
-						$span = $this->runSpanGamut($span);
-						$span = "<$tag>$span</$tag>";
-						$text_stack[0] .= $this->hashPart($span);
-						$$tag = ''; # $$tag stands for $em or $strong
-					}
-				} else {
-					# Reached opening three-char emphasis marker. Push on token 
-					# stack; will be handled by the special condition above.
-					$em = $token{0};
-					$strong = "$em$em";
-					array_unshift($token_stack, $token);
-					array_unshift($text_stack, '');
-					$tree_char_em = true;
-				}
-			} else if ($token_len == 2) {
-				if ($strong) {
-					# Unwind any dangling emphasis marker:
-					if (strlen($token_stack[0]) == 1) {
-						$text_stack[1] .= array_shift($token_stack);
-						$text_stack[0] .= array_shift($text_stack);
-					}
-					# Closing strong marker:
-					array_shift($token_stack);
-					$span = array_shift($text_stack);
-					$span = $this->runSpanGamut($span);
-					$span = "<strong>$span</strong>";
-					$text_stack[0] .= $this->hashPart($span);
-					$strong = '';
-				} else {
-					array_unshift($token_stack, $token);
-					array_unshift($text_stack, '');
-					$strong = $token;
-				}
-			} else {
-				# Here $token_len == 1
-				if ($em) {
-					if (strlen($token_stack[0]) == 1) {
-						# Closing emphasis marker:
-						array_shift($token_stack);
-						$span = array_shift($text_stack);
-						$span = $this->runSpanGamut($span);
-						$span = "<em>$span</em>";
-						$text_stack[0] .= $this->hashPart($span);
-						$em = '';
-					} else {
-						$text_stack[0] .= $token;
-					}
-				} else {
-					array_unshift($token_stack, $token);
-					array_unshift($text_stack, '');
-					$em = $token;
-				}
-			}
-		}
-		return $text_stack[0];
-	}
+    function makeCodeSpan($code)
+    {
+    #
+    # Create a code span markup for $code. Called from handleSpanToken.
+    #
+        $code = htmlspecialchars(trim($code), ENT_NOQUOTES);
+        return $this->hashPart("<code>$code</code>");
+    }
 
 
-	function doBlockQuotes($text) {
-		$text = preg_replace_callback('/
+    var $em_relist = array(
+        ''  => '(?:(?<!\*)\*(?!\*)|(?<!_)_(?!_))(?=\S|$)(?![.,:;]\s)',
+        '*' => '(?<=\S|^)(?<!\*)\*(?!\*)',
+        '_' => '(?<=\S|^)(?<!_)_(?!_)',
+        );
+    var $strong_relist = array(
+        ''   => '(?:(?<!\*)\*\*(?!\*)|(?<!_)__(?!_))(?=\S|$)(?![.,:;]\s)',
+        '**' => '(?<=\S|^)(?<!\*)\*\*(?!\*)',
+        '__' => '(?<=\S|^)(?<!_)__(?!_)',
+        );
+    var $em_strong_relist = array(
+        ''    => '(?:(?<!\*)\*\*\*(?!\*)|(?<!_)___(?!_))(?=\S|$)(?![.,:;]\s)',
+        '***' => '(?<=\S|^)(?<!\*)\*\*\*(?!\*)',
+        '___' => '(?<=\S|^)(?<!_)___(?!_)',
+        );
+    var $em_strong_prepared_relist;
+    
+    function prepareItalicsAndBold()
+    {
+    #
+    # Prepare regular expressions for searching emphasis tokens in any
+    # context.
+    #
+        foreach ($this->em_relist as $em => $em_re) {
+            foreach ($this->strong_relist as $strong => $strong_re) {
+                # Construct list of allowed token expressions.
+                $token_relist = array();
+                if (isset($this->em_strong_relist["$em$strong"])) {
+                    $token_relist[] = $this->em_strong_relist["$em$strong"];
+                }
+                $token_relist[] = $em_re;
+                $token_relist[] = $strong_re;
+                
+                # Construct master expression from list.
+                $token_re = '{('. implode('|', $token_relist) .')}';
+                $this->em_strong_prepared_relist["$em$strong"] = $token_re;
+            }
+        }
+    }
+    
+    function doItalicsAndBold($text)
+    {
+        $token_stack = array('');
+        $text_stack = array('');
+        $em = '';
+        $strong = '';
+        $tree_char_em = false;
+        
+        while (1) {
+            #
+            # Get prepared regular expression for seraching emphasis tokens
+            # in current context.
+            #
+            $token_re = $this->em_strong_prepared_relist["$em$strong"];
+            
+            #
+            # Each loop iteration search for the next emphasis token.
+            # Each token is then passed to handleSpanToken.
+            #
+            $parts = preg_split($token_re, $text, 2, PREG_SPLIT_DELIM_CAPTURE);
+            $text_stack[0] .= $parts[0];
+            $token =& $parts[1];
+            $text =& $parts[2];
+            
+            if (empty($token)) {
+                # Reached end of text span: empty stack without emitting.
+                # any more emphasis.
+                while ($token_stack[0]) {
+                    $text_stack[1] .= array_shift($token_stack);
+                    $text_stack[0] .= array_shift($text_stack);
+                }
+                break;
+            }
+            
+            $token_len = strlen($token);
+            if ($tree_char_em) {
+                # Reached closing marker while inside a three-char emphasis.
+                if ($token_len == 3) {
+                    # Three-char closing marker, close em and strong.
+                    array_shift($token_stack);
+                    $span = array_shift($text_stack);
+                    $span = $this->runSpanGamut($span);
+                    $span = "<strong><em>$span</em></strong>";
+                    $text_stack[0] .= $this->hashPart($span);
+                    $em = '';
+                    $strong = '';
+                } else {
+                    # Other closing marker: close one em or strong and
+                    # change current token state to match the other
+                    $token_stack[0] = str_repeat($token{0}, 3-$token_len);
+                    $tag = $token_len == 2 ? "strong" : "em";
+                    $span = $text_stack[0];
+                    $span = $this->runSpanGamut($span);
+                    $span = "<$tag>$span</$tag>";
+                    $text_stack[0] = $this->hashPart($span);
+                    $$tag = ''; # $$tag stands for $em or $strong
+                }
+                $tree_char_em = false;
+            } else if ($token_len == 3) {
+                if ($em) {
+                    # Reached closing marker for both em and strong.
+                    # Closing strong marker:
+                    for ($i = 0; $i < 2; ++$i) {
+                        $shifted_token = array_shift($token_stack);
+                        $tag = strlen($shifted_token) == 2 ? "strong" : "em";
+                        $span = array_shift($text_stack);
+                        $span = $this->runSpanGamut($span);
+                        $span = "<$tag>$span</$tag>";
+                        $text_stack[0] .= $this->hashPart($span);
+                        $$tag = ''; # $$tag stands for $em or $strong
+                    }
+                } else {
+                    # Reached opening three-char emphasis marker. Push on token
+                    # stack; will be handled by the special condition above.
+                    $em = $token{0};
+                    $strong = "$em$em";
+                    array_unshift($token_stack, $token);
+                    array_unshift($text_stack, '');
+                    $tree_char_em = true;
+                }
+            } else if ($token_len == 2) {
+                if ($strong) {
+                    # Unwind any dangling emphasis marker:
+                    if (strlen($token_stack[0]) == 1) {
+                        $text_stack[1] .= array_shift($token_stack);
+                        $text_stack[0] .= array_shift($text_stack);
+                    }
+                    # Closing strong marker:
+                    array_shift($token_stack);
+                    $span = array_shift($text_stack);
+                    $span = $this->runSpanGamut($span);
+                    $span = "<strong>$span</strong>";
+                    $text_stack[0] .= $this->hashPart($span);
+                    $strong = '';
+                } else {
+                    array_unshift($token_stack, $token);
+                    array_unshift($text_stack, '');
+                    $strong = $token;
+                }
+            } else {
+                # Here $token_len == 1
+                if ($em) {
+                    if (strlen($token_stack[0]) == 1) {
+                        # Closing emphasis marker:
+                        array_shift($token_stack);
+                        $span = array_shift($text_stack);
+                        $span = $this->runSpanGamut($span);
+                        $span = "<em>$span</em>";
+                        $text_stack[0] .= $this->hashPart($span);
+                        $em = '';
+                    } else {
+                        $text_stack[0] .= $token;
+                    }
+                } else {
+                    array_unshift($token_stack, $token);
+                    array_unshift($text_stack, '');
+                    $em = $token;
+                }
+            }
+        }
+        return $text_stack[0];
+    }
+
+
+    function doBlockQuotes($text)
+    {
+        $text = preg_replace_callback(
+            '/
 			  (								# Wrap whole match in $1
 				(?>
 				  ^[ ]*>[ ]?			# ">" at the start of a line
@@ -1203,139 +1289,157 @@ class Markdown_Parser {
 				)+
 			  )
 			/xm',
-			array(&$this, '_doBlockQuotes_callback'), $text);
+            array(&$this, '_doBlockQuotes_callback'),
+            $text
+        );
 
-		return $text;
-	}
-	function _doBlockQuotes_callback($matches) {
-		$bq = $matches[1];
-		# trim one level of quoting - trim whitespace-only lines
-		$bq = preg_replace('/^[ ]*>[ ]?|^[ ]+$/m', '', $bq);
-		$bq = $this->runBlockGamut($bq);		# recurse
+        return $text;
+    }
+    function _doBlockQuotes_callback($matches)
+    {
+        $bq = $matches[1];
+        # trim one level of quoting - trim whitespace-only lines
+        $bq = preg_replace('/^[ ]*>[ ]?|^[ ]+$/m', '', $bq);
+        $bq = $this->runBlockGamut($bq);        # recurse
 
-		$bq = preg_replace('/^/m', "  ", $bq);
-		# These leading spaces cause problem with <pre> content, 
-		# so we need to fix that:
-		$bq = preg_replace_callback('{(\s*<pre>.+?</pre>)}sx', 
-			array(&$this, '_doBlockQuotes_callback2'), $bq);
+        $bq = preg_replace('/^/m', "  ", $bq);
+        # These leading spaces cause problem with <pre> content,
+        # so we need to fix that:
+        $bq = preg_replace_callback(
+            '{(\s*<pre>.+?</pre>)}sx',
+            array(&$this, '_doBlockQuotes_callback2'),
+            $bq
+        );
 
-		return "\n". $this->hashBlock("<blockquote>\n$bq\n</blockquote>")."\n\n";
-	}
-	function _doBlockQuotes_callback2($matches) {
-		$pre = $matches[1];
-		$pre = preg_replace('/^  /m', '', $pre);
-		return $pre;
-	}
+        return "\n". $this->hashBlock("<blockquote>\n$bq\n</blockquote>")."\n\n";
+    }
+    function _doBlockQuotes_callback2($matches)
+    {
+        $pre = $matches[1];
+        $pre = preg_replace('/^  /m', '', $pre);
+        return $pre;
+    }
 
 
-	function formParagraphs($text) {
-	#
-	#	Params:
-	#		$text - string to process with html <p> tags
-	#
-		# Strip leading and trailing lines:
-		$text = preg_replace('/\A\n+|\n+\z/', '', $text);
+    function formParagraphs($text)
+    {
+    #
+    #   Params:
+    #       $text - string to process with html <p> tags
+    #
+        # Strip leading and trailing lines:
+        $text = preg_replace('/\A\n+|\n+\z/', '', $text);
 
-		$grafs = preg_split('/\n{2,}/', $text, -1, PREG_SPLIT_NO_EMPTY);
+        $grafs = preg_split('/\n{2,}/', $text, -1, PREG_SPLIT_NO_EMPTY);
 
-		#
-		# Wrap <p> tags and unhashify HTML blocks
-		#
-		foreach ($grafs as $key => $value) {
-			if (!preg_match('/^B\x1A[0-9]+B$/', $value)) {
-				# Is a paragraph.
-				$value = $this->runSpanGamut($value);
-				$value = preg_replace('/^([ ]*)/', "<p>", $value);
-				$value .= "</p>";
-				$grafs[$key] = $this->unhash($value);
-			}
-			else {
-				# Is a block.
-				# Modify elements of @grafs in-place...
-				$graf = $value;
-				$block = $this->html_hashes[$graf];
-				$graf = $block;
-//				if (preg_match('{
-//					\A
-//					(							# $1 = <div> tag
-//					  <div  \s+
-//					  [^>]*
-//					  \b
-//					  markdown\s*=\s*  ([\'"])	#	$2 = attr quote char
-//					  1
-//					  \2
-//					  [^>]*
-//					  >
-//					)
-//					(							# $3 = contents
-//					.*
-//					)
-//					(</div>)					# $4 = closing tag
-//					\z
-//					}xs', $block, $matches))
-//				{
-//					list(, $div_open, , $div_content, $div_close) = $matches;
+        #
+        # Wrap <p> tags and unhashify HTML blocks
+        #
+        foreach ($grafs as $key => $value) {
+            if (!preg_match('/^B\x1A[0-9]+B$/', $value)) {
+                # Is a paragraph.
+                $value = $this->runSpanGamut($value);
+                $value = preg_replace('/^([ ]*)/', "<p>", $value);
+                $value .= "</p>";
+                $grafs[$key] = $this->unhash($value);
+            } else {
+                # Is a block.
+                # Modify elements of @grafs in-place...
+                $graf = $value;
+                $block = $this->html_hashes[$graf];
+                $graf = $block;
+//              if (preg_match('{
+//                  \A
+//                  (                           # $1 = <div> tag
+//                    <div  \s+
+//                    [^>]*
+//                    \b
+//                    markdown\s*=\s*  ([\'"])  #   $2 = attr quote char
+//                    1
+//                    \2
+//                    [^>]*
+//                    >
+//                  )
+//                  (                           # $3 = contents
+//                  .*
+//                  )
+//                  (</div>)                    # $4 = closing tag
+//                  \z
+//                  }xs', $block, $matches))
+//              {
+//                  list(, $div_open, , $div_content, $div_close) = $matches;
 //
-//					# We can't call Markdown(), because that resets the hash;
-//					# that initialization code should be pulled into its own sub, though.
-//					$div_content = $this->hashHTMLBlocks($div_content);
-//					
-//					# Run document gamut methods on the content.
-//					foreach ($this->document_gamut as $method => $priority) {
-//						$div_content = $this->$method($div_content);
-//					}
+//                  # We can't call Markdown(), because that resets the hash;
+//                  # that initialization code should be pulled into its own sub, though.
+//                  $div_content = $this->hashHTMLBlocks($div_content);
 //
-//					$div_open = preg_replace(
-//						'{\smarkdown\s*=\s*([\'"]).+?\1}', '', $div_open);
+//                  # Run document gamut methods on the content.
+//                  foreach ($this->document_gamut as $method => $priority) {
+//                      $div_content = $this->$method($div_content);
+//                  }
 //
-//					$graf = $div_open . "\n" . $div_content . "\n" . $div_close;
-//				}
-				$grafs[$key] = $graf;
-			}
-		}
+//                  $div_open = preg_replace(
+//                      '{\smarkdown\s*=\s*([\'"]).+?\1}', '', $div_open);
+//
+//                  $graf = $div_open . "\n" . $div_content . "\n" . $div_close;
+//              }
+                $grafs[$key] = $graf;
+            }
+        }
 
-		return implode("\n\n", $grafs);
-	}
-
-
-	function encodeAttribute($text) {
-	#
-	# Encode text for a double-quoted HTML attribute. This function
-	# is *not* suitable for attributes enclosed in single quotes.
-	#
-		$text = $this->encodeAmpsAndAngles($text);
-		$text = str_replace('"', '&quot;', $text);
-		return $text;
-	}
-	
-	
-	function encodeAmpsAndAngles($text) {
-	#
-	# Smart processing for ampersands and angle brackets that need to 
-	# be encoded. Valid character entities are left alone unless the
-	# no-entities mode is set.
-	#
-		if ($this->no_entities) {
-			$text = str_replace('&', '&amp;', $text);
-		} else {
-			# Ampersand-encoding based entirely on Nat Irons's Amputator
-			# MT plugin: <http://bumppo.net/projects/amputator/>
-			$text = preg_replace('/&(?!#?[xX]?(?:[0-9a-fA-F]+|\w+);)/', 
-								'&amp;', $text);;
-		}
-		# Encode remaining <'s
-		$text = str_replace('<', '&lt;', $text);
-
-		return $text;
-	}
+        return implode("\n\n", $grafs);
+    }
 
 
-	function doAutoLinks($text) {
-		$text = preg_replace_callback('{<((https?|ftp|dict):[^\'">\s]+)>}i', 
-			array(&$this, '_doAutoLinks_url_callback'), $text);
+    function encodeAttribute($text)
+    {
+    #
+    # Encode text for a double-quoted HTML attribute. This function
+    # is *not* suitable for attributes enclosed in single quotes.
+    #
+        $text = $this->encodeAmpsAndAngles($text);
+        $text = str_replace('"', '&quot;', $text);
+        return $text;
+    }
+    
+    
+    function encodeAmpsAndAngles($text)
+    {
+    #
+    # Smart processing for ampersands and angle brackets that need to
+    # be encoded. Valid character entities are left alone unless the
+    # no-entities mode is set.
+    #
+        if ($this->no_entities) {
+            $text = str_replace('&', '&amp;', $text);
+        } else {
+            # Ampersand-encoding based entirely on Nat Irons's Amputator
+            # MT plugin: <http://bumppo.net/projects/amputator/>
+            $text = preg_replace(
+                '/&(?!#?[xX]?(?:[0-9a-fA-F]+|\w+);)/',
+                '&amp;',
+                $text
+            );
+            ;
+        }
+        # Encode remaining <'s
+        $text = str_replace('<', '&lt;', $text);
 
-		# Email addresses: <address@domain.foo>
-		$text = preg_replace_callback('{
+        return $text;
+    }
+
+
+    function doAutoLinks($text)
+    {
+        $text = preg_replace_callback(
+            '{<((https?|ftp|dict):[^\'">\s]+)>}i',
+            array(&$this, '_doAutoLinks_url_callback'),
+            $text
+        );
+
+        # Email addresses: <address@domain.foo>
+        $text = preg_replace_callback(
+            '{
 			<
 			(?:mailto:)?
 			(
@@ -1353,73 +1457,83 @@ class Markdown_Parser {
 			)
 			>
 			}xi',
-			array(&$this, '_doAutoLinks_email_callback'), $text);
+            array(&$this, '_doAutoLinks_email_callback'),
+            $text
+        );
 
-		return $text;
-	}
-	function _doAutoLinks_url_callback($matches) {
-		$url = $this->encodeAttribute($matches[1]);
-    $url = str_ireplace("javascript:","",$url); // added by alla
-		$link = "<a href=\"$url\">$url</a>";
-		return $this->hashPart($link);
-	}
-	function _doAutoLinks_email_callback($matches) {
-		$address = $matches[1];
-		$link = $this->encodeEmailAddress($address);
-    $link = str_ireplace("javascript:","",$link); // added by alla
-		return $this->hashPart($link);
-	}
-
-
-	function encodeEmailAddress($addr) {
-	#
-	#	Input: an email address, e.g. "foo@example.com"
-	#
-	#	Output: the email address as a mailto link, with each character
-	#		of the address encoded as either a decimal or hex entity, in
-	#		the hopes of foiling most address harvesting spam bots. E.g.:
-	#
-	#	  <p><a href="&#109;&#x61;&#105;&#x6c;&#116;&#x6f;&#58;&#x66;o&#111;
-	#        &#x40;&#101;&#x78;&#97;&#x6d;&#112;&#x6c;&#101;&#46;&#x63;&#111;
-	#        &#x6d;">&#x66;o&#111;&#x40;&#101;&#x78;&#97;&#x6d;&#112;&#x6c;
-	#        &#101;&#46;&#x63;&#111;&#x6d;</a></p>
-	#
-	#	Based by a filter by Matthew Wickline, posted to BBEdit-Talk.
-	#   With some optimizations by Milian Wolff.
-	#
-		$addr = "mailto:" . $addr;
-		$chars = preg_split('/(?<!^)(?!$)/', $addr);
-		$seed = (int)abs(crc32($addr) / strlen($addr)); # Deterministic seed.
-		
-		foreach ($chars as $key => $char) {
-			$ord = ord($char);
-			# Ignore non-ascii chars.
-			if ($ord < 128) {
-				$r = ($seed * (1 + $key)) % 100; # Pseudo-random function.
-				# roughly 10% raw, 45% hex, 45% dec
-				# '@' *must* be encoded. I insist.
-				if ($r > 90 && $char != '@') /* do nothing */;
-				else if ($r < 45) $chars[$key] = '&#x'.dechex($ord).';';
-				else              $chars[$key] = '&#'.$ord.';';
-			}
-		}
-		
-		$addr = implode('', $chars);
-		$text = implode('', array_slice($chars, 7)); # text without `mailto:`
-		$addr = "<a href=\"$addr\">$text</a>";
-
-		return $addr;
-	}
+        return $text;
+    }
+    function _doAutoLinks_url_callback($matches)
+    {
+        $url = $this->encodeAttribute($matches[1]);
+        $url = str_ireplace("javascript:", "", $url); // added by alla
+        $link = "<a href=\"$url\">$url</a>";
+        return $this->hashPart($link);
+    }
+    function _doAutoLinks_email_callback($matches)
+    {
+        $address = $matches[1];
+        $link = $this->encodeEmailAddress($address);
+        $link = str_ireplace("javascript:", "", $link); // added by alla
+        return $this->hashPart($link);
+    }
 
 
-	function parseSpan($str) {
-	#
-	# Take the string $str and parse it into tokens, hashing embeded HTML,
-	# escaped characters and handling code spans.
-	#
-		$output = '';
-		
-		$span_re = '{
+    function encodeEmailAddress($addr)
+    {
+    #
+    #   Input: an email address, e.g. "foo@example.com"
+    #
+    #   Output: the email address as a mailto link, with each character
+    #       of the address encoded as either a decimal or hex entity, in
+    #       the hopes of foiling most address harvesting spam bots. E.g.:
+    #
+    #     <p><a href="&#109;&#x61;&#105;&#x6c;&#116;&#x6f;&#58;&#x66;o&#111;
+    #        &#x40;&#101;&#x78;&#97;&#x6d;&#112;&#x6c;&#101;&#46;&#x63;&#111;
+    #        &#x6d;">&#x66;o&#111;&#x40;&#101;&#x78;&#97;&#x6d;&#112;&#x6c;
+    #        &#101;&#46;&#x63;&#111;&#x6d;</a></p>
+    #
+    #   Based by a filter by Matthew Wickline, posted to BBEdit-Talk.
+    #   With some optimizations by Milian Wolff.
+    #
+        $addr = "mailto:" . $addr;
+        $chars = preg_split('/(?<!^)(?!$)/', $addr);
+        $seed = (int)abs(crc32($addr) / strlen($addr)); # Deterministic seed.
+        
+        foreach ($chars as $key => $char) {
+            $ord = ord($char);
+            # Ignore non-ascii chars.
+            if ($ord < 128) {
+                $r = ($seed * (1 + $key)) % 100; # Pseudo-random function.
+                # roughly 10% raw, 45% hex, 45% dec
+                # '@' *must* be encoded. I insist.
+                if ($r > 90 && $char != '@') {
+/* do nothing */;
+                } else if ($r < 45) {
+                    $chars[$key] = '&#x'.dechex($ord).';';
+                } else {
+                    $chars[$key] = '&#'.$ord.';';
+                }
+            }
+        }
+        
+        $addr = implode('', $chars);
+        $text = implode('', array_slice($chars, 7)); # text without `mailto:`
+        $addr = "<a href=\"$addr\">$text</a>";
+
+        return $addr;
+    }
+
+
+    function parseSpan($str)
+    {
+    #
+    # Take the string $str and parse it into tokens, hashing embeded HTML,
+    # escaped characters and handling code spans.
+    #
+        $output = '';
+        
+        $span_re = '{
 				(
 					\\\\'.$this->escape_chars_re.'
 				|
@@ -1441,124 +1555,139 @@ class Markdown_Parser {
 				)
 				}xs';
 
-		while (1) {
-			#
-			# Each loop iteration seach for either the next tag, the next 
-			# openning code span marker, or the next escaped character. 
-			# Each token is then passed to handleSpanToken.
-			#
-			$parts = preg_split($span_re, $str, 2, PREG_SPLIT_DELIM_CAPTURE);
-			
-			# Create token from text preceding tag.
-			if ($parts[0] != "") {
-				$output .= $parts[0];
-			}
-			
-			# Check if we reach the end.
-			if (isset($parts[1])) {
-				$output .= $this->handleSpanToken($parts[1], $parts[2]);
-				$str = $parts[2];
-			}
-			else {
-				break;
-			}
-		}
-		
-		return $output;
-	}
-	
-	
-	function handleSpanToken($token, &$str) {
-	#
-	# Handle $token provided by parseSpan by determining its nature and 
-	# returning the corresponding value that should replace it.
-	#
-		switch ($token{0}) {
-			case "\\":
-				return $this->hashPart("&#". ord($token{1}). ";");
-			case "`":
-				# Search for end marker in remaining text.
-				if (preg_match('/^(.*?[^`])'.preg_quote($token).'(?!`)(.*)$/sm', 
-					$str, $matches))
-				{
-					$str = $matches[2];
-					$codespan = $this->makeCodeSpan($matches[1]);
-					return $this->hashPart($codespan);
-				}
-				return $token; // return as text since no ending marker found.
-			default:
-				return $this->hashPart($token);
-		}
-	}
+        while (1) {
+            #
+            # Each loop iteration seach for either the next tag, the next
+            # openning code span marker, or the next escaped character.
+            # Each token is then passed to handleSpanToken.
+            #
+            $parts = preg_split($span_re, $str, 2, PREG_SPLIT_DELIM_CAPTURE);
+            
+            # Create token from text preceding tag.
+            if ($parts[0] != "") {
+                $output .= $parts[0];
+            }
+            
+            # Check if we reach the end.
+            if (isset($parts[1])) {
+                $output .= $this->handleSpanToken($parts[1], $parts[2]);
+                $str = $parts[2];
+            } else {
+                break;
+            }
+        }
+        
+        return $output;
+    }
+    
+    
+    function handleSpanToken($token, &$str)
+    {
+    #
+    # Handle $token provided by parseSpan by determining its nature and
+    # returning the corresponding value that should replace it.
+    #
+        switch ($token{0}) {
+            case "\\":
+                return $this->hashPart("&#". ord($token{1}). ";");
+            case "`":
+                # Search for end marker in remaining text.
+                if (preg_match(
+                    '/^(.*?[^`])'.preg_quote($token).'(?!`)(.*)$/sm',
+                    $str,
+                    $matches
+                )) {
+                    $str = $matches[2];
+                    $codespan = $this->makeCodeSpan($matches[1]);
+                    return $this->hashPart($codespan);
+                }
+                return $token; // return as text since no ending marker found.
+            default:
+                return $this->hashPart($token);
+        }
+    }
 
 
-	function outdent($text) {
-	#
-	# Remove one level of line-leading tabs or spaces
-	#
-		return preg_replace('/^(\t|[ ]{1,'.$this->tab_width.'})/m', '', $text);
-	}
+    function outdent($text)
+    {
+    #
+    # Remove one level of line-leading tabs or spaces
+    #
+        return preg_replace('/^(\t|[ ]{1,'.$this->tab_width.'})/m', '', $text);
+    }
 
 
-	# String length function for detab. `_initDetab` will create a function to 
-	# hanlde UTF-8 if the default function does not exist.
-	var $utf8_strlen = 'mb_strlen';
-	
-	function detab($text) {
-	#
-	# Replace tabs with the appropriate amount of space.
-	#
-		# For each line we separate the line in blocks delemited by
-		# tab characters. Then we reconstruct every line by adding the 
-		# appropriate number of space between each blocks.
-		
-		$text = preg_replace_callback('/^.*\t.*$/m',
-			array(&$this, '_detab_callback'), $text);
+    # String length function for detab. `_initDetab` will create a function to
+    # hanlde UTF-8 if the default function does not exist.
+    var $utf8_strlen = 'mb_strlen';
+    
+    function detab($text)
+    {
+    #
+    # Replace tabs with the appropriate amount of space.
+    #
+        # For each line we separate the line in blocks delemited by
+        # tab characters. Then we reconstruct every line by adding the
+        # appropriate number of space between each blocks.
+        
+        $text = preg_replace_callback(
+            '/^.*\t.*$/m',
+            array(&$this, '_detab_callback'),
+            $text
+        );
 
-		return $text;
-	}
-	function _detab_callback($matches) {
-		$line = $matches[0];
-		$strlen = $this->utf8_strlen; # strlen function for UTF-8.
-		
-		# Split in blocks.
-		$blocks = explode("\t", $line);
-		# Add each blocks to the line.
-		$line = $blocks[0];
-		unset($blocks[0]); # Do not add first block twice.
-		foreach ($blocks as $block) {
-			# Calculate amount of space, insert spaces, insert block.
-			$amount = $this->tab_width - 
-				$strlen($line, 'UTF-8') % $this->tab_width;
-			$line .= str_repeat(" ", $amount) . $block;
-		}
-		return $line;
-	}
-	function _initDetab() {
-	#
-	# Check for the availability of the function in the `utf8_strlen` property
-	# (initially `mb_strlen`). If the function is not available, create a 
-	# function that will loosely count the number of UTF-8 characters with a
-	# regular expression.
-	#
-		if (function_exists($this->utf8_strlen)) return;
-		$this->utf8_strlen = create_function('$text', 'return preg_match_all(
+        return $text;
+    }
+    function _detab_callback($matches)
+    {
+        $line = $matches[0];
+        $strlen = $this->utf8_strlen; # strlen function for UTF-8.
+        
+        # Split in blocks.
+        $blocks = explode("\t", $line);
+        # Add each blocks to the line.
+        $line = $blocks[0];
+        unset($blocks[0]); # Do not add first block twice.
+        foreach ($blocks as $block) {
+            # Calculate amount of space, insert spaces, insert block.
+            $amount = $this->tab_width -
+                $strlen($line, 'UTF-8') % $this->tab_width;
+            $line .= str_repeat(" ", $amount) . $block;
+        }
+        return $line;
+    }
+    function _initDetab()
+    {
+    #
+    # Check for the availability of the function in the `utf8_strlen` property
+    # (initially `mb_strlen`). If the function is not available, create a
+    # function that will loosely count the number of UTF-8 characters with a
+    # regular expression.
+    #
+        if (function_exists($this->utf8_strlen)) {
+            return;
+        }
+        $this->utf8_strlen = create_function('$text', 'return preg_match_all(
 			"/[\\\\x00-\\\\xBF]|[\\\\xC0-\\\\xFF][\\\\x80-\\\\xBF]*/", 
 			$text, $m);');
-	}
+    }
 
 
-	function unhash($text) {
-	#
-	# Swap back in all the tags hashed by _HashHTMLBlocks.
-	#
-		return preg_replace_callback('/(.)\x1A[0-9]+\1/', 
-			array(&$this, '_unhash_callback'), $text);
-	}
-	function _unhash_callback($matches) {
-		return $this->html_hashes[$matches[0]];
-	}
-
+    function unhash($text)
+    {
+    #
+    # Swap back in all the tags hashed by _HashHTMLBlocks.
+    #
+        return preg_replace_callback(
+            '/(.)\x1A[0-9]+\1/',
+            array(&$this, '_unhash_callback'),
+            $text
+        );
+    }
+    function _unhash_callback($matches)
+    {
+        return $this->html_hashes[$matches[0]];
+    }
 }
 
 /*
@@ -1599,7 +1728,7 @@ expected; (3) the output Markdown actually produced.
 
 
 Version History
---------------- 
+---------------
 
 See the readme file for detailed release notes for this version.
 
@@ -1608,29 +1737,29 @@ Copyright and License
 ---------------------
 
 PHP Markdown
-Copyright (c) 2004-2009 Michel Fortin  
-<http://michelf.com/>  
+Copyright (c) 2004-2009 Michel Fortin
+<http://michelf.com/>
 All rights reserved.
 
 Based on Markdown
-Copyright (c) 2003-2006 John Gruber   
-<http://daringfireball.net/>   
+Copyright (c) 2003-2006 John Gruber
+<http://daringfireball.net/>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 
-*	Redistributions of source code must retain the above copyright notice,
-	this list of conditions and the following disclaimer.
+*   Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
 
-*	Redistributions in binary form must reproduce the above copyright
-	notice, this list of conditions and the following disclaimer in the
-	documentation and/or other materials provided with the distribution.
+*   Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
 
-*	Neither the name "Markdown" nor the names of its contributors may
-	be used to endorse or promote products derived from this software
-	without specific prior written permission.
+*   Neither the name "Markdown" nor the names of its contributors may
+    be used to endorse or promote products derived from this software
+    without specific prior written permission.
 
 This software is provided by the copyright holders and contributors "as
 is" and any express or implied warranties, including, but not limited
@@ -1645,4 +1774,3 @@ negligence or otherwise) arising in any way out of the use of this
 software, even if advised of the possibility of such damage.
 
 */
-?>

--- a/wiki/lib/vcs.inc.php
+++ b/wiki/lib/vcs.inc.php
@@ -3,159 +3,178 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class vcs {
+class vcs
+{
 
-  public $name;
-  public $repoprefix;
-  public $repodir;
-  public $commit;
-  public $log = " log ";
-  public $metadir;
-  public $add_everything;
-  public $cat;
+    public $name;
+    public $repoprefix;
+    public $repodir;
+    public $commit;
+    public $log = " log ";
+    public $metadir;
+    public $add_everything;
+    public $cat;
 
-  function __construct($repo) {
-    if (!$repo) {
-      $this->error("vcs::__construct: No repo specified: ".$repo);
+    function __construct($repo)
+    {
+        if (!$repo) {
+            $this->error("vcs::__construct: No repo specified: ".$repo);
+        }
+        if (!is_dir($repo)) {
+            $this->error("vcs::__construct: The repo directory does not exist: ".$repo);
+        }
+        if (!preg_match("/\/$/", $repo)) {
+            $repo.= "/"; // make sure repo ends in a slash
+        }
+        if (!is_dir($repo.$this->metadir)) {
+            $this->error("vcs::__construct: The vcs metadata directory does not exist: ".$repo.$this->metadir);
+        }
+
+        if (is_dir($repo) && !is_dir($repo.$this->metadir)) {
+            $this->msg("vcs::__construct: No metadir found. Initializing repository.");
+            $this->init();
+        }
     }
-    if (!is_dir($repo)) {
-      $this->error("vcs::__construct: The repo directory does not exist: ".$repo);
+    function get()
+    {
+      // Check if we're using a VCS
+        $class = "vcs_".config::get_config_item("wikiVCS");
+        if (class_exists($class)) {
+            $vcs = new $class(wiki_module::get_wiki_path());
+        }
+        return $vcs;
     }
-    if (!preg_match("/\/$/",$repo)) {
-      $repo.= "/"; // make sure repo ends in a slash
+    function error($msg = "")
+    {
+      //echo "\n<br>vcs->error: ".$msg;
     }
-    if (!is_dir($repo.$this->metadir)) {
-      $this->error("vcs::__construct: The vcs metadata directory does not exist: ".$repo.$this->metadir);
+    function msg($msg = "")
+    {
+      //echo "\n<br>vcs->msg: ".$msg;
+    }
+    function juggle_command_order($name, $command, $repo)
+    {
+        return $name." ".$command." ".$repo;
+    }
+    function run($command)
+    {
+        if ($command) {
+          // 2>&1 nope
+            $str = $this->juggle_command_order($this->name, $command, $this->repoprefix);
+            $this->debug and print "<br>vcs->run: ".page::htmlentities($str);
+            list($output, $result) = $this->exec($str);
+            if ($result != 0) {
+                //$error = $str."<br>".implode("<br>", $output)."<br>".$result;
+                //$this->error("vcs::run:error ".$error);
+                $output and $this->error("vcs::run:error: ".implode("<br>", $output));
+                return $output;
+            }
+            $output and $this->msg("vcs::run:msg: ".implode("<br>", $output));
+            return $output;
+        }
+    }
+    function exec($str)
+    {
+        $this->msg("vcs::exec:command: ".$str);
+        $oldUMask = umask(0002);
+        exec($str, $output, $result);
+        umask($oldUMask);
+        $this->msg("vcs::exec:result: ".sprintf("%d ", $result).implode("<br>", $output));
+        return array($output,$result);
+    }
+    function init()
+    {
+        $this->run("init");
+        $this->run($this->add_everything);
+        $this->commit("", "Initial import.");
+    }
+    function commit($file, $message = false)
+    {
+        $message or $message = "Modified file.";
+        if (!$this->file_in_vcs($file)) {
+            $this->add($file);
+        }
+        $this->run($this->commit." ".escapeshellarg($message)." ".escapeshellarg($file));
+    }
+    function log($file)
+    {
+        return $this->run($this->log." ".escapeshellarg($file));
+    }
+    function cat($file, $revision)
+    {
+        $lines = $this->run(sprintf(
+            $this->cat,
+            escapeshellarg($file),
+            escapeshellarg($revision),
+            escapeshellarg(str_replace(wiki_module::get_wiki_path(), "", $file))
+        ));
+        $lines or $lines = array();
+        return implode("\n", $lines);
+    }
+    function diff()
+    {
+    }
+    function add($file)
+    {
+        $this->run("add ".escapeshellarg($file));
+    }
+    function rm($src, $message)
+    {
+        $this->run("rm ".escapeshellarg($src));
+        $this->run($this->commit." ".escapeshellarg($message)." ".escapeshellarg($src));
+    }
+    function mv($src, $dst, $message)
+    {
+        $this->run("mv ".escapeshellarg($src)." ".escapeshellarg($dst));
+        $this->run($this->commit." ".escapeshellarg($message)." ".escapeshellarg($src)." ".escapeshellarg($dst));
+    }
+    function format_log($logs = array())
+    {
+      /*
+        We're expecting each log entry to look like this:
+        Hash: r2432432
+        Author: Alex Lance
+        Date: 43242432
+        Msg: This is the commit message
+      */
+
+        $logs or $logs = array();
+        $rtn or $rtn = array();
+        foreach ($logs as $line) {
+            if (preg_match("/^Hash: (\w+)/", $line, $matches)) {
+                $id = $matches[1];
+            } else if (preg_match("/^Author: (.*$)/", $line, $matches)) {
+                $rtn[$id]["author"] = page::htmlentities(trim($matches[1]));
+            } else if (preg_match("/^Date: (.*$)/", $line, $matches)) {
+                $rtn[$id]["date"] = date("Y-m-d H:i:s", page::htmlentities(trim($matches[1])));
+            } else if (preg_match("/^Msg: (.+$)/", $line, $matches)) {
+                $rtn[$id]["msg"] = page::htmlentities(trim($matches[1]));
+            }
+        }
+        return $rtn;
     }
 
-    if (is_dir($repo) && !is_dir($repo.$this->metadir)) {
-      $this->msg("vcs::__construct: No metadir found. Initializing repository.");
-      $this->init();
-    }
-  }
-  function get() {
-    // Check if we're using a VCS
-    $class = "vcs_".config::get_config_item("wikiVCS");
-    if (class_exists($class)) {
-      $vcs = new $class(wiki_module::get_wiki_path());
-    }
-    return $vcs;
-  }
-  function error($msg="") {
-    //echo "\n<br>vcs->error: ".$msg;
-  }
-  function msg($msg="") {
-    //echo "\n<br>vcs->msg: ".$msg;
-  }
-  function juggle_command_order($name, $command, $repo) {
-    return $name." ".$command." ".$repo;
-  }
-  function run($command) {
-    if ($command) {
-      // 2>&1 nope
-      $str = $this->juggle_command_order($this->name, $command, $this->repoprefix);
-      $this->debug and print "<br>vcs->run: ".page::htmlentities($str);
-      list($output, $result) = $this->exec($str);
-      if ($result != 0) {
-        //$error = $str."<br>".implode("<br>", $output)."<br>".$result;
-        //$this->error("vcs::run:error ".$error);
-        $output and $this->error("vcs::run:error: ".implode("<br>",$output));
-        return $output;
-      }
-      $output and $this->msg("vcs::run:msg: ".implode("<br>",$output));
-      return $output;
-    }
-  }
-  function exec($str) {
-    $this->msg("vcs::exec:command: ".$str);
-    $oldUMask = umask(0002);
-    exec($str,$output,$result);
-    umask($oldUMask);
-    $this->msg("vcs::exec:result: ".sprintf("%d ",$result).implode("<br>",$output));
-    return array($output,$result);
-  }
-  function init() {
-    $this->run("init");
-    $this->run($this->add_everything);
-    $this->commit("", "Initial import.");
-  }
-  function commit($file,$message=false) {
-    $message or $message = "Modified file.";
-    if (!$this->file_in_vcs($file)) {
-      $this->add($file);
-    }
-    $this->run($this->commit." ".escapeshellarg($message)." ".escapeshellarg($file));
-  }
-  function log($file) {
-    return $this->run($this->log." ".escapeshellarg($file));
-  }
-  function cat($file, $revision) {
-    $lines = $this->run(sprintf($this->cat, escapeshellarg($file), escapeshellarg($revision)
-                                ,escapeshellarg(str_replace(wiki_module::get_wiki_path(),"",$file))));
-    $lines or $lines = array();
-    return implode("\n",$lines);
-  }
-  function diff() {
-  }
-  function add($file) {
-    $this->run("add ".escapeshellarg($file));
-  }
-  function rm($src, $message) {
-    $this->run("rm ".escapeshellarg($src));
-    $this->run($this->commit." ".escapeshellarg($message)." ".escapeshellarg($src));
-  }
-  function mv($src, $dst, $message) {
-    $this->run("mv ".escapeshellarg($src)." ".escapeshellarg($dst));
-    $this->run($this->commit." ".escapeshellarg($message)." ".escapeshellarg($src)." ".escapeshellarg($dst));
-  }
-  function format_log($logs=array()) {
-    /*
-      We're expecting each log entry to look like this:
-      Hash: r2432432
-      Author: Alex Lance
-      Date: 43242432
-      Msg: This is the commit message
-    */
-
-    $logs or $logs = array();
-    $rtn or $rtn = array();
-    foreach($logs as $line) {
-      if (preg_match("/^Hash: (\w+)/",$line,$matches)) {
-        $id = $matches[1];
-      } else if (preg_match("/^Author: (.*$)/",$line,$matches)) {
-        $rtn[$id]["author"] = page::htmlentities(trim($matches[1]));
-      } else if (preg_match("/^Date: (.*$)/",$line,$matches)) {
-        $rtn[$id]["date"] = date("Y-m-d H:i:s",page::htmlentities(trim($matches[1])));
-      } else if (preg_match("/^Msg: (.+$)/",$line,$matches)) {
-        $rtn[$id]["msg"] = page::htmlentities(trim($matches[1]));
-      }
-    }
-    return $rtn;
-  }
 
 
-
-  function file_in_vcs() {}
-
+    function file_in_vcs()
+    {
+    }
 }
-
-
-?>

--- a/wiki/lib/vcs_darcs.inc.php
+++ b/wiki/lib/vcs_darcs.inc.php
@@ -3,67 +3,66 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class vcs_darcs extends vcs {
+class vcs_darcs extends vcs
+{
 
-  function __construct($repo) {
-    $current_user = &singleton("current_user");
-    $this->name = "darcs ";
-    $this->repodir = $repo;
-    $this->repoprefix = " --repodir=".$repo." ";
-    $this->commit = " rec --author=".escapeshellarg($current_user->get_name()." <".$current_user->get_value("emailAddress").">")." --all -m ";
-    $this->log = " changes --xml-output ";
-    $this->metadir = "_darcs";
-    $this->add_everything = " add -r . ";
-    $this->cat = ' show contents %1$s --match %2$s ';
-    parent::__construct($repo);
-  }
-
-  function file_in_vcs($file) {
-    $output = $this->run("changes --count ".$file);
-    if (end($output) > 0) {
-      return true;
+    function __construct($repo)
+    {
+        $current_user = &singleton("current_user");
+        $this->name = "darcs ";
+        $this->repodir = $repo;
+        $this->repoprefix = " --repodir=".$repo." ";
+        $this->commit = " rec --author=".escapeshellarg($current_user->get_name()." <".$current_user->get_value("emailAddress").">")." --all -m ";
+        $this->log = " changes --xml-output ";
+        $this->metadir = "_darcs";
+        $this->add_everything = " add -r . ";
+        $this->cat = ' show contents %1$s --match %2$s ';
+        parent::__construct($repo);
     }
-  }
 
-  function format_log($msg="") {
-    $rtn = array();
-    $msg = implode(" ",$msg);
-    if ($msg) {
-      $xml = new SimpleXMLElement($msg);
-      if (is_object($xml) && is_object($xml->patch)) {
-        foreach($xml->patch as $attr) {
-          $id = "hash ".(string)$attr["hash"];
-          $rtn[$id]["author"] = (string)$attr["author"];
-          //$rtn[$id]["date"] = date("Y-m-d H:i:s",(string)$attr["date"]);
-          preg_match("/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/",(string)$attr["date"],$m);
-          $rtn[$id]["date"] = $m[1]."-".$m[2]."-".$m[3]." ".$m[4].":".$m[5].":".$m[6];
-          $rtn[$id]["msg"] = (string)$attr->name;
+    function file_in_vcs($file)
+    {
+        $output = $this->run("changes --count ".$file);
+        if (end($output) > 0) {
+            return true;
         }
-      }
     }
-    return $rtn;
-  }
 
-
+    function format_log($msg = "")
+    {
+        $rtn = array();
+        $msg = implode(" ", $msg);
+        if ($msg) {
+            $xml = new SimpleXMLElement($msg);
+            if (is_object($xml) && is_object($xml->patch)) {
+                foreach ($xml->patch as $attr) {
+                    $id = "hash ".(string)$attr["hash"];
+                    $rtn[$id]["author"] = (string)$attr["author"];
+                  //$rtn[$id]["date"] = date("Y-m-d H:i:s",(string)$attr["date"]);
+                    preg_match("/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/", (string)$attr["date"], $m);
+                    $rtn[$id]["date"] = $m[1]."-".$m[2]."-".$m[3]." ".$m[4].":".$m[5].":".$m[6];
+                    $rtn[$id]["msg"] = (string)$attr->name;
+                }
+            }
+        }
+        return $rtn;
+    }
 }
-
-
-?>

--- a/wiki/lib/vcs_git.inc.php
+++ b/wiki/lib/vcs_git.inc.php
@@ -3,52 +3,52 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class vcs_git extends vcs {
+class vcs_git extends vcs
+{
 
-  function __construct($repo) {
-    $current_user = &singleton("current_user");
-    //$this->debug = true;
-    $this->name = "git ";
-    $this->repodir = $repo;
-    $this->repoprefix = " --git-dir '".$repo.".git' --work-tree '".$repo."' ";
-    $this->commit = " commit --author '".$current_user->get_name()." <".$current_user->get_value("emailAddress").">' -m ";
-    $this->metadir = ".git";
-    $this->add_everything = " add ".$repo."/. "; 
-    $this->log = " log --pretty=format:'Hash: %H%nAuthor: %an%nDate: %ct%nMsg: %s' -M -C --follow ";
-    $this->cat = ' show %2$s:%3$s ';
-    parent::__construct($repo);
-  }
-
-  function file_in_vcs($file) {
-    $output = $this->run("log ".$file);
-    if (count($output) > 0 && !preg_match("/^fatal:/",current($output))) {
-      return true;
+    function __construct($repo)
+    {
+        $current_user = &singleton("current_user");
+      //$this->debug = true;
+        $this->name = "git ";
+        $this->repodir = $repo;
+        $this->repoprefix = " --git-dir '".$repo.".git' --work-tree '".$repo."' ";
+        $this->commit = " commit --author '".$current_user->get_name()." <".$current_user->get_value("emailAddress").">' -m ";
+        $this->metadir = ".git";
+        $this->add_everything = " add ".$repo."/. ";
+        $this->log = " log --pretty=format:'Hash: %H%nAuthor: %an%nDate: %ct%nMsg: %s' -M -C --follow ";
+        $this->cat = ' show %2$s:%3$s ';
+        parent::__construct($repo);
     }
-  }
 
-  function juggle_command_order($name, $command, $repo) {
-    return $name." ".$repo." ".$command;
-  }
+    function file_in_vcs($file)
+    {
+        $output = $this->run("log ".$file);
+        if (count($output) > 0 && !preg_match("/^fatal:/", current($output))) {
+            return true;
+        }
+    }
 
+    function juggle_command_order($name, $command, $repo)
+    {
+        return $name." ".$repo." ".$command;
+    }
 }
-
-
-?>

--- a/wiki/lib/vcs_mercurial.inc.php
+++ b/wiki/lib/vcs_mercurial.inc.php
@@ -3,86 +3,86 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-class vcs_mercurial extends vcs {
+class vcs_mercurial extends vcs
+{
 
-  function __construct($repo) {
-    $current_user = &singleton("current_user");
-    $this->name = "hg ";
-    $this->repodir = $repo;
-    $this->repoprefix = " --cwd '".$repo."' ";
-    $this->commit = " commit --user='".$current_user->get_name()." <".$current_user->get_value("emailAddress").">' -m ";
-    $this->metadir = ".hg";
-    $this->add_everything = " add "; 
-    $this->cat = ' cat -r %2$s %1$s ';
+    function __construct($repo)
+    {
+        $current_user = &singleton("current_user");
+        $this->name = "hg ";
+        $this->repodir = $repo;
+        $this->repoprefix = " --cwd '".$repo."' ";
+        $this->commit = " commit --user='".$current_user->get_name()." <".$current_user->get_value("emailAddress").">' -m ";
+        $this->metadir = ".hg";
+        $this->add_everything = " add ";
+        $this->cat = ' cat -r %2$s %1$s ';
 
-    /* 
-    author String. The unmodified author of the changeset. 
-    branches String. The name of the branch on which the changeset was committed. Will be empty if the branch name was default. 
-    date Date information. The date when the changeset was committed. This is not human-readable; you must pass it through a filter that will render it appropriately. See section 11.6 for more information on filters. The date is expressed as a pair of numbers. The first number is a Unix UTC timestamp (seconds since January 1, 1970); the second is the offset of the committer’s timezone from UTC, in seconds. 
-    desc String. The text of the changeset description. 
-    files List of strings. All files modified, added, or removed by this changeset. 
-    filet4ht@95xadds List of strings. Files added by this changeset. 
-    filet4ht@95xdels List of strings. Files removed by this changeset. 
-    node String. The changeset identification hash, as a 40-character hexadecimal string. 
-    parents List of strings. The parents of the changeset. 
-    rev Integer. The repository-local changeset revision number. 
-    tags List of strings. Any tags associated with the changeset.
-    */
-    $this->log = " log --template 'Hash: {node}\nAuthor: {author}\nDate: {date}\nMsg: {desc}\n' ";
-    parent::__construct($repo);
-  }
-
-  function file_in_vcs($file) {
-    $output = $this->run("log ".$file);
-    if (count($output) > 0) {
-      return true;
+      /*
+      author String. The unmodified author of the changeset.
+      branches String. The name of the branch on which the changeset was committed. Will be empty if the branch name was default.
+      date Date information. The date when the changeset was committed. This is not human-readable; you must pass it through a filter that will render it appropriately. See section 11.6 for more information on filters. The date is expressed as a pair of numbers. The first number is a Unix UTC timestamp (seconds since January 1, 1970); the second is the offset of the committer’s timezone from UTC, in seconds.
+      desc String. The text of the changeset description.
+      files List of strings. All files modified, added, or removed by this changeset.
+      filet4ht@95xadds List of strings. Files added by this changeset.
+      filet4ht@95xdels List of strings. Files removed by this changeset.
+      node String. The changeset identification hash, as a 40-character hexadecimal string.
+      parents List of strings. The parents of the changeset.
+      rev Integer. The repository-local changeset revision number.
+      tags List of strings. Any tags associated with the changeset.
+      */
+        $this->log = " log --template 'Hash: {node}\nAuthor: {author}\nDate: {date}\nMsg: {desc}\n' ";
+        parent::__construct($repo);
     }
-  }
 
-  function juggle_command_order($name, $command, $repo) {
-    return $name." ".$repo." ".$command;
-  }
-
-  function format_log($msg) {
-    $msg = parent::format_log($msg);
-    $msg or $msg = array();
-    foreach ($msg as $id => $arr) { 
-      $a = explode(" ",$arr["author"]); // need to strip the email address from the author field
-      count($a) >1 and array_pop($a);
-      $msg[$id]["author"] = implode(" ",$a);
+    function file_in_vcs($file)
+    {
+        $output = $this->run("log ".$file);
+        if (count($output) > 0) {
+            return true;
+        }
     }
-    return $msg;
-  }
 
-  function log($file) {
+    function juggle_command_order($name, $command, $repo)
+    {
+        return $name." ".$repo." ".$command;
+    }
+
+    function format_log($msg)
+    {
+        $msg = parent::format_log($msg);
+        $msg or $msg = array();
+        foreach ($msg as $id => $arr) {
+            $a = explode(" ", $arr["author"]); // need to strip the email address from the author field
+            count($a) >1 and array_pop($a);
+            $msg[$id]["author"] = implode(" ", $a);
+        }
+        return $msg;
+    }
+
+    function log($file)
+    {
   
-    if (is_file(wiki_module::get_wiki_path().DIRECTORY_SEPARATOR.$file)) {
-      $this->log.= " -f "; // follow renames to files
+        if (is_file(wiki_module::get_wiki_path().DIRECTORY_SEPARATOR.$file)) {
+            $this->log.= " -f "; // follow renames to files
+        }
+        return $this->run($this->log." ".escapeshellarg($file));
     }
-    return $this->run($this->log." ".escapeshellarg($file));
-  }
-
-
-
 }
-
-
-?>

--- a/wiki/lib/wiki.inc.php
+++ b/wiki/lib/wiki.inc.php
@@ -20,29 +20,31 @@
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
 
-class wiki {
+class wiki
+{
 
-  public static function get_list($_FORM) {
-    global $TPL;
-    $current_user = &singleton("current_user");
+    public static function get_list($_FORM)
+    {
+        global $TPL;
+        $current_user = &singleton("current_user");
 
-    $wiki_path = wiki_module::get_wiki_path();
-    $files = search::get_recursive_dir_list($wiki_path);
+        $wiki_path = wiki_module::get_wiki_path();
+        $files = search::get_recursive_dir_list($wiki_path);
 
-    foreach ($files as $row) {
-      $file = str_replace($wiki_path,"",$row);
-      if ($_FORM["starred"] && $current_user->prefs["stars"]["wiki"][base64_encode($file)]) {
-        $rows[] = array("filename"=>$file);
-      }
+        foreach ($files as $row) {
+            $file = str_replace($wiki_path, "", $row);
+            if ($_FORM["starred"] && $current_user->prefs["stars"]["wiki"][base64_encode($file)]) {
+                $rows[] = array("filename"=>$file);
+            }
+        }
+        return (array)$rows;
     }
-    return (array)$rows;
-  }
 
-  function get_list_html($rows=array(),$ops=array()) {
-    global $TPL;
-    $TPL["wikiListRows"] = $rows;
-    $TPL["_FORM"] = $ops;
-    include_template(dirname(__FILE__)."/../templates/wikiListS.tpl");
-  }
+    function get_list_html($rows = array(), $ops = array())
+    {
+        global $TPL;
+        $TPL["wikiListRows"] = $rows;
+        $TPL["_FORM"] = $ops;
+        include_template(dirname(__FILE__)."/../templates/wikiListS.tpl");
+    }
 }
-?>

--- a/wiki/wiki.php
+++ b/wiki/wiki.php
@@ -3,19 +3,19 @@
 /*
  * Copyright (C) 2006-2011 Alex Lance, Clancy Malcolm, Cyber IT Solutions
  * Pty. Ltd.
- * 
+ *
  * This file is part of the allocPSA application <info@cyber.com.au>.
- * 
+ *
  * allocPSA is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * allocPSA is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with allocPSA. If not, see <http://www.gnu.org/licenses/>.
 */
@@ -27,11 +27,9 @@ $TPL["rev"] = $_GET["rev"];
 $TPL["wiki_tree"] = ATTACHMENTS_DIR."wiki";
 
 if ($_REQUEST['op'] == 'new') {
-  $TPL['newFile'] = 'true';
+    $TPL['newFile'] = 'true';
 } else {
-  $TPL['newFile'] = '';
+    $TPL['newFile'] = '';
 }
 
 include_template("templates/wikiM.tpl");
-
-?>


### PR DESCRIPTION
Right, this should be easier to check than PR #43. 🙂

Steps to reproduce:

1. run phpcbf (found in package `php-codesniffer` on debian based systems) using the PSR-2 ruleset on your copy of alloc, but excluding the `else if` check:

```
$ phpcbf --standard=PSR2 --exclude=PSR2.ControlStructures.ElseIfDeclaration .
```

2. run `git checkout -- <files>` to remove non php files, php libraries that aren't alloc and the patches dir:

```
$ git checkout -- zend/ shared/lib/C*.php shared/lib/PclZip.inc.php shared/lib/Services_JSON.inc.php email/lib/Mail_*.php javascript/ css/ patches/ services/doc/stylesheet.css
```

3. finally, replace the one existing `elseif` in config/configEdit.php with `else if` for consistency:

```
$ sed -i 's/elseif/else if/' config/configEdit.php
```

You will notice that there has been no manual indentation of comments, arrays, or sql. That will come in the next PR.