### PR TITLE
Remove assignment by reference operator.

### DIFF
--- a/alloc.php
+++ b/alloc.php
@@ -226,7 +226,7 @@ if (defined("IN_INSTALL_RIGHT_NOW")) {
     if (is_object($current_user) && $current_user->get_id()) {
         $history = new history();
         $history->save_history();
-        $TPL["current_user"] = &$current_user;
+        $TPL["current_user"] = $current_user;
     }
 }
 


### PR DESCRIPTION
For some reason this pointer to the data of `$current_user` causes apache2 to segfault under php7.3 (see the comment on https://github.com/cyberitsolutions/alloc/issues/39#issuecomment-487813779).

Using `&$current_user` was originally added in da3e7cc9177d16be635b354163b96faef60c17d0

TBH, I'm not entirely sure _why_ this causes a segfault, but I think this bug fix has something to do with it: https://www.php.net/manual/en/migration73.incompatible.php#migration73.incompatible.core.static-properties

For what its worth, I have tested logging in and out multiple times with this change under php5.6, php7.0, and php7.3 and it works just fine under each version.
