### PR TITLE
Tidy Javascript

### DIFF
--- a/.esformatter
+++ b/.esformatter
@@ -1,0 +1,14 @@
+{
+    "plugins": [
+        "esformatter-dot-notation",
+        "esformatter-semicolons",
+        "esformatter-braces",
+        "esformatter-eol-last",
+        "esformatter-quotes",
+        "esformatter-var-each"
+    ],
+    "quotes": {
+        "type": "single",
+        "avoidEscape": true
+    }
+}

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -192,6 +192,8 @@ to the main alloc repo! This will mess up other peoples clones.
 
 ## Alloc coding standards
 
+## PHP
+
 We follow the [PSR-2](https://www.php-fig.org/psr/psr-2/) coding
 standard with the exception of `else if`. Please use `else if` instead
 of `elseif`.
@@ -199,3 +201,21 @@ of `elseif`.
 Because the alloc code base did not use PSR-2 until late 2018, many
 class/method names do not match the PSR-2 recommendations, this is an
 ongoing effort.
+
+## Javascript
+
+You'll need to install esformatter and the needed plugins, e.g.:
+
+```
+$ npm install -g esformatter esformatter-dot-notation esformatter-semicolons esformatter-braces esformatter-eol-last esformatter-quotes esformatter-var-each
+```
+
+Note: you may want to set a prefix (install path) with `--prefix`. If you do,
+make sure to add the `bin` directory from your node prefix/install path to your
+`PATH`.
+
+To use esformatter:
+
+```
+$ esformatter -i javascript/zz_alloc.js
+```

--- a/javascript/zz_alloc.js
+++ b/javascript/zz_alloc.js
@@ -1,44 +1,44 @@
 function redraw_multiple_selects(container) {
   var c = container;
-  if (typeof container == "string") {
-    c = "#"+container;
+  if (typeof container == 'string') {
+    c = '#' + container;
   }
-  $("select[multiple]",c).selectn("destroy",c);
-  $("select[multiple]",c).selectn();
+  $('select[multiple]', c).selectn('destroy', c);
+  $('select[multiple]', c).selectn();
 }
 
 // Make the XML request thing, specify the callback function
 function refreshProjectList(radiobutton) {
-  url = get_alloc_var('url')+'task/updateProjectList.php?projectType='+radiobutton.value;
-  makeAjaxRequest(url, 'projectListDropdown','',1)
+  url = get_alloc_var('url') + 'task/updateProjectList.php?projectType=' + radiobutton.value;
+  makeAjaxRequest(url, 'projectListDropdown', '', 1);
 }
 
 function add_gst(value) {
-  var tax_percent = get_alloc_var("tax_percent");
-  return Math.round(value * (tax_percent/100 +1)*100)/100;
+  var tax_percent = get_alloc_var('tax_percent');
+  return Math.round(value * (tax_percent / 100 + 1) * 100) / 100;
 }
 
 function deduct_gst(value) {
-  var tax_percent = get_alloc_var("tax_percent");
-  return Math.round(value / (tax_percent/100 +1)*100)/100;
+  var tax_percent = get_alloc_var('tax_percent');
+  return Math.round(value / (tax_percent / 100 + 1) * 100) / 100;
 }
 
 function toggle_view_edit(reset) {
-  $(".view").toggle();
-  $(".edit").toggle();
+  $('.view').toggle();
+  $('.edit').toggle();
   if (reset) {
-    $(this).parents("form").reset();
+    $(this).parents('form').reset();
   }
   redraw_multiple_selects();
   return false;
 }
 
-function makeAjaxRequest(url,entityid,extra_fields,redraw) {
-  $("#"+entityid).html('<img class="ticker" src="../images/ticker2.gif" alt="Updating field..." title="Updating field...">');
-  jQuery.get(url,extra_fields,function(data) {
-    $("#"+entityid).hide();
-    $("#"+entityid).html(data);
-    $("#"+entityid).fadeIn("fast");
+function makeAjaxRequest(url, entityid, extra_fields, redraw) {
+  $('#' + entityid).html('<img class="ticker" src="../images/ticker2.gif" alt="Updating field..." title="Updating field...">');
+  jQuery.get(url, extra_fields, function(data) {
+    $('#' + entityid).hide();
+    $('#' + entityid).html(data);
+    $('#' + entityid).fadeIn('fast');
 
     // We may need to redraw the select widgets
     if (redraw) {
@@ -51,50 +51,50 @@ function makeAjaxRequest(url,entityid,extra_fields,redraw) {
 function set_grow_shrink(id, id_to_hide, use_classes_instead_of_ids) {
   // toggle the other div - if any
   if (use_classes_instead_of_ids && id_to_hide) {
-    $("."+id_to_hide).slideToggle("fast");
+    $('.' + id_to_hide).slideToggle('fast');
   } else if (id_to_hide) {
-    $("#"+id_to_hide).slideToggle("fast");
+    $('#' + id_to_hide).slideToggle('fast');
   }
   // hide or show the actual div
   if (use_classes_instead_of_ids) {
-    $("."+id).slideToggle("fast");
+    $('.' + id).slideToggle('fast');
   } else {
-    $("#"+id).slideToggle("fast");
+    $('#' + id).slideToggle('fast');
   }
   return false;
 }
 
-function sidebyside_activate(id,redraw) {
+function sidebyside_activate(id, redraw) {
   var arr = [];
-  $.each($(".sidebyside"), function(k,v) {
-    arr[arr.length] = v.id.replace("sbs_link_","");
+  $.each($('.sidebyside'), function(k, v) {
+    arr[arr.length] = v.id.replace('sbs_link_', '');
   });
 
   if (!id) {
-    id = get_alloc_var("side_by_side_link");
+    id = get_alloc_var('side_by_side_link');
   }
   if (!id) {
     id = arr[0];
   }
 
-  if (id == "sbsAll") {
-    for (var i=0; i<arr.length; i++) {
-      if (arr[i] != "sbsAll") {
-        $("#"+arr[i]).show();
-        $('#sbs_link_'+arr[i]).removeClass("sidebyside_active").addClass("sidebyside");
+  if (id == 'sbsAll') {
+    for (var i = 0; i < arr.length; i++) {
+      if (arr[i] != 'sbsAll') {
+        $('#' + arr[i]).show();
+        $('#sbs_link_' + arr[i]).removeClass('sidebyside_active').addClass('sidebyside');
       }
     }
-    $('#sbs_link_' + id).addClass("sidebyside_active");
+    $('#sbs_link_' + id).addClass('sidebyside_active');
 
   } else {
-    for (var i=0; i<arr.length; i++) {
-      if (arr[i] != "sbsAll") {
-        $("#"+arr[i]).hide();
+    for (var i = 0; i < arr.length; i++) {
+      if (arr[i] != 'sbsAll') {
+        $('#' + arr[i]).hide();
       }
-      $('#sbs_link_' + arr[i]).removeClass("sidebyside_active").addClass("sidebyside");
+      $('#sbs_link_' + arr[i]).removeClass('sidebyside_active').addClass('sidebyside');
     }
-    $('#sbs_link_' + id).addClass("sidebyside_active");
-    $("#"+id).show();
+    $('#sbs_link_' + id).addClass('sidebyside_active');
+    $('#' + id).show();
   }
 
   // allows us to target particular pages for redraw_multiple_selects();
@@ -104,41 +104,41 @@ function sidebyside_activate(id,redraw) {
 function help_text_on(id, str) {
   $('#main').append("<div id='helper' class='corner' style='display:none'></div>");
   $('#helper').html(str).hide();
-  var offset = $('#'+id).position();
-  var x = offset.left -420;
+  var offset = $('#' + id).position();
+  var x = offset.left - 420;
   if (x < 0) {
     x = x + 400;
   }
   var y = offset.top + 20;
   if ((y + $('#helper').height() + 40) > $(document).height()) {
-    y = y-$('#helper').height() - 40;
+    y = y - $('#helper').height() - 40;
   }
-  $("#helper").css('left',x);
-  $("#helper").css('top',y);
-  $("#helper").fadeIn("normal");
+  $('#helper').css('left', x);
+  $('#helper').css('top', y);
+  $('#helper').fadeIn('normal');
 }
 function help_text_off(id) {
-  $("#helper").fadeOut("normal");
+  $('#helper').fadeOut('normal');
   $('#helper').remove();
 }
 function preload_field(element, text) {
   $(document).ready(function() {
-    $(element).bind("focus", function(e){
+    $(element).bind('focus', function(e) {
       if (this.value == text) {
-        this.style.color = "#333333";
-        this.value = "";
+        this.style.color = '#333333';
+        this.value = '';
       }
     });
-    $(element).each(function(){
-      if (this.value == "") {
-        this.style.color = "#bbbbbb";
+    $(element).each(function() {
+      if (this.value == '') {
+        this.style.color = '#bbbbbb';
         this.value = text;
       }
     });
-    $('form').submit(function(){
-      $(element).each(function(){
+    $('form').submit(function() {
+      $(element).each(function() {
         if (this.value == text) {
-          this.value = "";
+          this.value = '';
         }
       });
     });
@@ -147,51 +147,54 @@ function preload_field(element, text) {
 
 function save_recipients(data) {
   var p = data.select.parent();
-  var commentID = p.find("input[name=commentID]").val();
+  var commentID = p.find('input[name=commentID]').val();
   var values = data.select.val();
 
-  jQuery.post("../comment/updateRecipients.php",{ "commentID":commentID, "comment_recipients":values},function(data) {
+  jQuery.post('../comment/updateRecipients.php', {
+    'commentID': commentID,
+    'comment_recipients': values
+  }, function(data) {
     p.parent().hide();
     if (data == 'external') {
-      var label = '<em class="faint warn">[ External Conversation ]</em>'
-      p.parents(".panel").addClass("loud");
+      var label = '<em class="faint warn">[ External Conversation ]</em>';
+      p.parents('.panel').addClass('loud');
     } else {
-      var label = '<em class="faint">[ Internal Conversation ]</em>'
-      p.parents(".panel").removeClass("loud");
+      var label = '<em class="faint">[ Internal Conversation ]</em>';
+      p.parents('.panel').removeClass('loud');
     }
-    p.parent().parent().find("a.recipient_editor_link").html(label).show();
+    p.parent().parent().find('a.recipient_editor_link').html(label).show();
   });
 }
 
-calendar_counter = 0
+calendar_counter = 0;
 function refresh_calendars() {
-  $(".datefield").each(function(){
-    calendar_counter = calendar_counter +1;
-    var calendar_id = "calendar_"+calendar_counter;
-    var button_id = "calendar_button_"+calendar_counter;
-    $(this).attr("id",calendar_id);
-    $(this).next("img").attr("id",button_id);
+  $('.datefield').each(function() {
+    calendar_counter = calendar_counter + 1;
+    var calendar_id = 'calendar_' + calendar_counter;
+    var button_id = 'calendar_button_' + calendar_counter;
+    $(this).attr('id', calendar_id);
+    $(this).next('img').attr('id', button_id);
 
-    var settings = {}
-    settings["inputField"] = calendar_id;
-    settings["ifFormat"] = "%Y-%m-%d";
-    settings["button"] = button_id;
-    settings["showOthers"] = 1;
-    settings["align"] = "Bl";
-    settings["firstDay"] = get_alloc_var("cal_first_day");
-    settings["step"] = 1;
-    settings["weekNumbers"] = 0;
-    settings["date"] = $(this).attr("value");
+    var settings = {};
+    settings.inputField = calendar_id;
+    settings.ifFormat = '%Y-%m-%d';
+    settings.button = button_id;
+    settings.showOthers = 1;
+    settings.align = 'Bl';
+    settings.firstDay = get_alloc_var('cal_first_day');
+    settings.step = 1;
+    settings.weekNumbers = 0;
+    settings.date = $(this).attr('value');
     Calendar.setup(settings);
   });
 }
 
 // Preload mouseover images
 if (document.images) {
-  pic5= new Image(119,13);
-  pic5.src="../images/ticker2.gif";
-  pic6= new Image(16,16);
-  pic6.src="../images/spinner.gif";
+  pic5 = new Image(119, 13);
+  pic5.src = '../images/ticker2.gif';
+  pic6 = new Image(16, 16);
+  pic6.src = '../images/spinner.gif';
 }
 
 
@@ -199,57 +202,61 @@ if (document.images) {
 $(document).ready(function() {
 
   // Focus the login form fields
-  if ($("#login_form").length) {
-    if (!$("#username").val()) {
-      $("#username").focus();
+  if ($('#login_form').length) {
+    if (!$('#username').val()) {
+      $('#username').focus();
     } else {
-      $("#password").focus();
+      $('#password').focus();
     }
   }
 
   // Enable the dynamic table sorting
-  $("table.sortable").each(function() {
+  $('table.sortable').each(function() {
     var t = $(this).stupidtable();
-    var arr = $("<i class='arrow icon-circle-arrow-up' style='font-size:95%'></i>").css("visibility","hidden");
-    $('thead > tr > th',this).not(function(){ return $(this).data("sort") == "none"; }).append(arr).css({"cursor":"pointer"});
+    var arr = $("<i class='arrow icon-circle-arrow-up' style='font-size:95%'></i>").css('visibility', 'hidden');
+    $('thead > tr > th', this).not(function() {
+      return $(this).data('sort') == 'none';
+    }).append(arr).css({
+      'cursor': 'pointer'
+    });
 
-    t.bind('aftertablesort', function (event, data) {
-      var th = $(this).find("th");
-      th.find(".arrow").css("visibility","hidden");
-      th.eq(data.column).find(".arrow").removeClass("icon-circle-arrow-down icon-circle-arrow-up").addClass(data.direction === "asc" ? "icon-circle-arrow-up" : "icon-circle-arrow-down").css("visibility","visible");
-      $("tr:nth-child(even)",this).removeClass("even odd").addClass("even");
-      $("tr:nth-child(odd)",this).removeClass("even odd").addClass("odd");
+    t.bind('aftertablesort', function(event, data) {
+      var th = $(this).find('th');
+      th.find('.arrow').css('visibility', 'hidden');
+      th.eq(data.column).find('.arrow').removeClass('icon-circle-arrow-down icon-circle-arrow-up').addClass(data.direction === 'asc' ? 'icon-circle-arrow-up' : 'icon-circle-arrow-down').css('visibility', 'visible');
+      $('tr:nth-child(even)', this).removeClass('even odd').addClass('even');
+      $('tr:nth-child(odd)', this).removeClass('even odd').addClass('odd');
     });
   });
 
   // Give the tables alternating stripes
-  $(".list tr:nth-child(even)").addClass("even");
-  $(".list tr:nth-child(odd)").addClass("odd");
-  $(".delete_button").on("click", function(e){
-    return confirm("Click OK to confirm deletion.");
+  $('.list tr:nth-child(even)').addClass('even');
+  $('.list tr:nth-child(odd)').addClass('odd');
+  $('.delete_button').on('click', function(e) {
+    return confirm('Click OK to confirm deletion.');
   });
-  $(".confirm_button").bind("click", function(e){
-    return confirm("Click OK to confirm.");
+  $('.confirm_button').bind('click', function(e) {
+    return confirm('Click OK to confirm.');
   });
-  $("input.datefield").bind("dblclick", function(e){
+  $('input.datefield').bind('dblclick', function(e) {
     var now = new Date();
-    this.value=now.getFullYear()+'-'+((1e2 + now.getMonth()+1 + '').substr(1))+'-'+(1e2 + now.getDate() + '').substr(1);
+    this.value = now.getFullYear() + '-' + ((1e2 + now.getMonth() + 1 + '').substr(1)) + '-' + (1e2 + now.getDate() + '').substr(1);
   });
 
-  $('tr.clickrow').bind('click',function(e){
+  $('tr.clickrow').bind('click', function(e) {
     var id = this.id.split('_')[1]; // clickrow_43242
     if (id && !$(e.target).is('input:checkbox') && !$(e.target).is('a') && !$(e.target).is('b')) {
-      $('#checkbox_'+id).attr('checked',!$('#checkbox_'+id).attr('checked'));
+      $('#checkbox_' + id).attr('checked', !$('#checkbox_' + id).attr('checked'));
     }
   });
 
   // This loads up certain textboxes with faint help text that vanishes upon focus
-  preload_field("#menu_form_needle", "Enter search text or ID...");
+  preload_field('#menu_form_needle', 'Enter search text or ID...');
 
-  $("#search_action").change(function(){
-    var bits = $(this).val().split("_");
-    if (bits[0] == "create" || bits[0] == "history") {
-      $("#form_search").submit();
+  $('#search_action').change(function() {
+    var bits = $(this).val().split('_');
+    if (bits[0] == 'create' || bits[0] == 'history') {
+      $('#form_search').submit();
     }
   });
 
@@ -257,95 +264,103 @@ $(document).ready(function() {
   $('textarea:not(.processed)').TextAreaResizer();
 
   // Add toggles for filters
-  $(".toggleFilter").click(function(){
-    var d = $(".filter").css("display");
-    if (d == "table") {
-      var l = "Show Filter";
-      var d = "none";
+  $('.toggleFilter').click(function() {
+    var d = $('.filter').css('display');
+    if (d == 'table') {
+      var l = 'Show Filter';
+      var d = 'none';
     } else {
-      var l = "Hide Filter";
-      var d = "table";
+      var l = 'Hide Filter';
+      var d = 'table';
     }
-    $(".filter").css("display",d);
+    $('.filter').css('display', d);
     $(this).text(l);
     redraw_multiple_selects();
     return false;
   });
 
   // Activate user preference for displaying filters
-  if (get_alloc_var("show_filters") != "yes") {
-    $(".toggleFilter").trigger("click");
+  if (get_alloc_var('show_filters') != 'yes') {
+    $('.toggleFilter').trigger('click');
   }
 
-  $("td.calendar_day img").hide();
-  $(".alloc_calendar").on('click', 'td.calendar_day' ,function(e){
-    $("img",this).toggle();
-    $(this).toggleClass("selected");
+  $('td.calendar_day img').hide();
+  $('.alloc_calendar').on('click', 'td.calendar_day', function(e) {
+    $('img', this).toggle();
+    $(this).toggleClass('selected');
     return true;
   });
 
-  $('input.toggler').click(function(){
+  $('input.toggler').click(function() {
     return $('.task_checkboxes').each(function() {
-      this.checked = !this.checked
+      this.checked = !this.checked;
     });
   });
 
   // Activate side by side links/tabs, if any
-  $(".sidebyside").click(function(e) {
-    var redraw = $(this).attr("data-sbs-redraw");
-    sidebyside_activate(e.target.id.replace("sbs_link_",""),redraw);
+  $('.sidebyside').click(function(e) {
+    var redraw = $(this).attr('data-sbs-redraw');
+    sidebyside_activate(e.target.id.replace('sbs_link_', ''), redraw);
     return false;
   });
   sidebyside_activate();
 
-  $(".edit").hide();
+  $('.edit').hide();
 
   // Mark up the date fields with dynamic calendars
   refresh_calendars();
 
   // Interested Parties recipients editor
-  $(".recipient_editor_link").click(function(){
-    var commentID = this.id.split("_")[2]
+  $('.recipient_editor_link').click(function() {
+    var commentID = this.id.split('_')[2];
     $(this).toggle();
-    $("#recipient_dropdown_"+commentID).slideToggle("fast");
-    redraw_multiple_selects("recipient_dropdown_"+commentID);
+    $('#recipient_dropdown_' + commentID).slideToggle('fast');
+    redraw_multiple_selects('recipient_dropdown_' + commentID);
     return false;
   });
 
-  $(".commentreply").click(function(e){
-    $("#interested_parties_selector").hide();
-    $(this).parents(".pcomment").append($("#id_new_comment").css( { "display" : "inline-table" } ));
-    $("#id_new_comment").find("input[name=entity]").val("comment");
-    $("#id_new_comment").find("input[name=entityID]").val($(this).parents(".pcomment").attr("data-comment-id"));
+  $('.commentreply').click(function(e) {
+    $('#interested_parties_selector').hide();
+    $(this).parents('.pcomment').append($('#id_new_comment').css({
+      'display': 'inline-table'
+    }));
+    $('#id_new_comment').find('input[name=entity]').val('comment');
+    $('#id_new_comment').find('input[name=entityID]').val($(this).parents('.pcomment').attr('data-comment-id'));
     return false;
   });
 
-  $(".commentnew").click(function(e){
-    $("#interested_parties_selector").show();
-    $("#id_new_comment").find("input[name=entity]").val($("#id_new_comment").find("input[name=commentMaster]").val());
-    $("#id_new_comment").find("input[name=entityID]").val($("#id_new_comment").find("input[name=commentMasterID]").val());
-    $("#new_comment_container").append($("#id_new_comment").css( { "display" : "inline-table" } ));
+  $('.commentnew').click(function(e) {
+    $('#interested_parties_selector').show();
+    $('#id_new_comment').find('input[name=entity]').val($('#id_new_comment').find('input[name=commentMaster]').val());
+    $('#id_new_comment').find('input[name=entityID]').val($('#id_new_comment').find('input[name=commentMasterID]').val());
+    $('#new_comment_container').append($('#id_new_comment').css({
+      'display': 'inline-table'
+    }));
     return false;
   });
 
-  $("a.star").on('click',function(){
-    if ($("b",$(this)).hasClass('icon-star-empty')) {
-      $("b",$(this)).removeClass('icon-star-empty').addClass('icon-star');
-      $(this).addClass("hot");
-      $(this).closest("td").attr({"data-sort-value":"1"});
+  $('a.star').on('click', function() {
+    if ($('b', $(this)).hasClass('icon-star-empty')) {
+      $('b', $(this)).removeClass('icon-star-empty').addClass('icon-star');
+      $(this).addClass('hot');
+      $(this).closest('td').attr({
+        'data-sort-value': '1'
+      });
     } else {
-      $("b",$(this)).removeClass('icon-star hot').addClass('icon-star-empty');
-      $(this).removeClass("hot");
-      $(this).closest("td").attr({"data-sort-value":"2"});
+      $('b', $(this)).removeClass('icon-star hot').addClass('icon-star-empty');
+      $(this).removeClass('hot');
+      $(this).closest('td').attr({
+        'data-sort-value': '2'
+      });
     }
-    $.get($(this).attr("href"));
+    $.get($(this).attr('href'));
     return false;
   });
 
 
   // This duplicates a button with class=default and puts it first,
   // so that the web browser treats it as the default submission button.
-  $('form').each(function () {
+  $('form').each(function() {
     var thisform = $(this);
     thisform.prepend(thisform.find('button.default').clone().css({
       position: 'absolute',
@@ -357,20 +372,21 @@ $(document).ready(function() {
   });
 
 
-  $(".config-link").click(function(){
+  $('.config-link').click(function() {
 
-    var elem = $("."+$(this).attr("id")).css({"position":"absolute"
-                                             ,"top":10
-                                             ,"right":0
-                                             ,"display":"inline"
-                                             }).addClass("corner").addClass("shadow");
+    var elem = $('.' + $(this).attr('id')).css({
+      'position': 'absolute',
+      'top': 10,
+      'right': 0,
+      'display': 'inline'
+    }).addClass('corner').addClass('shadow');
 
     // config boxes that have class "lazy" are lazy-loading, i.e. dynamically populated via ajax
-    var i = $(this).attr("id");
-    if ($("."+i).hasClass("lazy")) {
-      $("."+i).html('<img class="ticker" src="../images/ticker2.gif" alt="Updating field..." title="Updating field...">');
-      $.get(get_alloc_var("url")+"home/"+i+".php", function(data) {
-        $("."+i).html(data);
+    var i = $(this).attr('id');
+    if ($('.' + i).hasClass('lazy')) {
+      $('.' + i).html('<img class="ticker" src="../images/ticker2.gif" alt="Updating field..." title="Updating field...">');
+      $.get(get_alloc_var('url') + 'home/' + i + '.php', function(data) {
+        $('.' + i).html(data);
         redraw_multiple_selects();
       });
     }
@@ -382,9 +398,9 @@ $(document).ready(function() {
 
   // This is mainly used for the edit comment recipient logic on the comments screens
   // The data-callback is most likely save_recipients(); Go there.
-  $("html").bind("selectn-closed",function(e,data){
-    if (data.select.attr("data-callback")) {
-      window[data.select.attr("data-callback")](data);
+  $('html').bind('selectn-closed', function(e, data) {
+    if (data.select.attr('data-callback')) {
+      window[data.select.attr('data-callback')](data);
     }
   });
 

--- a/javascript/zz_alloc.js
+++ b/javascript/zz_alloc.js
@@ -66,6 +66,7 @@ function set_grow_shrink(id, id_to_hide, use_classes_instead_of_ids) {
 
 function sidebyside_activate(id, redraw) {
   var arr = [];
+  var i;
   $.each($('.sidebyside'), function(k, v) {
     arr[arr.length] = v.id.replace('sbs_link_', '');
   });
@@ -78,7 +79,7 @@ function sidebyside_activate(id, redraw) {
   }
 
   if (id == 'sbsAll') {
-    for (var i = 0; i < arr.length; i++) {
+    for (i = 0; i < arr.length; i++) {
       if (arr[i] != 'sbsAll') {
         $('#' + arr[i]).show();
         $('#sbs_link_' + arr[i]).removeClass('sidebyside_active').addClass('sidebyside');
@@ -87,7 +88,7 @@ function sidebyside_activate(id, redraw) {
     $('#sbs_link_' + id).addClass('sidebyside_active');
 
   } else {
-    for (var i = 0; i < arr.length; i++) {
+    for (i = 0; i < arr.length; i++) {
       if (arr[i] != 'sbsAll') {
         $('#' + arr[i]).hide();
       }
@@ -149,6 +150,7 @@ function save_recipients(data) {
   var p = data.select.parent();
   var commentID = p.find('input[name=commentID]').val();
   var values = data.select.val();
+  var label;
 
   jQuery.post('../comment/updateRecipients.php', {
     'commentID': commentID,
@@ -156,10 +158,10 @@ function save_recipients(data) {
   }, function(data) {
     p.parent().hide();
     if (data == 'external') {
-      var label = '<em class="faint warn">[ External Conversation ]</em>';
+      label = '<em class="faint warn">[ External Conversation ]</em>';
       p.parents('.panel').addClass('loud');
     } else {
-      var label = '<em class="faint">[ Internal Conversation ]</em>';
+      label = '<em class="faint">[ Internal Conversation ]</em>';
       p.parents('.panel').removeClass('loud');
     }
     p.parent().parent().find('a.recipient_editor_link').html(label).show();
@@ -265,13 +267,14 @@ $(document).ready(function() {
 
   // Add toggles for filters
   $('.toggleFilter').click(function() {
+    var l;
     var d = $('.filter').css('display');
     if (d == 'table') {
-      var l = 'Show Filter';
-      var d = 'none';
+      l = 'Show Filter';
+      d = 'none';
     } else {
-      var l = 'Hide Filter';
-      var d = 'table';
+      l = 'Hide Filter';
+      d = 'table';
     }
     $('.filter').css('display', d);
     $(this).text(l);

--- a/javascript/zz_alloc.js
+++ b/javascript/zz_alloc.js
@@ -7,7 +7,7 @@ function redraw_multiple_selects(container) {
   $("select[multiple]",c).selectn();
 }
 
-// Make the XML request thing, specify the callback function 
+// Make the XML request thing, specify the callback function
 function refreshProjectList(radiobutton) {
   url = get_alloc_var('url')+'task/updateProjectList.php?projectType='+radiobutton.value;
   makeAjaxRequest(url, 'projectListDropdown','',1)
@@ -108,7 +108,7 @@ function help_text_on(id, str) {
   var x = offset.left -420;
   if (x < 0) {
     x = x + 400;
-  } 
+  }
   var y = offset.top + 20;
   if ((y + $('#helper').height() + 40) > $(document).height()) {
     y = y-$('#helper').height() - 40;
@@ -116,11 +116,11 @@ function help_text_on(id, str) {
   $("#helper").css('left',x);
   $("#helper").css('top',y);
   $("#helper").fadeIn("normal");
-} 
+}
 function help_text_off(id) {
   $("#helper").fadeOut("normal");
   $('#helper').remove();
-} 
+}
 function preload_field(element, text) {
   $(document).ready(function() {
     $(element).bind("focus", function(e){
@@ -236,7 +236,7 @@ $(document).ready(function() {
     this.value=now.getFullYear()+'-'+((1e2 + now.getMonth()+1 + '').substr(1))+'-'+(1e2 + now.getDate() + '').substr(1);
   });
 
-  $('tr.clickrow').bind('click',function(e){                                                                                                     
+  $('tr.clickrow').bind('click',function(e){
     var id = this.id.split('_')[1]; // clickrow_43242
     if (id && !$(e.target).is('input:checkbox') && !$(e.target).is('a') && !$(e.target).is('b')) {
       $('#checkbox_'+id).attr('checked',!$('#checkbox_'+id).attr('checked'));
@@ -286,7 +286,7 @@ $(document).ready(function() {
 
   $('input.toggler').click(function(){
     return $('.task_checkboxes').each(function() {
-      this.checked = !this.checked 
+      this.checked = !this.checked
     });
   });
 
@@ -338,7 +338,7 @@ $(document).ready(function() {
       $(this).removeClass("hot");
       $(this).closest("td").attr({"data-sort-value":"2"});
     }
-    $.get($(this).attr("href"));   
+    $.get($(this).attr("href"));
     return false;
   });
 


### PR DESCRIPTION
This closes issue #55.

* 9762bfe removes trailing whitespace

* 66d0cbd adds the esformatter config and adds instructions to [DEVELOPERS.md](../tree/master/DEVELOPERS.md) **Notice I've removed esformatter-onevar from the esformatter config.** This is because esformatter-onevar is not reproducible, i.e. every time you run esformatter with it enabled it adds more and more newlines. 😑

* cae74d4 reformats zz_alloc.js with the esformatter rules.

* 3060e54 manually fix already defined and out of scope variables because it's not done automatically now the esformatter-onevar plugin isn't used.