### PR TITLE
25171 fix tasklist sort order for percent

### DIFF
--- a/task/templates/taskListS.tpl
+++ b/task/templates/taskListS.tpl
@@ -31,7 +31,7 @@
   {if $_FORM["showTimes"]}<th>Actual</th>{/}
   {if $_FORM["showTimes"]}<th>Limit</th>{/}
   {if $_FORM["showTags"]}<th>Tags</th>{/}
-  {if $_FORM["showPercent"]}<th>%</th>{/}
+  {if $_FORM["showPercent"]}<th data-sort="int">%</th>{/}
   {if $_FORM["showStatus"]}<th>Status</th>{/}
   {if $_FORM["showEdit"] || $_FORM["showStarred"]}<th data-sort="num" width="1%" style="font-size:120%"><i class="icon-star"></i></th>{/}
   </tr>


### PR DESCRIPTION
Set the % column to use `data-sort="int"`.

This fixes the sorting of that column if a number is 100% or greater. For example, as it stand now the % column sorts like this:

```
0%
100%
95%
```

Using `data-sort="int"` sorts like this:

```
0%
95%
100%
```