### PR TITLE
Add doc to audit

### DIFF
--- a/audit/lib/audit.inc.php
+++ b/audit/lib/audit.inc.php
@@ -32,16 +32,18 @@ class audit extends db_entity
                                 "field",
                                 "value");
 
+    /**
+     * Get a list of task history items with sophisticated filtering and
+     * somewhat sophisticated output
+     *
+     * (n.b., the output from this generally needs to be post-processed to
+     * handle the semantic meaning of changes in various fields)
+     *
+     * @param array $_FORM
+     * @return array $rows an array of audit records
+     */
     public static function get_list($_FORM)
     {
-      /*
-       *
-       * Get a list of task history items with sophisticated filtering and somewhat sophisticated output
-       *
-       * (n.b., the output from this generally needs to be post-processed to handle the semantic meaning of changes in various fields)
-       *
-       */
-
         $filter = audit::get_list_filter($_FORM);
 
         if (is_array($filter) && count($filter)) {
@@ -57,7 +59,6 @@ class audit extends db_entity
             $entity->set_id($_FORM["taskID"]);
             $entity->select();
         }
-
 
         $q = "SELECT *
                 FROM audit
@@ -77,7 +78,12 @@ class audit extends db_entity
         return $rows;
     }
 
-
+    /**
+     * Get an array to use as a filter
+     *
+     * @param array $filter
+     * @return array $sql an array of project or task id to filter by. e.g.: Array([0] => (taskID = 1))
+     */
     public static function get_list_filter($filter)
     {
         $filter["taskID"]    and $sql[] = prepare("(taskID = %d)", $filter["taskID"]);

--- a/audit/lib/audit.inc.php
+++ b/audit/lib/audit.inc.php
@@ -60,13 +60,11 @@ class audit extends db_entity
             $entity->select();
         }
 
-        $q = "SELECT *
-                FROM audit
-              $where_clause
-            ORDER BY dateChanged";
-
         $db = new db_alloc();
-        $db->query($q);
+        $db->query("SELECT *
+                      FROM audit
+                    $where_clause
+                  ORDER BY dateChanged");
 
         $items = array();
         while ($row = $db->next_record()) {


### PR DESCRIPTION
Three parts to this PR:

 * added PHPDoc for two functions. I used PHPDoc because @alexlance has previously used that in [services.inc.php](https://github.com/cyberitsolutions/alloc/blob/master/services/lib/services.inc.php) and is the proposed [PSR-5](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md)

* removed the unused `get_list_vars()` function. Can be confirmed with a checkout of alloc and: `grep -rn get_list_vars . | grep audit`

* removed the single letter variable `$q` for readability. Also because a variable is unnecessary now.

NOTE:: this is non-cyber work, i.e. just because I felt like it. 😂

Like usual, I've tested this in a docker container. 🙂