### PR TITLE
33456 Mark email read if adding it as a comment worked

### DIFF
--- a/email/lib/inbox.inc.php
+++ b/email/lib/inbox.inc.php
@@ -141,6 +141,7 @@ class inbox extends db_entity
         // Commit the db, and move the email into its storage location eg: INBOX.task1234
         if (!$failed && !$TPL["message"]) {
             $db->commit();
+            $email_receive->mark_seen();
             $email_receive->archive();
         }
 


### PR DESCRIPTION
If adding comment via email works, the email is not marked as read. This results in a duplicate comment.

So mark the email as seen.