### PR TITLE
22745 make save button the default button on return

### DIFF
--- a/person/person.php
+++ b/person/person.php
@@ -63,6 +63,7 @@ function show_action_buttons()
 {
     global $person;
     global $TPL;
+    echo '<button type="submit" name="save" value="1" class="save_button hidden" aria-hidden="true"></button> ';
     if ($person->have_perm(PERM_DELETE)) {
         echo '<button type="submit" name="delete" value="1" class="delete_button">Delete<i class="icon-trash"></i></button> ';
     }


### PR DESCRIPTION
Currently when you hit enter/return on the person details page, the delete button is triggered. This is a big problem, especially if you disable Javascript because it will delete the person no questions asked.

There are a few possible ways to solve this:
 
1. Use Javascript to catch the enter and click the save button instead. However, this is not reliable. Add to that it doesn't fix the issue for users with Javascript disabled.

2. Put the save button first in the form, the reorder the buttons with CSS. This breaks easily.

3. Put a hidden button at the start of the form that saves by default. This is reliable, and using `aria-hidden` hides the button from screen readers, and even w3m.

I went with option 3 as it was reliable in my testing. 🙂