### PR TITLE
fix traceback when pressing 'delete transactions'

### DIFF
--- a/time/lib/timeSheet.inc.php
+++ b/time/lib/timeSheet.inc.php
@@ -243,7 +243,6 @@ class timeSheet extends db_entity
         $db = new db_alloc();
         $query = prepare("DELETE FROM transaction WHERE timeSheetID = %d AND transactionType != 'invoice'", $this->get_id());
         $db->query($query);
-        $db->next_record();
     }
 
     function createTransactions($status = "pending")


### PR DESCRIPTION
Fix traceback when pressing 'delete transactions' in the timesheet invoice stage.

ref: 8a43f5338b2fd5feaf8d79e8f326b512f24f1594
