### PR TITLE
25059 use parse_url() to check there is a URL scheme in the client URL, if not add one

### DIFF
--- a/client/templates/clientM.tpl
+++ b/client/templates/clientM.tpl
@@ -27,6 +27,9 @@ $(document).ready(function() {
                           ,$url_alloc_client."clientID=".$client_clientID,null,$clientSelfLink)}
 {/}
 
+{if parse_url($client_clientURL, PHP_URL_SCHEME) === null}
+{$client_clientURL = "http://" . $client_clientURL}
+{/}
 <!-- need to merge this style back into the stylesheets -->
 <style>
 .task_pane {


### PR DESCRIPTION
Use parse_url() to add `http://` if the URL scheme is null.

This fixes the issue where a client URL points to the alloc instance.

https://www.php.net/parse_url