### PR TITLE
Add vim to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:stretch-slim
 # install apache, php, and mariadb (mysql)
 RUN apt-get update &&\
 	apt-get -y upgrade &&\
-	apt-get install -y apache2 php php-mysql php-mbstring php-gd mariadb-server make python
+	apt-get install -y apache2 php php-mysql php-mbstring php-gd mariadb-server make python vim
 
 # rm any files/folders created by apcahe
 RUN rm -rvf /var/www/html/*

--- a/time/lib/timeSheet.inc.php
+++ b/time/lib/timeSheet.inc.php
@@ -243,7 +243,6 @@ class timeSheet extends db_entity
         $db = new db_alloc();
         $query = prepare("DELETE FROM transaction WHERE timeSheetID = %d AND transactionType != 'invoice'", $this->get_id());
         $db->query($query);
-        $db->next_record();
     }
 
     function createTransactions($status = "pending")


### PR DESCRIPTION
I've added vim to the list of things to install because it helps to be able to use an editor when working inside the docker container. nano isn't installed by default, and since I figure most developers *should* know how to use vim, and vim has syntax highlighting for lots of langs by default, I picked vim