### PR TITLE
fix broken buttons in transactions table

### DIFF
--- a/time/templates/timeSheetTransactionListM.tpl
+++ b/time/templates/timeSheetTransactionListM.tpl
@@ -11,14 +11,15 @@
 </tr>
 <tr>
   <td>
-    <table class='sortable list'>
+    <!-- FIXME: ideally this table would be sortable, but the stupidtable() function in jquery.stupidtable.js is broken. cjb, 2019-05 -->
+    <table class='list'>
       <tr>
         <th width="1%">Date</th>
         <th>Product</th>
         <th width="1%">Source TF</th>
         <th width="1%">Dest TF</th>
         <th width="1%">Amount{$amount_msg}</th>
-        <th width="1%">Type</th> 
+        <th width="1%">Type</th>
         <th width="1%" data-sort="none" class="nobr" style="font-size:80%">{$p_a_r_buttons}</th>
         <th width="1%">&nbsp;</th>
       </tr>


### PR DESCRIPTION
This is a simple 'temporary' fix for the broken buttons inside the transactions table on timesheets.